### PR TITLE
Prevent duplicate time logs per entry time

### DIFF
--- a/src/main/resources/sql/schema-postgres.sql
+++ b/src/main/resources/sql/schema-postgres.sql
@@ -101,6 +101,9 @@ CREATE TABLE time_log (
 CREATE INDEX idx_timelog_employee ON time_log(employee_id);
 CREATE INDEX idx_timelog_worksite ON time_log(worksite_id);
 CREATE INDEX idx_timelog_entry    ON time_log(entry_time);
+CREATE UNIQUE INDEX uk_timelog_employee_entry_time_active
+  ON time_log(employee_id, entry_time)
+  WHERE deleted = FALSE;
 
 -- ============================================================
 -- WORK_SHIFT


### PR DESCRIPTION
## Summary
- ensure the time log service rejects clock-ins when a non-deleted entry already exists for the same employee and entry time
- add an integration test that exercises the duplicate clock-in scenario
- add a partial unique index to the PostgreSQL schema to enforce the constraint at the database level

## Testing
- `mvn -Dtest=TimeLogControllerIt test` *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68f20e9bbd0c8327b21981c70dbe348e