### PR TITLE
Enable JaCoCo coverage reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,12 @@
 	<name>Janus</name>
 	<description>Timetable management application.</description>
 	
-	<properties>
-		<java.version>25</java.version>
-		<jackson-databind-nullable.version>0.2.7</jackson-databind-nullable.version>
-		<springdoc-openapi.version>2.8.13</springdoc-openapi.version>
-	</properties>
+        <properties>
+                <java.version>25</java.version>
+                <jackson-databind-nullable.version>0.2.7</jackson-databind-nullable.version>
+                <springdoc-openapi.version>2.8.13</springdoc-openapi.version>
+                <jacoco.version>0.8.11</jacoco.version>
+        </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,16 +67,35 @@
 	</dependencies>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                <plugins>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>jacoco-maven-plugin</artifactId>
+                                <version>${jacoco.version}</version>
+                                <executions>
+                                        <execution>
+                                                <goals>
+                                                        <goal>prepare-agent</goal>
+                                                </goals>
+                                        </execution>
+                                        <execution>
+                                                <id>report</id>
+                                                <phase>verify</phase>
+                                                <goals>
+                                                        <goal>report</goal>
+                                                </goals>
+                                        </execution>
+                                </executions>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-surefire-plugin</artifactId>
+                                <configuration>
+                                        <argLine>-XX:+EnableDynamicAgentLoading</argLine>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
## Summary
- add the JaCoCo Maven plugin so Sonar can consume unit test coverage results
- expose the plugin version via a dedicated Maven property for easier upgrades

## Testing
- mvn test *(fails: build environment does not support Java 25 specified by the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e42ccc2d688327acb20b25d40c2dda