### PR TITLE
Add employee controller endpoints

### DIFF
--- a/src/main/java/es/nivel36/janus/api/v1/employee/CreateEmployeeRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/employee/CreateEmployeeRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.employee;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import es.nivel36.janus.service.employee.Employee;
+import es.nivel36.janus.service.schedule.Schedule;
+
+/**
+ * Request payload for creating a new {@link Employee}.
+ *
+ * @param name       the employee's first name; optional but, if provided, must not
+ *                   exceed 255 characters
+ * @param surname    the employee's surname; optional but, if provided, must not
+ *                   exceed 255 characters
+ * @param email      the unique email address identifying the employee; must be a
+ *                   valid email address and contain at most 254 characters
+ * @param scheduleId the identifier of the {@link Schedule} assigned to the
+ *                   employee; must be a positive number
+ */
+public record CreateEmployeeRequest(@Size(max = 255) String name, @Size(max = 255) String surname,
+                @NotBlank @Email @Size(max = 254) String email, @NotNull @Positive Long scheduleId) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/employee/EmployeeController.java
+++ b/src/main/java/es/nivel36/janus/api/v1/employee/EmployeeController.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.employee;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import es.nivel36.janus.api.Mapper;
+import es.nivel36.janus.service.ResourceNotFoundException;
+import es.nivel36.janus.service.employee.Employee;
+import es.nivel36.janus.service.employee.EmployeeService;
+import es.nivel36.janus.service.schedule.Schedule;
+import es.nivel36.janus.service.worksite.Worksite;
+import es.nivel36.janus.service.worksite.WorksiteService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/**
+ * REST controller exposing CRUD operations and ancillary actions for
+ * {@link Employee} entities.
+ */
+@RestController
+@RequestMapping("/api/v1/employees")
+public class EmployeeController {
+
+        private static final Logger logger = LoggerFactory.getLogger(EmployeeController.class);
+
+        private final EmployeeService employeeService;
+        private final WorksiteService worksiteService;
+        private final Mapper<Employee, EmployeeResponse> employeeResponseMapper;
+
+        public EmployeeController(final EmployeeService employeeService, final WorksiteService worksiteService,
+                        final Mapper<Employee, EmployeeResponse> employeeResponseMapper) {
+                this.employeeService = Objects.requireNonNull(employeeService, "EmployeeService can't be null");
+                this.worksiteService = Objects.requireNonNull(worksiteService, "WorksiteService can't be null");
+                this.employeeResponseMapper = Objects.requireNonNull(employeeResponseMapper,
+                                "EmployeeResponseMapper can't be null");
+        }
+
+        /**
+         * Retrieves an {@link Employee} by its identifier.
+         *
+         * @param employeeId the identifier of the employee; must not be {@code null}
+         * @return the {@link EmployeeResponse} matching the identifier
+         */
+        @GetMapping("/{employeeId}")
+        public ResponseEntity<EmployeeResponse> findEmployeeById(
+                        final @PathVariable("employeeId") @Positive Long employeeId) {
+                Objects.requireNonNull(employeeId, "EmployeeId can't be null");
+                logger.debug("Find employee by id ACTION performed");
+
+                final Employee employee = this.employeeService.findEmployeeById(employeeId);
+                final EmployeeResponse response = mapToResponse(employee);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Retrieves an {@link Employee} by its email address.
+         *
+         * @param employeeEmail the unique email address of the employee; must not be
+         *                      {@code null}
+         * @return the {@link EmployeeResponse} matching the email
+         */
+        @GetMapping("/by-email/{employeeEmail}")
+        public ResponseEntity<EmployeeResponse> findEmployeeByEmail(
+                        final @PathVariable("employeeEmail") @Email @Size(max = 254) String employeeEmail) {
+                Objects.requireNonNull(employeeEmail, "EmployeeEmail can't be null");
+                logger.debug("Find employee by email ACTION performed");
+
+                final Employee employee = findEmployee(employeeEmail);
+                final EmployeeResponse response = mapToResponse(employee);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Creates a new {@link Employee} using the provided payload.
+         *
+         * @param request the data describing the employee to create; must not be
+         *                {@code null}
+         * @return the created {@link EmployeeResponse}
+         */
+        @PostMapping
+        public ResponseEntity<EmployeeResponse> createEmployee(@Valid @RequestBody final CreateEmployeeRequest request) {
+                Objects.requireNonNull(request, "CreateEmployeeRequest can't be null");
+                logger.debug("Create employee ACTION performed");
+
+                final Employee employee = buildEmployee(request);
+                final Employee createdEmployee = this.employeeService.createEmployee(employee);
+                final EmployeeResponse response = mapToResponse(createdEmployee);
+                return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        }
+
+        /**
+         * Updates an existing {@link Employee} identified by its identifier.
+         *
+         * @param employeeId the identifier of the employee to update; must not be
+         *                   {@code null}
+         * @param request    the payload containing the new employee data; must not be
+         *                   {@code null}
+         * @return the updated {@link EmployeeResponse}
+         */
+        @PutMapping("/{employeeId}")
+        public ResponseEntity<EmployeeResponse> updateEmployee(
+                        final @PathVariable("employeeId") @Positive Long employeeId,
+                        @Valid @RequestBody final UpdateEmployeeRequest request) {
+                Objects.requireNonNull(employeeId, "EmployeeId can't be null");
+                Objects.requireNonNull(request, "UpdateEmployeeRequest can't be null");
+                logger.debug("Update employee ACTION performed");
+
+                final Employee existingEmployee = this.employeeService.findEmployeeById(employeeId);
+                merge(existingEmployee, request);
+
+                final Employee updatedEmployee = this.employeeService.updateEmployee(existingEmployee);
+                final EmployeeResponse response = mapToResponse(updatedEmployee);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Adds a {@link Worksite} to an {@link Employee}.
+         *
+         * @param employeeId  the identifier of the employee; must not be {@code null}
+         * @param worksiteCode the worksite business code; must not be {@code null}
+         * @return the updated {@link EmployeeResponse}
+         */
+        @PostMapping("/{employeeId}/worksites/{worksiteCode}")
+        public ResponseEntity<EmployeeResponse> addWorksiteToEmployee(
+                        final @PathVariable("employeeId") @Positive Long employeeId,
+                        final @PathVariable("worksiteCode") @Pattern(regexp = "[A-Za-z0-9_-]{1,50}") String worksiteCode) {
+                Objects.requireNonNull(employeeId, "EmployeeId can't be null");
+                Objects.requireNonNull(worksiteCode, "WorksiteCode can't be null");
+                logger.debug("Add worksite to employee ACTION performed");
+
+                final Employee employee = this.employeeService.findEmployeeById(employeeId);
+                final Worksite worksite = findWorksite(worksiteCode);
+                this.employeeService.addWorksiteToEmployee(worksite, employee);
+
+                final EmployeeResponse response = mapToResponse(employee);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Removes a {@link Worksite} from an {@link Employee}.
+         *
+         * @param employeeId  the identifier of the employee; must not be {@code null}
+         * @param worksiteCode the worksite business code; must not be {@code null}
+         * @return the updated {@link EmployeeResponse}
+         */
+        @DeleteMapping("/{employeeId}/worksites/{worksiteCode}")
+        public ResponseEntity<EmployeeResponse> removeWorksiteFromEmployee(
+                        final @PathVariable("employeeId") @Positive Long employeeId,
+                        final @PathVariable("worksiteCode") @Pattern(regexp = "[A-Za-z0-9_-]{1,50}") String worksiteCode) {
+                Objects.requireNonNull(employeeId, "EmployeeId can't be null");
+                Objects.requireNonNull(worksiteCode, "WorksiteCode can't be null");
+                logger.debug("Remove worksite from employee ACTION performed");
+
+                final Employee employee = this.employeeService.findEmployeeById(employeeId);
+                final Worksite worksite = findWorksite(worksiteCode);
+                this.employeeService.removeWorksiteFromEmployee(worksite, employee);
+
+                final EmployeeResponse response = mapToResponse(employee);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Deletes an existing {@link Employee}.
+         *
+         * @param employeeId the identifier of the employee; must not be {@code null}
+         * @return an empty response with status {@link HttpStatus#NO_CONTENT}
+         */
+        @DeleteMapping("/{employeeId}")
+        public ResponseEntity<Void> deleteEmployee(final @PathVariable("employeeId") @Positive Long employeeId) {
+                Objects.requireNonNull(employeeId, "EmployeeId can't be null");
+                logger.debug("Delete employee ACTION performed");
+
+                final Employee employee = this.employeeService.findEmployeeById(employeeId);
+                this.employeeService.deleteEmployee(employee);
+                return ResponseEntity.noContent().build();
+        }
+
+        /**
+         * Finds the identifiers of employees with time logs but no generated work
+         * shifts since the provided instant.
+         *
+         * @param fromInclusive the lower bound instant to evaluate; must not be
+         *                      {@code null}
+         * @return the identifiers of the employees matching the criteria
+         */
+        @GetMapping("/without-workshifts")
+        public ResponseEntity<List<Long>> findEmployeesWithoutWorkshiftsSince(
+                        final @RequestParam("fromInclusive") Instant fromInclusive) {
+                Objects.requireNonNull(fromInclusive, "FromInclusive can't be null");
+                logger.debug("Find employees without workshifts ACTION performed");
+
+                final List<Long> employeeIds = this.employeeService.findEmployeesWithoutWorkshiftsSince(fromInclusive);
+                return ResponseEntity.ok(employeeIds);
+        }
+
+        private Employee buildEmployee(final CreateEmployeeRequest request) {
+                final Employee employee = new Employee();
+                employee.setName(request.name());
+                employee.setSurname(request.surname());
+                employee.setEmail(request.email());
+                employee.setSchedule(buildScheduleReference(request.scheduleId()));
+                return employee;
+        }
+
+        private void merge(final Employee employee, final UpdateEmployeeRequest request) {
+                employee.setName(request.name());
+                employee.setSurname(request.surname());
+                employee.setEmail(request.email());
+                employee.setSchedule(buildScheduleReference(request.scheduleId()));
+        }
+
+        private Schedule buildScheduleReference(final Long scheduleId) {
+                Objects.requireNonNull(scheduleId, "ScheduleId can't be null");
+                final Schedule schedule = new Schedule();
+                schedule.setId(scheduleId);
+                return schedule;
+        }
+
+        private Worksite findWorksite(final String worksiteCode) {
+                final Worksite worksite = this.worksiteService.findWorksiteByCode(worksiteCode);
+                if (worksite == null) {
+                        logger.warn("No worksite found with code: {}", worksiteCode);
+                        throw new ResourceNotFoundException("No worksite found with code " + worksiteCode);
+                }
+                return worksite;
+        }
+
+        private Employee findEmployee(final String employeeEmail) {
+                final Employee employee = this.employeeService.findEmployeeByEmail(employeeEmail);
+                if (employee == null) {
+                        logger.warn("No employee found with email: {}", employeeEmail);
+                        throw new ResourceNotFoundException("No employee found with email " + employeeEmail);
+                }
+                return employee;
+        }
+
+        private EmployeeResponse mapToResponse(final Employee employee) {
+                return this.employeeResponseMapper.map(employee);
+        }
+}

--- a/src/main/java/es/nivel36/janus/api/v1/employee/EmployeeResponse.java
+++ b/src/main/java/es/nivel36/janus/api/v1/employee/EmployeeResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.employee;
+
+import java.util.Set;
+
+import es.nivel36.janus.service.employee.Employee;
+
+/**
+ * Response DTO exposing the public representation of an {@link Employee}.
+ *
+ * @param id            the unique identifier of the employee
+ * @param name          the employee's first name
+ * @param surname       the employee's surname
+ * @param email         the employee's unique email address
+ * @param scheduleId    the identifier of the schedule assigned to the employee
+ * @param worksiteCodes the set of worksite business codes linked to the employee
+ */
+public record EmployeeResponse(Long id, String name, String surname, String email, Long scheduleId,
+                Set<String> worksiteCodes) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/employee/EmployeeResponseMapper.java
+++ b/src/main/java/es/nivel36/janus/api/v1/employee/EmployeeResponseMapper.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.employee;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import es.nivel36.janus.api.Mapper;
+import es.nivel36.janus.service.employee.Employee;
+import es.nivel36.janus.service.schedule.Schedule;
+import es.nivel36.janus.service.worksite.Worksite;
+
+/**
+ * Maps {@link Employee} entities into {@link EmployeeResponse} DTOs.
+ */
+@Component
+public class EmployeeResponseMapper implements Mapper<Employee, EmployeeResponse> {
+
+        @Override
+        public EmployeeResponse map(final Employee employee) {
+                if (employee == null) {
+                        return null;
+                }
+
+                final Long scheduleId = extractScheduleId(employee.getSchedule());
+                final Set<String> worksiteCodes = extractWorksiteCodes(employee.getWorksites());
+
+                return new EmployeeResponse(employee.getId(), employee.getName(), employee.getSurname(), employee.getEmail(),
+                                scheduleId, worksiteCodes);
+        }
+
+        private Long extractScheduleId(final Schedule schedule) {
+                if (schedule == null) {
+                        return null;
+                }
+                return schedule.getId();
+        }
+
+        private Set<String> extractWorksiteCodes(final Set<Worksite> worksites) {
+                if ((worksites == null) || worksites.isEmpty()) {
+                        return Set.of();
+                }
+
+                final LinkedHashSet<String> codes = worksites.stream() //
+                                .filter(Objects::nonNull) //
+                                .map(Worksite::getCode) //
+                                .filter(Objects::nonNull) //
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+                return Collections.unmodifiableSet(codes);
+        }
+}

--- a/src/main/java/es/nivel36/janus/api/v1/employee/UpdateEmployeeRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/employee/UpdateEmployeeRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.employee;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import es.nivel36.janus.service.employee.Employee;
+import es.nivel36.janus.service.schedule.Schedule;
+
+/**
+ * Request payload for updating an existing {@link Employee}.
+ *
+ * @param name       the new first name of the employee; optional but, if provided,
+ *                   must not exceed 255 characters
+ * @param surname    the new surname of the employee; optional but, if provided,
+ *                   must not exceed 255 characters
+ * @param email      the new email address of the employee; must be a valid email
+ *                   address and contain at most 254 characters
+ * @param scheduleId the identifier of the {@link Schedule} assigned to the
+ *                   employee; must be a positive number
+ */
+public record UpdateEmployeeRequest(@Size(max = 255) String name, @Size(max = 255) String surname,
+                @NotBlank @Email @Size(max = 254) String email, @NotNull @Positive Long scheduleId) {
+}


### PR DESCRIPTION
## Summary
- add an employee REST controller that mirrors the service operations with validation, logging, and helper methods
- introduce DTO records and a mapper to expose employee data in the API

## Testing
- `mvn -q -DskipTests compile` *(fails: release version 25 not supported in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55fce318083279b01040b0f6525e5