### PR TITLE
Add schedule API endpoints and integration coverage

### DIFF
--- a/src/main/java/es/nivel36/janus/api/v1/schedule/CreateScheduleRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/CreateScheduleRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.util.List;
+
+import es.nivel36.janus.service.schedule.Schedule;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * Request payload used to create a new {@link Schedule} aggregate.
+ *
+ * @param code  unique business identifier assigned to the schedule; must follow
+ *              the {@code [A-Za-z0-9_-]{1,50}} pattern
+ * @param name  human readable name describing the schedule; must contain between
+ *              1 and 250 allowed characters
+ * @param rules collection of rule definitions associated with the schedule; must
+ *              not be {@code null}
+ */
+public record CreateScheduleRequest( //
+                @NotBlank(message = "code must not be blank") //
+                @Pattern( //
+                                regexp = "[A-Za-z0-9_-]{1,50}", //
+                                message = "code must contain only letters, digits, underscores or hyphens (max 50)" //
+                ) //
+                String code, //
+
+                @NotBlank(message = "name must not be blank") //
+                @Pattern( //
+                                regexp = "^[\\p{L}0-9 _'.,-]{1,250}$", //
+                                message = "name must contain only letters, digits, spaces, and basic punctuation (max 250)" //
+                ) //
+                String name, //
+
+                @NotNull(message = "rules must not be null") //
+                List<@Valid ScheduleRuleRequest> rules //
+) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleController.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleController.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import es.nivel36.janus.api.Mapper;
+import es.nivel36.janus.service.schedule.DayOfWeekTimeRange;
+import es.nivel36.janus.service.schedule.Schedule;
+import es.nivel36.janus.service.schedule.ScheduleRule;
+import es.nivel36.janus.service.schedule.ScheduleService;
+import es.nivel36.janus.service.schedule.TimeRange;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * REST controller exposing CRUD operations for {@link Schedule} aggregates.
+ */
+@RestController
+@RequestMapping("/api/v1/schedules")
+public class ScheduleController {
+
+        private static final Logger logger = LoggerFactory.getLogger(ScheduleController.class);
+
+        private final ScheduleService scheduleService;
+        private final Mapper<Schedule, ScheduleResponse> scheduleResponseMapper;
+
+        /**
+         * Creates a controller that exposes schedule management endpoints.
+         *
+         * @param scheduleService        service handling {@link Schedule} domain
+         *                               operations; must not be {@code null}
+         * @param scheduleResponseMapper mapper translating {@link Schedule} entities to
+         *                               {@link ScheduleResponse} DTOs; must not be
+         *                               {@code null}
+         */
+        public ScheduleController(final ScheduleService scheduleService,
+                        final Mapper<Schedule, ScheduleResponse> scheduleResponseMapper) {
+                this.scheduleService = Objects.requireNonNull(scheduleService, "scheduleService can't be null");
+                this.scheduleResponseMapper = Objects.requireNonNull(scheduleResponseMapper,
+                                "scheduleResponseMapper can't be null");
+        }
+
+        /**
+         * Retrieves all schedules registered in the system.
+         *
+         * @return a {@link ResponseEntity} containing the list of schedules
+         */
+        @GetMapping
+        public ResponseEntity<List<ScheduleResponse>> getSchedules() {
+                logger.debug("List schedules ACTION performed");
+
+                final List<Schedule> schedules = this.scheduleService.findAllSchedules();
+                final List<ScheduleResponse> responses = schedules.stream().map(scheduleResponseMapper::map).toList();
+                return ResponseEntity.ok(responses);
+        }
+
+        /**
+         * Retrieves a specific schedule by its unique code.
+         *
+         * @param scheduleCode the unique code of the schedule; must not be {@code null}
+         * @return a {@link ResponseEntity} containing the requested schedule
+         */
+        @GetMapping("/{scheduleCode}")
+        public ResponseEntity<ScheduleResponse> findSchedule(final @PathVariable("scheduleCode") //
+        @Pattern( //
+                        regexp = "[A-Za-z0-9_-]{1,50}", //
+                        message = "code must contain only letters, digits, underscores or hyphens (max 50)" //
+        ) //
+        String scheduleCode) {
+                logger.debug("Find schedule ACTION performed");
+
+                final Schedule schedule = this.scheduleService.findScheduleByCode(scheduleCode);
+                final ScheduleResponse response = this.scheduleResponseMapper.map(schedule);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Creates a new schedule.
+         *
+         * @param request the payload describing the schedule to create; must not be
+         *                {@code null}
+         * @return a {@link ResponseEntity} containing the created schedule
+         */
+        @PostMapping
+        public ResponseEntity<ScheduleResponse> createSchedule(@Valid @RequestBody final CreateScheduleRequest request) {
+                logger.debug("Create schedule ACTION performed");
+
+                final Schedule schedulePayload = this.mapCreateRequest(request);
+                final Schedule createdSchedule = this.scheduleService.createSchedule(request.name(), request.code(),
+                                schedulePayload.getRules());
+                final ScheduleResponse response = this.scheduleResponseMapper.map(createdSchedule);
+                return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        }
+
+        /**
+         * Updates an existing schedule identified by its code.
+         *
+         * @param scheduleCode the code of the schedule to update; must not be
+         *                     {@code null}
+         * @param request      the payload describing the new schedule data; must not be
+         *                     {@code null}
+         * @return a {@link ResponseEntity} containing the updated schedule
+         */
+        @PutMapping("/{scheduleCode}")
+        public ResponseEntity<ScheduleResponse> updateSchedule(final @PathVariable("scheduleCode") //
+        @Pattern( //
+                        regexp = "[A-Za-z0-9_-]{1,50}", //
+                        message = "code must contain only letters, digits, underscores or hyphens (max 50)" //
+        ) //
+        String scheduleCode, @Valid @RequestBody final UpdateScheduleRequest request) {
+                logger.debug("Update schedule ACTION performed");
+
+                final Schedule schedulePayload = this.mapUpdateRequest(request);
+                final Schedule updatedSchedule = this.scheduleService.updateSchedule(scheduleCode, schedulePayload);
+                final ScheduleResponse response = this.scheduleResponseMapper.map(updatedSchedule);
+                return ResponseEntity.ok(response);
+        }
+
+        /**
+         * Deletes the schedule identified by the given code.
+         *
+         * @param scheduleCode the unique code of the schedule; must not be {@code null}
+         * @return a {@link ResponseEntity} with an empty body and HTTP 204 status
+         */
+        @DeleteMapping("/{scheduleCode}")
+        public ResponseEntity<Void> deleteSchedule(final @PathVariable("scheduleCode") //
+        @Pattern( //
+                        regexp = "[A-Za-z0-9_-]{1,50}", //
+                        message = "code must contain only letters, digits, underscores or hyphens (max 50)" //
+        ) //
+        String scheduleCode) {
+                logger.debug("Delete schedule ACTION performed");
+
+                final Schedule schedule = this.scheduleService.findScheduleByCode(scheduleCode);
+                this.scheduleService.deleteSchedule(schedule);
+                return ResponseEntity.noContent().build();
+        }
+
+        private Schedule mapCreateRequest(final CreateScheduleRequest request) {
+                final Schedule schedule = new Schedule();
+                schedule.setName(request.name());
+                schedule.setCode(request.code());
+                schedule.setRules(new ArrayList<>());
+                if (request.rules() != null) {
+                        for (final ScheduleRuleRequest ruleRequest : request.rules()) {
+                                if (ruleRequest != null) {
+                                        schedule.getRules().add(this.mapRule(schedule, ruleRequest));
+                                }
+                        }
+                }
+                return schedule;
+        }
+
+        private Schedule mapUpdateRequest(final UpdateScheduleRequest request) {
+                final Schedule schedule = new Schedule();
+                schedule.setName(request.name());
+                schedule.setRules(new ArrayList<>());
+                if (request.rules() != null) {
+                        for (final ScheduleRuleRequest ruleRequest : request.rules()) {
+                                if (ruleRequest != null) {
+                                        schedule.getRules().add(this.mapRule(schedule, ruleRequest));
+                                }
+                        }
+                }
+                return schedule;
+        }
+
+        private ScheduleRule mapRule(final Schedule schedule, final ScheduleRuleRequest ruleRequest) {
+                final ScheduleRule rule = new ScheduleRule();
+                rule.setSchedule(schedule);
+                rule.setName(ruleRequest.name());
+                rule.setStartDate(ruleRequest.startDate());
+                rule.setEndDate(ruleRequest.endDate());
+                if (ruleRequest.dayOfWeekRanges() != null) {
+                        for (final ScheduleRuleTimeRangeRequest requestRange : ruleRequest.dayOfWeekRanges()) {
+                                if (requestRange != null) {
+                                        rule.getDayOfWeekRanges().add(this.mapDayOfWeekRange(rule, requestRange));
+                                }
+                        }
+                }
+                return rule;
+        }
+
+        private DayOfWeekTimeRange mapDayOfWeekRange(final ScheduleRule rule,
+                        final ScheduleRuleTimeRangeRequest requestRange) {
+                final DayOfWeekTimeRange dayOfWeekTimeRange = new DayOfWeekTimeRange();
+                dayOfWeekTimeRange.setScheduleRule(rule);
+                dayOfWeekTimeRange.setDayOfWeek(requestRange.dayOfWeek());
+                dayOfWeekTimeRange.setEffectiveWorkHours(requestRange.effectiveWorkHours());
+                final TimeRange timeRange;
+                if (requestRange.timeRange() != null) {
+                        timeRange = new TimeRange();
+                        timeRange.setStartTime(requestRange.timeRange().startTime());
+                        timeRange.setEndTime(requestRange.timeRange().endTime());
+                } else {
+                        timeRange = null;
+                }
+                dayOfWeekTimeRange.setTimeRange(timeRange);
+                return dayOfWeekTimeRange;
+        }
+}

--- a/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleResponse.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleResponse.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import es.nivel36.janus.service.schedule.Schedule;
+
+/**
+ * API response representing a {@link Schedule} aggregate and its rules.
+ *
+ * @param code  unique business identifier of the schedule
+ * @param name  human readable name describing the schedule
+ * @param rules rules associated with the schedule
+ */
+public record ScheduleResponse(String code, String name, List<ScheduleRuleResponse> rules) {
+
+        /**
+         * Response fragment describing a single rule inside a schedule.
+         *
+         * @param name            human readable name of the rule
+         * @param startDate       optional start date delimiting when the rule becomes
+         *                        active
+         * @param endDate         optional end date delimiting when the rule stops being
+         *                        active
+         * @param dayOfWeekRanges day specific working ranges belonging to the rule
+         */
+        public record ScheduleRuleResponse(String name, LocalDate startDate, LocalDate endDate,
+                        List<DayOfWeekTimeRangeResponse> dayOfWeekRanges) {
+        }
+
+        /**
+         * Response fragment describing the time range allowed for a specific day of the
+         * week.
+         *
+         * @param dayOfWeek          day when the shift starts
+         * @param effectiveWorkHours effective working duration expected for the shift
+         * @param timeRange          allowed start and end times for the shift
+         */
+        public record DayOfWeekTimeRangeResponse(DayOfWeek dayOfWeek, Duration effectiveWorkHours,
+                        TimeRangeResponse timeRange) {
+        }
+
+        /**
+         * Response fragment representing the start and end times of a shift.
+         *
+         * @param startTime lower bound for the shift
+         * @param endTime   upper bound for the shift
+         */
+        public record TimeRangeResponse(LocalTime startTime, LocalTime endTime) {
+        }
+}

--- a/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleResponseMapper.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleResponseMapper.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import es.nivel36.janus.api.Mapper;
+import es.nivel36.janus.api.v1.schedule.ScheduleResponse.DayOfWeekTimeRangeResponse;
+import es.nivel36.janus.api.v1.schedule.ScheduleResponse.ScheduleRuleResponse;
+import es.nivel36.janus.api.v1.schedule.ScheduleResponse.TimeRangeResponse;
+import es.nivel36.janus.service.schedule.DayOfWeekTimeRange;
+import es.nivel36.janus.service.schedule.Schedule;
+import es.nivel36.janus.service.schedule.ScheduleRule;
+
+/**
+ * Maps {@link Schedule} aggregates to {@link ScheduleResponse} DTOs.
+ */
+@Component
+public class ScheduleResponseMapper implements Mapper<Schedule, ScheduleResponse> {
+
+        @Override
+        public ScheduleResponse map(final Schedule schedule) {
+                if (schedule == null) {
+                        return null;
+                }
+                final List<ScheduleRuleResponse> rules = this.mapRules(schedule.getRules());
+                return new ScheduleResponse(schedule.getCode(), schedule.getName(), rules);
+        }
+
+        private List<ScheduleRuleResponse> mapRules(final List<ScheduleRule> rules) {
+                if (rules == null || rules.isEmpty()) {
+                        return Collections.emptyList();
+                }
+                return rules.stream().filter(Objects::nonNull).map(this::mapRule).toList();
+        }
+
+        private ScheduleRuleResponse mapRule(final ScheduleRule rule) {
+                final List<DayOfWeekTimeRangeResponse> dayOfWeekRanges = this.mapDayOfWeekRanges(rule.getDayOfWeekRanges());
+                return new ScheduleRuleResponse(rule.getName(), rule.getStartDate(), rule.getEndDate(), dayOfWeekRanges);
+        }
+
+        private List<DayOfWeekTimeRangeResponse> mapDayOfWeekRanges(final List<DayOfWeekTimeRange> ranges) {
+                if (ranges == null || ranges.isEmpty()) {
+                        return Collections.emptyList();
+                }
+                return ranges.stream().filter(Objects::nonNull).map(this::mapDayOfWeekRange).toList();
+        }
+
+        private DayOfWeekTimeRangeResponse mapDayOfWeekRange(final DayOfWeekTimeRange range) {
+                final TimeRangeResponse timeRangeResponse;
+                if (range.getTimeRange() != null) {
+                        timeRangeResponse = new TimeRangeResponse(range.getTimeRange().getStartTime(),
+                                        range.getTimeRange().getEndTime());
+                } else {
+                        timeRangeResponse = null;
+                }
+                return new DayOfWeekTimeRangeResponse(range.getDayOfWeek(), range.getEffectiveWorkHours(),
+                                timeRangeResponse);
+        }
+}

--- a/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleRuleRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleRuleRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import es.nivel36.janus.service.schedule.ScheduleRule;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * Defines the structure of a rule contained in {@link CreateScheduleRequest} or
+ * {@link UpdateScheduleRequest}.
+ *
+ * @param name            human readable name of the rule; must contain between 1
+ *                        and 250 allowed characters
+ * @param startDate       optional start date delimiting when the rule becomes
+ *                        active
+ * @param endDate         optional end date delimiting when the rule stops being
+ *                        active
+ * @param dayOfWeekRanges day specific working ranges that compose the rule; must
+ *                        not be {@code null}
+ */
+public record ScheduleRuleRequest( //
+                @NotBlank(message = "name must not be blank") //
+                @Pattern( //
+                                regexp = "^[\\p{L}0-9 _'.,-]{1,250}$", //
+                                message = "name must contain only letters, digits, spaces, and basic punctuation (max 250)" //
+                ) //
+                String name, //
+
+                LocalDate startDate, //
+
+                LocalDate endDate, //
+
+                @NotNull(message = "dayOfWeekRanges must not be null") //
+                List<@Valid ScheduleRuleTimeRangeRequest> dayOfWeekRanges //
+) {
+
+        /**
+         * Validates that {@code endDate} is not before {@code startDate} when both are
+         * provided.
+         *
+         * @return {@code true} if the date range is valid or incomplete, {@code false}
+         *         otherwise
+         */
+        @AssertTrue(message = "endDate must be on or after startDate")
+        public boolean isDateRangeValid() {
+                if (this.startDate == null || this.endDate == null) {
+                        return true;
+                }
+                return !this.endDate.isBefore(this.startDate);
+        }
+}

--- a/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleRuleTimeRangeRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleRuleTimeRangeRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+
+import es.nivel36.janus.service.schedule.DayOfWeekTimeRange;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Defines the request payload for day-specific {@link DayOfWeekTimeRange}
+ * definitions.
+ *
+ * @param dayOfWeek          day of the week when the shift starts; must not be
+ *                           {@code null}
+ * @param effectiveWorkHours effective working duration for the range as an
+ *                           ISO-8601 {@link Duration}; must not be {@code null}
+ * @param timeRange          allowed clock-in and clock-out bounds; must not be
+ *                           {@code null}
+ */
+public record ScheduleRuleTimeRangeRequest( //
+                @NotNull(message = "dayOfWeek must not be null") //
+                DayOfWeek dayOfWeek, //
+
+                @NotNull(message = "effectiveWorkHours must not be null") //
+                Duration effectiveWorkHours, //
+
+                @NotNull(message = "timeRange must not be null") //
+                @Valid ScheduleTimeRangeRequest timeRange //
+) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleTimeRangeRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleTimeRangeRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.time.LocalTime;
+
+import es.nivel36.janus.service.schedule.TimeRange;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Defines the bounds of a {@link TimeRange} in schedule requests.
+ *
+ * @param startTime lower bound for the allowed time window; must not be
+ *                  {@code null}
+ * @param endTime   upper bound for the allowed time window; must not be
+ *                  {@code null}
+ */
+public record ScheduleTimeRangeRequest( //
+                @NotNull(message = "startTime must not be null") //
+                LocalTime startTime, //
+
+                @NotNull(message = "endTime must not be null") //
+                LocalTime endTime //
+) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/schedule/UpdateScheduleRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/UpdateScheduleRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.util.List;
+
+import es.nivel36.janus.service.schedule.Schedule;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * Request payload used to update an existing {@link Schedule} aggregate.
+ *
+ * @param name  new human readable name describing the schedule; must contain
+ *              between 1 and 250 allowed characters
+ * @param rules collection of rule definitions that replace the previous ones;
+ *              must not be {@code null}
+ */
+public record UpdateScheduleRequest( //
+                @NotBlank(message = "name must not be blank") //
+                @Pattern( //
+                                regexp = "^[\\p{L}0-9 _'.,-]{1,250}$", //
+                                message = "name must contain only letters, digits, spaces, and basic punctuation (max 250)" //
+                ) //
+                String name, //
+
+                @NotNull(message = "rules must not be null") //
+                List<@Valid ScheduleRuleRequest> rules //
+) {
+}

--- a/src/main/java/es/nivel36/janus/service/schedule/ScheduleService.java
+++ b/src/main/java/es/nivel36/janus/service/schedule/ScheduleService.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,11 +131,11 @@ public class ScheduleService {
 		return updatedSchedule;
 	}
 
-	private void attachScheduleToRules(final Schedule schedule, final List<ScheduleRule> rules) {
-		if (rules == null) {
-			return;
-		}
-		for (final ScheduleRule rule : rules) {
+        private void attachScheduleToRules(final Schedule schedule, final List<ScheduleRule> rules) {
+                if (rules == null) {
+                        return;
+                }
+                for (final ScheduleRule rule : rules) {
 			if (rule != null) {
 				rule.setSchedule(schedule);
 			}
@@ -178,8 +179,21 @@ public class ScheduleService {
 		Objects.requireNonNull(code, "code can't be null");
 		logger.debug("Finding schedule by code {}", code);
 
-		return this.findSchedule(code);
-	}
+                return this.findSchedule(code);
+        }
+
+        /**
+         * Retrieves all {@link Schedule} aggregates available in the repository.
+         *
+         * @return immutable list containing every persisted schedule
+         */
+        @Transactional(readOnly = true)
+        public List<Schedule> findAllSchedules() {
+                logger.debug("Listing all schedules");
+
+                final Iterable<Schedule> schedules = this.scheduleRepository.findAll();
+                return StreamSupport.stream(schedules.spliterator(), false).toList();
+        }
 
 	private Schedule findSchedule(final String code) {
 		final Schedule schedule = this.scheduleRepository.findByCode(code);

--- a/src/test/java/es/nivel36/janus/api/v1/schedule/ScheduleControllerIt.java
+++ b/src/test/java/es/nivel36/janus/api/v1/schedule/ScheduleControllerIt.java
@@ -1,0 +1,257 @@
+package es.nivel36.janus.api.v1.schedule;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Transactional
+class ScheduleControllerIt {
+
+        private static final String BASE = "/api/v1/schedules";
+
+        private @Autowired MockMvc mvc;
+
+        @Test
+        void testCreateScheduleShouldReturn201AndBody() throws Exception {
+                String body = """
+                                {
+                                  "code": "STD-WH",
+                                  "name": "Standard Work Hours",
+                                  "rules": [
+                                    {
+                                      "name": "Weekday Rule",
+                                      "dayOfWeekRanges": [
+                                        {
+                                          "dayOfWeek": "MONDAY",
+                                          "effectiveWorkHours": "PT8H",
+                                          "timeRange": {
+                                            "startTime": "09:00",
+                                            "endTime": "17:00"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
+                                .andExpect(status().isCreated()) //
+                                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)) //
+                                .andExpect(jsonPath("$.code").value("STD-WH")) //
+                                .andExpect(jsonPath("$.rules[0].dayOfWeekRanges[0].effectiveWorkHours").value("PT8H")) //
+                                .andExpect(jsonPath("$.rules[0].dayOfWeekRanges[0].timeRange.startTime").value("09:00:00"));
+        }
+
+        @Test
+        void testCreateDuplicatedScheduleShouldReturn400() throws Exception {
+                String body = """
+                                {
+                                  "code": "STD-WH",
+                                  "name": "Standard Work Hours",
+                                  "rules": [
+                                    {
+                                      "name": "Weekday Rule",
+                                      "dayOfWeekRanges": [
+                                        {
+                                          "dayOfWeek": "MONDAY",
+                                          "effectiveWorkHours": "PT8H",
+                                          "timeRange": {
+                                            "startTime": "09:00",
+                                            "endTime": "17:00"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
+                                .andExpect(status().isCreated());
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
+                                .andExpect(status().isBadRequest()) //
+                                .andExpect(content().contentTypeCompatibleWith(APPLICATION_PROBLEM_JSON));
+        }
+
+        @Test
+        void testGetSchedulesShouldReturn200AndBody() throws Exception {
+                String body = """
+                                {
+                                  "code": "STD-WH",
+                                  "name": "Standard Work Hours",
+                                  "rules": [
+                                    {
+                                      "name": "Weekday Rule",
+                                      "dayOfWeekRanges": [
+                                        {
+                                          "dayOfWeek": "MONDAY",
+                                          "effectiveWorkHours": "PT8H",
+                                          "timeRange": {
+                                            "startTime": "09:00",
+                                            "endTime": "17:00"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
+                                .andExpect(status().isCreated());
+
+                mvc.perform(get(BASE)) //
+                                .andExpect(status().isOk()) //
+                                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)) //
+                                .andExpect(jsonPath("$[0].code").value("STD-WH"));
+        }
+
+        @Test
+        void testFindScheduleShouldReturn200AndBody() throws Exception {
+                String body = """
+                                {
+                                  "code": "STD-WH",
+                                  "name": "Standard Work Hours",
+                                  "rules": [
+                                    {
+                                      "name": "Weekday Rule",
+                                      "dayOfWeekRanges": [
+                                        {
+                                          "dayOfWeek": "MONDAY",
+                                          "effectiveWorkHours": "PT8H",
+                                          "timeRange": {
+                                            "startTime": "09:00",
+                                            "endTime": "17:00"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
+                                .andExpect(status().isCreated());
+
+                mvc.perform(get(BASE + "/{code}", "STD-WH")) //
+                                .andExpect(status().isOk()) //
+                                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)) //
+                                .andExpect(jsonPath("$.name").value("Standard Work Hours")) //
+                                .andExpect(jsonPath("$.rules[0].dayOfWeekRanges[0].dayOfWeek").value("MONDAY"));
+        }
+
+        @Test
+        void testUpdateScheduleShouldReturn200AndBody() throws Exception {
+                String createBody = """
+                                {
+                                  "code": "STD-WH",
+                                  "name": "Standard Work Hours",
+                                  "rules": [
+                                    {
+                                      "name": "Weekday Rule",
+                                      "dayOfWeekRanges": [
+                                        {
+                                          "dayOfWeek": "MONDAY",
+                                          "effectiveWorkHours": "PT8H",
+                                          "timeRange": {
+                                            "startTime": "09:00",
+                                            "endTime": "17:00"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(createBody)) //
+                                .andExpect(status().isCreated());
+
+                String updateBody = """
+                                {
+                                  "name": "Updated Work Hours",
+                                  "rules": [
+                                    {
+                                      "name": "Weekend Rule",
+                                      "dayOfWeekRanges": [
+                                        {
+                                          "dayOfWeek": "SATURDAY",
+                                          "effectiveWorkHours": "PT6H",
+                                          "timeRange": {
+                                            "startTime": "10:00",
+                                            "endTime": "16:00"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+                mvc.perform(put(BASE + "/{code}", "STD-WH").contentType(APPLICATION_JSON).content(updateBody)) //
+                                .andExpect(status().isOk()) //
+                                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)) //
+                                .andExpect(jsonPath("$.name").value("Updated Work Hours")) //
+                                .andExpect(jsonPath("$.rules[0].dayOfWeekRanges[0].dayOfWeek").value("SATURDAY"));
+        }
+
+        @Test
+        void testDeleteScheduleShouldReturn204() throws Exception {
+                String body = """
+                                {
+                                  "code": "STD-WH",
+                                  "name": "Standard Work Hours",
+                                  "rules": [
+                                    {
+                                      "name": "Weekday Rule",
+                                      "dayOfWeekRanges": [
+                                        {
+                                          "dayOfWeek": "MONDAY",
+                                          "effectiveWorkHours": "PT8H",
+                                          "timeRange": {
+                                            "startTime": "09:00",
+                                            "endTime": "17:00"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
+                                .andExpect(status().isCreated());
+
+                mvc.perform(delete(BASE + "/{code}", "STD-WH")) //
+                                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @Sql(statements = {
+                        "INSERT INTO schedule(id,code,name) VALUES (5,'IN-USE','In Use Schedule')",
+                        "INSERT INTO employee(id,name,surname,email,schedule_id) VALUES (9,'Jane','Doe','jane.doe@example.com',5)"
+        })
+        void testDeleteScheduleWithAssignedEmployeesShouldReturn409() throws Exception {
+                mvc.perform(delete(BASE + "/{code}", "IN-USE")) //
+                                .andExpect(status().isConflict()) //
+                                .andExpect(content().contentTypeCompatibleWith(APPLICATION_PROBLEM_JSON));
+        }
+}


### PR DESCRIPTION
## Summary
- add schedule request/response DTOs and controller with logging and validation mirroring the time log style
- expose a ScheduleService helper to list all schedules for the new API
- cover the new endpoints with integration tests following the time log test conventions

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68f7e6672fc883279ad1c53836dc2879