### PR TITLE
feat: refresh Angular welcome dashboard

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -89,5 +89,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,30 +1,150 @@
+:host {
+  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+}
+
 .app-shell {
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #1976d2, #42a5f5);
-  color: #fff;
-  font-family: "Segoe UI", Roboto, sans-serif;
+  background-color: #050505;
   padding: 2rem;
   box-sizing: border-box;
 }
 
-.hero {
-  text-align: center;
-  background: rgba(0, 0, 0, 0.2);
-  border-radius: 16px;
-  padding: 3rem 4rem;
-  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.2);
+.dashboard {
+  width: min(640px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  color: #f9f9f9;
 }
 
-.hero h1 {
-  font-size: 3rem;
-  margin-bottom: 1rem;
-  letter-spacing: 0.05em;
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  letter-spacing: 0.08em;
+  font-weight: 600;
 }
 
-.hero .lead {
+.brand {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #f9d600;
+}
+
+.section-label {
+  font-size: 1rem;
+  color: rgba(249, 249, 249, 0.72);
+  text-transform: uppercase;
+}
+
+.clock-card {
+  background-color: #f9d600;
+  color: #040404;
+  border-radius: 20px;
+  padding: 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.25);
+}
+
+.clock-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.clock-label {
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  font-size: 0.9rem;
+}
+
+.clock-time {
+  font-size: clamp(2.5rem, 5vw + 1rem, 3.5rem);
+  font-weight: 700;
+}
+
+.clock-button {
+  background-color: #040404;
+  color: #f9d600;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 2.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.clock-button:hover,
+.clock-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.timelog {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.timelog-title {
   font-size: 1.25rem;
   margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.timelog-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #0f0f0f;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.2);
+}
+
+.timelog-table th,
+.timelog-table td {
+  padding: 1rem 1.5rem;
+  text-align: left;
+}
+
+.timelog-table thead {
+  background-color: rgba(249, 214, 0, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.85rem;
+}
+
+.timelog-table tbody tr:nth-child(odd) {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.timelog-table tbody tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.timelog-table tbody tr:hover {
+  background-color: rgba(249, 214, 0, 0.18);
+}
+
+@media (max-width: 640px) {
+  .clock-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .clock-button {
+    align-self: stretch;
+    text-align: center;
+  }
 }

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,6 +1,56 @@
 <main class="app-shell">
-  <section class="hero">
-    <h1>Hola mundo</h1>
-    <p class="lead">Tu aplicación Angular ya está funcionando junto a la API REST.</p>
+  <section class="dashboard">
+    <header class="dashboard-header">
+      <h1 class="brand">TIMELOG</h1>
+      <span class="section-label">Dashboard</span>
+    </header>
+
+    <div class="clock-card">
+      <div class="clock-info">
+        <span class="clock-label">Clock In</span>
+        <time class="clock-time" datetime="2024-04-23T08:30">08:30 AM</time>
+      </div>
+      <button class="clock-button" type="button">Clock In</button>
+    </div>
+
+    <section class="timelog">
+      <h2 class="timelog-title">Time Logs</h2>
+      <table class="timelog-table">
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Clock In</th>
+            <th scope="col">Clock Out</th>
+            <th scope="col">Duration</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>04/23/2024</td>
+            <td>08:32 AM</td>
+            <td>05:15 PM</td>
+            <td>8h 43m</td>
+          </tr>
+          <tr>
+            <td>04/22/2024</td>
+            <td>08:29 AM</td>
+            <td>05:31 PM</td>
+            <td>9h 02m</td>
+          </tr>
+          <tr>
+            <td>04/21/2024</td>
+            <td>08:34 AM</td>
+            <td>05:11 PM</td>
+            <td>8h 37m</td>
+          </tr>
+          <tr>
+            <td>04/20/2024</td>
+            <td>08:33 AM</td>
+            <td>05:11 PM</td>
+            <td>8h 52m</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- replace the default Angular welcome markup with a TimeLog dashboard mock-up
- style the shell to match the requested black and yellow aesthetic and improve responsiveness
- disable Angular CLI analytics to avoid prompts during local development

## Testing
- npm start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68fa8bbea3c48327b324d1fa67b9a6ca