### PR TITLE
Add CRUD endpoints for worksite management

### DIFF
--- a/src/main/java/es/nivel36/janus/api/v1/worksite/CreateWorksiteRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/worksite/CreateWorksiteRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.worksite;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import es.nivel36.janus.service.worksite.Worksite;
+
+/**
+ * Request payload for creating a new {@link Worksite}.
+ *
+ * @param code     the unique business code identifying the worksite; must follow
+ *                 the {@code [A-Za-z0-9_-]{1,50}} pattern
+ * @param name     the human readable name of the worksite; must contain between 1
+ *                 and 250 characters
+ * @param timeZone the {@link java.time.ZoneId} identifier associated with the
+ *                 worksite; must contain between 1 and 80 characters
+ */
+public record CreateWorksiteRequest(
+                @NotBlank @Pattern(regexp = "[A-Za-z0-9_-]{1,50}") String code,
+                @NotBlank @Size(min = 1, max = 250) String name,
+                @NotBlank @Size(min = 1, max = 80) String timeZone) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/worksite/UpdateWorksiteRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/worksite/UpdateWorksiteRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.worksite;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import es.nivel36.janus.service.worksite.Worksite;
+
+/**
+ * Request payload for updating an existing {@link Worksite}.
+ *
+ * @param name     the new human readable name of the worksite; must contain
+ *                 between 1 and 250 characters
+ * @param timeZone the new {@link java.time.ZoneId} identifier of the worksite;
+ *                 must contain between 1 and 80 characters
+ */
+public record UpdateWorksiteRequest(@NotBlank @Size(min = 1, max = 250) String name,
+                @NotBlank @Size(min = 1, max = 80) String timeZone) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
+++ b/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
@@ -15,16 +15,140 @@
  */
 package es.nivel36.janus.api.v1.worksite;
 
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import es.nivel36.janus.api.Mapper;
+import es.nivel36.janus.service.worksite.Worksite;
+import es.nivel36.janus.service.worksite.WorksiteService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+
 /**
- * REST controller responsible for exposing work places operations.
+ * REST controller responsible for exposing worksite CRUD operations.
  */
 @RestController
 @RequestMapping("/api/v1/workplace")
 public class WorksiteController {
 
+        private static final Logger logger = LoggerFactory.getLogger(WorksiteController.class);
 
-	
+        private final WorksiteService worksiteService;
+        private final Mapper<Worksite, WorksiteResponse> worksiteResponseMapper;
+
+        public WorksiteController(final WorksiteService worksiteService,
+                        final Mapper<Worksite, WorksiteResponse> worksiteResponseMapper) {
+                this.worksiteService = Objects.requireNonNull(worksiteService, "WorksiteService can't be null");
+                this.worksiteResponseMapper = Objects.requireNonNull(worksiteResponseMapper,
+                                "WorksiteResponseMapper can't be null");
+        }
+
+        /**
+         * Retrieves all worksites registered in the system.
+         *
+         * @return a {@link ResponseEntity} containing the list of worksites
+         */
+        @GetMapping
+        public ResponseEntity<List<WorksiteResponse>> getWorksites() {
+                logger.debug("List worksites ACTION performed");
+
+                final List<Worksite> worksites = this.worksiteService.findAllWorksites();
+                final List<WorksiteResponse> responses = worksites.stream().map(worksiteResponseMapper::map).toList();
+                return ResponseEntity.ok(responses);
+        }
+
+        /**
+         * Retrieves a specific worksite by its unique code.
+         *
+         * @param worksiteCode the unique code of the worksite; must not be {@code null}
+         * @return a {@link ResponseEntity} containing the requested worksite
+         */
+        @GetMapping("/{worksiteCode}")
+        public ResponseEntity<WorksiteResponse> getWorksite(
+                        final @PathVariable("worksiteCode") @Pattern(regexp = "[A-Za-z0-9_-]{1,50}") String worksiteCode) {
+                Objects.requireNonNull(worksiteCode, "WorksiteCode can't be null");
+                logger.debug("Get worksite ACTION performed for code {}", worksiteCode);
+
+                final Worksite worksite = this.worksiteService.getWorksiteByCode(worksiteCode);
+                final WorksiteResponse response = this.worksiteResponseMapper.map(worksite);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Creates a new worksite.
+         *
+         * @param request the payload describing the worksite to create; must not be
+         *                {@code null}
+         * @return a {@link ResponseEntity} containing the created worksite
+         */
+        @PostMapping
+        public ResponseEntity<WorksiteResponse> createWorksite(@Valid @RequestBody final CreateWorksiteRequest request) {
+                Objects.requireNonNull(request, "CreateWorksiteRequest can't be null");
+                logger.debug("Create worksite ACTION performed for code {}", request.code());
+
+                final String code = Objects.requireNonNull(request.code(), "Code can't be null");
+                final String name = Objects.requireNonNull(request.name(), "Name can't be null");
+                final String timeZoneId = Objects.requireNonNull(request.timeZone(), "TimeZone can't be null");
+                final ZoneId timeZone = ZoneId.of(timeZoneId);
+
+                final Worksite worksite = this.worksiteService.createWorksite(code, name, timeZone);
+                final WorksiteResponse response = this.worksiteResponseMapper.map(worksite);
+                return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        }
+
+        /**
+         * Updates an existing worksite identified by its code.
+         *
+         * @param worksiteCode the code of the worksite to update; must not be
+         *                     {@code null}
+         * @param request      the payload describing the new worksite data; must not
+         *                     be {@code null}
+         * @return a {@link ResponseEntity} containing the updated worksite
+         */
+        @PutMapping("/{worksiteCode}")
+        public ResponseEntity<WorksiteResponse> updateWorksite(
+                        final @PathVariable("worksiteCode") @Pattern(regexp = "[A-Za-z0-9_-]{1,50}") String worksiteCode,
+                        @Valid @RequestBody final UpdateWorksiteRequest request) {
+                Objects.requireNonNull(worksiteCode, "WorksiteCode can't be null");
+                Objects.requireNonNull(request, "UpdateWorksiteRequest can't be null");
+                logger.debug("Update worksite ACTION performed for code {}", worksiteCode);
+
+                final String name = Objects.requireNonNull(request.name(), "Name can't be null");
+                final String timeZoneId = Objects.requireNonNull(request.timeZone(), "TimeZone can't be null");
+                final ZoneId timeZone = ZoneId.of(timeZoneId);
+
+                final Worksite worksite = this.worksiteService.updateWorksite(worksiteCode, name, timeZone);
+                final WorksiteResponse response = this.worksiteResponseMapper.map(worksite);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Deletes the worksite identified by the given code.
+         *
+         * @param worksiteCode the unique code of the worksite; must not be {@code null}
+         * @return a {@link ResponseEntity} with an empty body and HTTP 204 status
+         */
+        @DeleteMapping("/{worksiteCode}")
+        public ResponseEntity<Void> deleteWorksite(
+                        final @PathVariable("worksiteCode") @Pattern(regexp = "[A-Za-z0-9_-]{1,50}") String worksiteCode) {
+                Objects.requireNonNull(worksiteCode, "WorksiteCode can't be null");
+                logger.debug("Delete worksite ACTION performed for code {}", worksiteCode);
+
+                this.worksiteService.deleteWorksite(worksiteCode);
+                return ResponseEntity.noContent().build();
+        }
 }

--- a/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteResponse.java
+++ b/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.worksite;
+
+import es.nivel36.janus.service.worksite.Worksite;
+
+/**
+ * Response payload describing a {@link Worksite}.
+ *
+ * @param code     the unique business code of the worksite
+ * @param name     the human readable name of the worksite
+ * @param timeZone the {@link java.time.ZoneId} identifier assigned to the
+ *                 worksite
+ */
+public record WorksiteResponse(String code, String name, String timeZone) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteResponseMapper.java
+++ b/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteResponseMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.worksite;
+
+import java.time.ZoneId;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import es.nivel36.janus.api.Mapper;
+import es.nivel36.janus.service.worksite.Worksite;
+
+/**
+ * {@link Mapper} implementation that transforms a {@link Worksite} entity into
+ * a {@link WorksiteResponse} record.
+ */
+@Component
+public class WorksiteResponseMapper implements Mapper<Worksite, WorksiteResponse> {
+
+        @Override
+        public WorksiteResponse map(final Worksite worksite) {
+                if (worksite == null) {
+                        return null;
+                }
+                final String code = Objects.requireNonNull(worksite.getCode(), "Code can't be null");
+                final String name = Objects.requireNonNull(worksite.getName(), "Name can't be null");
+                final ZoneId timeZone = Objects.requireNonNull(worksite.getTimeZone(), "TimeZone can't be null");
+                return new WorksiteResponse(code, name, timeZone.getId());
+        }
+}

--- a/src/main/java/es/nivel36/janus/service/worksite/WorksiteRepository.java
+++ b/src/main/java/es/nivel36/janus/service/worksite/WorksiteRepository.java
@@ -63,5 +63,15 @@ public interface WorksiteRepository extends CrudRepository<Worksite, Long> {
 	 * @return the {@link Worksite} entity with the given code, or {@code null} if
 	 *         no such worksite exists
 	 */
-	Worksite findWorksiteByCode(String code);
+        Worksite findWorksiteByCode(String code);
+
+        /**
+         * Checks whether a {@link Worksite} with the specified code exists.
+         *
+         * @param code the unique identifier code of the worksite; must not be
+         *             {@code null}
+         * @return {@code true} if a worksite with the given code exists;
+         *         {@code false} otherwise
+         */
+        boolean existsByCode(String code);
 }

--- a/src/main/java/es/nivel36/janus/service/worksite/WorksiteService.java
+++ b/src/main/java/es/nivel36/janus/service/worksite/WorksiteService.java
@@ -15,14 +15,17 @@
  */
 package es.nivel36.janus.service.worksite;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.StreamSupport;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import es.nivel36.janus.service.ResourceNotFoundException;
 import es.nivel36.janus.service.employee.Employee;
 
 /**
@@ -46,37 +49,146 @@ public class WorksiteService {
 		this.worksiteRepository = Objects.requireNonNull(worksiteRepository, "WorksiteRepository can't be null");
 	}
 
-	/**
-	 * Retrieves all {@link Worksite} entities in which the specified
-	 * {@link Employee} is registered.
-	 *
-	 * @param employee the employee whose worksites should be retrieved; must not be
-	 *                 {@code null}
-	 * @return a list of {@link Worksite} entities associated with the given
-	 *         employee, or an empty list if none exist
-	 * @throws NullPointerException if {@code employee} is {@code null}
-	 */
-	@Transactional(readOnly = true)
-	public List<Worksite> findWorksitesByEmployee(final Employee employee) {
-		Objects.requireNonNull(employee, "Employee can't be null");
-		logger.debug("Finding worksites by employee {}", employee);
-		
-		return worksiteRepository.findByEmployee(employee);
-	}
+        /**
+         * Retrieves all {@link Worksite} entities stored in the system.
+         *
+         * @return a list containing every existing {@link Worksite}; never
+         *         {@code null}
+         */
+        @Transactional(readOnly = true)
+        public List<Worksite> findAllWorksites() {
+                logger.debug("Retrieving all worksites");
 
-	/**
-	 * Finds a {@link Worksite} entity by its unique code.
-	 *
-	 * @param code the unique worksite code; must not be {@code null}
-	 * @return the {@link Worksite} with the given code, or {@code null} if none
-	 *         exists
-	 * @throws NullPointerException if {@code code} is {@code null}
-	 */
-	@Transactional(readOnly = true)
-	public Worksite findWorksiteByCode(final String code) {
-		Objects.requireNonNull(code, "Code can't be null");
-		logger.debug("Finding worksite by code {}", code);
-		
-		return worksiteRepository.findWorksiteByCode(code);
-	}
+                final Iterable<Worksite> worksites = worksiteRepository.findAll();
+                return StreamSupport.stream(worksites.spliterator(), false).toList();
+        }
+
+        /**
+         * Retrieves all {@link Worksite} entities in which the specified
+         * {@link Employee} is registered.
+         *
+         * @param employee the employee whose worksites should be retrieved; must not be
+         *                 {@code null}
+         * @return a list of {@link Worksite} entities associated with the given
+         *         employee, or an empty list if none exist
+         * @throws NullPointerException if {@code employee} is {@code null}
+         */
+        @Transactional(readOnly = true)
+        public List<Worksite> findWorksitesByEmployee(final Employee employee) {
+                Objects.requireNonNull(employee, "Employee can't be null");
+                logger.debug("Finding worksites by employee {}", employee);
+
+                return worksiteRepository.findByEmployee(employee);
+        }
+
+        /**
+         * Creates a new {@link Worksite} with the provided data.
+         *
+         * @param code     the unique code identifying the worksite; must not be
+         *                 {@code null}
+         * @param name     the human readable name of the worksite; must not be
+         *                 {@code null}
+         * @param timeZone the {@link ZoneId} associated with the worksite; must not be
+         *                 {@code null}
+         * @return the persisted {@link Worksite}
+         * @throws NullPointerException     if any argument is {@code null}
+         * @throws IllegalArgumentException if a worksite with the given code already
+         *                                   exists
+         */
+        @Transactional
+        public Worksite createWorksite(final String code, final String name, final ZoneId timeZone) {
+                Objects.requireNonNull(code, "Code can't be null");
+                Objects.requireNonNull(name, "Name can't be null");
+                Objects.requireNonNull(timeZone, "TimeZone can't be null");
+                logger.debug("Creating worksite with code {}", code);
+
+                if (worksiteRepository.existsByCode(code)) {
+                        logger.warn("Unable to create worksite. Code {} already exists", code);
+                        throw new IllegalArgumentException("Worksite already exists with code " + code);
+                }
+
+                final Worksite worksite = new Worksite(code, name, timeZone);
+                final Worksite savedWorksite = worksiteRepository.save(worksite);
+                logger.trace("Worksite {} created successfully", code);
+                return savedWorksite;
+        }
+
+        /**
+         * Finds a {@link Worksite} entity by its unique code.
+         *
+         * @param code the unique worksite code; must not be {@code null}
+         * @return the {@link Worksite} with the given code, or {@code null} if none
+         *         exists
+         * @throws NullPointerException if {@code code} is {@code null}
+         */
+        @Transactional(readOnly = true)
+        public Worksite findWorksiteByCode(final String code) {
+                Objects.requireNonNull(code, "Code can't be null");
+                logger.debug("Finding worksite by code {}", code);
+
+                return worksiteRepository.findWorksiteByCode(code);
+        }
+
+        /**
+         * Retrieves a {@link Worksite} by its code, throwing an exception if it does
+         * not exist.
+         *
+         * @param code the unique worksite code; must not be {@code null}
+         * @return the {@link Worksite} with the given code
+         * @throws NullPointerException     if {@code code} is {@code null}
+         * @throws ResourceNotFoundException if the worksite does not exist
+         */
+        @Transactional(readOnly = true)
+        public Worksite getWorksiteByCode(final String code) {
+                final Worksite worksite = findWorksiteByCode(code);
+                if (worksite == null) {
+                        logger.warn("No worksite found with code {}", code);
+                        throw new ResourceNotFoundException("No worksite found with code " + code);
+                }
+                return worksite;
+        }
+
+        /**
+         * Updates an existing {@link Worksite} with the provided data.
+         *
+         * @param code     the code identifying the worksite to update; must not be
+         *                 {@code null}
+         * @param name     the new name to assign; must not be {@code null}
+         * @param timeZone the new {@link ZoneId} to assign; must not be {@code null}
+         * @return the updated {@link Worksite}
+         * @throws NullPointerException      if any argument is {@code null}
+         * @throws ResourceNotFoundException if the worksite cannot be found
+         */
+        @Transactional
+        public Worksite updateWorksite(final String code, final String name, final ZoneId timeZone) {
+                Objects.requireNonNull(code, "Code can't be null");
+                Objects.requireNonNull(name, "Name can't be null");
+                Objects.requireNonNull(timeZone, "TimeZone can't be null");
+                logger.debug("Updating worksite with code {}", code);
+
+                final Worksite worksite = getWorksiteByCode(code);
+                worksite.setName(name);
+                worksite.setTimeZone(timeZone);
+
+                final Worksite updatedWorksite = worksiteRepository.save(worksite);
+                logger.trace("Worksite {} updated successfully", code);
+                return updatedWorksite;
+        }
+
+        /**
+         * Deletes an existing {@link Worksite} identified by its code.
+         *
+         * @param code the code of the worksite to delete; must not be {@code null}
+         * @throws NullPointerException      if {@code code} is {@code null}
+         * @throws ResourceNotFoundException if no worksite exists with the given code
+         */
+        @Transactional
+        public void deleteWorksite(final String code) {
+                Objects.requireNonNull(code, "Code can't be null");
+                logger.debug("Deleting worksite with code {}", code);
+
+                final Worksite worksite = getWorksiteByCode(code);
+                worksiteRepository.delete(worksite);
+                logger.trace("Worksite {} deleted successfully", code);
+        }
 }


### PR DESCRIPTION
## Summary
- add DTO records and mapping utilities for worksite API payloads
- implement worksite REST controller with CRUD endpoints backed by the service layer
- extend the worksite service and repository with natural-key based CRUD helpers

## Testing
- mvn -q -DskipTests package *(fails: release version 25 not supported in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43c0b66608327953ad84bc29f9893