### PR TITLE
Handle duplicate timelogs without deleted filter

### DIFF
--- a/src/main/java/es/nivel36/janus/service/timelog/TimeLogRepository.java
+++ b/src/main/java/es/nivel36/janus/service/timelog/TimeLogRepository.java
@@ -142,17 +142,6 @@ interface TimeLogRepository extends JpaRepository<TimeLog, Long> {
 	TimeLog findByEmployeeAndEntryTime(Employee employee, Instant entryTime);
 
 	/**
-	 * Checks whether a {@link TimeLog} exists for the specified employee and exact
-	 * {@code entryTime}.
-	 *
-	 * @param employee  the employee to check for
-	 * @param entryTime the exact entry timestamp to check
-	 * @return {@code true} if a record exists for the given employee and entry
-	 *         time; {@code false} otherwise
-	 */
-	boolean existsByEmployeeAndEntryTime(Employee employee, Instant entryTime);
-
-	/**
 	 * Returns the list of {@link TimeLog} records for the given employee that are
 	 * considered "orphans" since the specified instant; i.e., time logs that are
 	 * not linked to any {@link WorkShift} through the {@code workshift_timelog}

--- a/src/main/resources/sql/schema-postgres.sql
+++ b/src/main/resources/sql/schema-postgres.sql
@@ -101,6 +101,9 @@ CREATE TABLE time_log (
 CREATE INDEX idx_timelog_employee ON time_log(employee_id);
 CREATE INDEX idx_timelog_worksite ON time_log(worksite_id);
 CREATE INDEX idx_timelog_entry    ON time_log(entry_time);
+CREATE UNIQUE INDEX uk_timelog_employee_entry_not_deleted
+  ON time_log(employee_id, entry_time)
+  WHERE deleted = FALSE;
 
 -- ============================================================
 -- WORK_SHIFT

--- a/src/test/java/es/nivel36/janus/api/v1/timelog/TimeLogControllerIt.java
+++ b/src/test/java/es/nivel36/janus/api/v1/timelog/TimeLogControllerIt.java
@@ -82,7 +82,35 @@ class TimeLogControllerIt {
 				.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)) //
 				.andExpect(jsonPath("$.entryTime").value(entry)) //
 				.andExpect(jsonPath("$.exitTime").value(exit)) //
-				.andExpect(jsonPath("$.worksiteCode").value("BCN-HQ"));
+		                .andExpect(jsonPath("$.worksiteCode").value("BCN-HQ"));
+	}
+
+	@Test
+	@Sql(statements = { //
+		        "INSERT INTO schedule(id,code,name) VALUES(1,'STD-WH','Standard Work Hours')",
+		        "INSERT INTO employee(name,surname,email, schedule_id) VALUES('Abel','Ferrer','aferrer@nivel36.es',1)",
+		        "INSERT INTO worksite(code,name,time_zone) VALUES('BCN-HQ','Barcelona Headquarters','UTC+2')"//
+	})
+	void testClockInShouldRejectDuplicateEntryUnlessDeleted() throws Exception {
+		String entry = "2025-08-04T09:30:00Z";
+
+		mvc.perform(post(BASE + "/clock-in", "aferrer@nivel36.es") //
+		                .param("worksiteCode", "BCN-HQ") //
+		                .param("entryTime", entry)) //
+		                .andExpect(status().isCreated());
+
+		mvc.perform(post(BASE + "/clock-in", "aferrer@nivel36.es") //
+		                .param("worksiteCode", "BCN-HQ") //
+		                .param("entryTime", entry)) //
+		                .andExpect(status().isBadRequest());
+
+		mvc.perform(delete(BASE + "/{entryTime}", "aferrer@nivel36.es", entry)) //
+		                .andExpect(status().isNoContent());
+
+		mvc.perform(post(BASE + "/clock-in", "aferrer@nivel36.es") //
+		                .param("worksiteCode", "BCN-HQ") //
+		                .param("entryTime", entry)) //
+		                .andExpect(status().isCreated());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- remove the repository helper that filtered duplicates by deleted flag and rely on the existing finder
- ensure the service checks the fetched timelog's deleted status before rejecting clock-in or manual creation
- extend unit coverage for duplicate scenarios, including deleted timelog allowances, while keeping integration behavior intact

## Testing
- mvn test *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68f15b624f3483278f51c0e7e218254b