### PR TITLE
feat: migrate dashboard to PrimeNG

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,9 +18,13 @@
     "@angular/common": "^20.3.7",
     "@angular/compiler": "^20.3.7",
     "@angular/core": "^20.3.7",
+    "@angular/animations": "^20.0.4",
+    "@angular/cdk": "^20.0.3",
     "@angular/forms": "^20.3.7",
     "@angular/platform-browser": "^20.3.7",
     "@angular/router": "^20.3.7",
+    "primeicons": "^7.0.0",
+    "primeng": "^20.2.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2",
     "zone.js": "~0.15.0"

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,5 +1,6 @@
 :host {
-  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  color: #f9f9f9;
 }
 
 .app-shell {
@@ -12,12 +13,28 @@
   box-sizing: border-box;
 }
 
-.dashboard {
+.dashboard.p-panel {
   width: min(640px, 100%);
+  background: transparent;
+  border: none;
+}
+
+.dashboard .p-panel-header {
+  background: transparent;
+  border: none;
+  padding: 0 0 1rem;
+}
+
+.dashboard .p-panel-content {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.dashboard-content {
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
-  color: #f9f9f9;
 }
 
 .dashboard-header {
@@ -40,16 +57,22 @@
   text-transform: uppercase;
 }
 
-.clock-card {
+.clock-card.p-card {
   background-color: #f9d600;
   color: #040404;
   border-radius: 20px;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.25);
+}
+
+.clock-card .p-card-body {
   padding: 2.5rem;
+}
+
+.clock-card-content {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 2rem;
-  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.25);
 }
 
 .clock-info {
@@ -70,7 +93,7 @@
   font-weight: 700;
 }
 
-.clock-button {
+.clock-button.p-button {
   background-color: #040404;
   color: #f9d600;
   border: none;
@@ -80,20 +103,29 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.clock-button:hover,
-.clock-button:focus-visible {
+.clock-button.p-button:not(.p-disabled):hover,
+.clock-button.p-button:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.clock-button .p-button-loading-icon {
+  color: #f9d600;
 }
 
 .timelog {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.timelog-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .timelog-title {
@@ -103,47 +135,86 @@
   letter-spacing: 0.12em;
 }
 
-.timelog-table {
-  width: 100%;
-  border-collapse: collapse;
+.timelog-subtitle {
+  margin: 0;
+  color: rgba(249, 249, 249, 0.72);
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+}
+
+.timelog-table .p-datatable-wrapper {
   background-color: #0f0f0f;
   border-radius: 16px;
   overflow: hidden;
   box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.2);
 }
 
-.timelog-table th,
-.timelog-table td {
-  padding: 1rem 1.5rem;
-  text-align: left;
+.timelog-table table {
+  color: inherit;
 }
 
-.timelog-table thead {
+.timelog-table .p-datatable-thead > tr > th {
   background-color: rgba(249, 214, 0, 0.12);
+  color: #f9f9f9;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 0.85rem;
+  border: none;
+  padding: 1rem 1.5rem;
 }
 
-.timelog-table tbody tr:nth-child(odd) {
+.timelog-table .p-datatable-tbody > tr > td {
+  border: none;
+  padding: 1rem 1.5rem;
+}
+
+.timelog-table .p-datatable-tbody > tr:nth-child(odd) {
   background-color: rgba(255, 255, 255, 0.02);
 }
 
-.timelog-table tbody tr:nth-child(even) {
+.timelog-table .p-datatable-tbody > tr:nth-child(even) {
   background-color: rgba(255, 255, 255, 0.08);
 }
 
-.timelog-table tbody tr:hover {
+.timelog-table .p-datatable-tbody > tr:hover {
   background-color: rgba(249, 214, 0, 0.18);
 }
 
+.timelog-table .p-paginator {
+  border: none;
+  background: transparent;
+  color: rgba(249, 249, 249, 0.72);
+}
+
+.timelog-table .p-paginator .p-paginator-page,
+.timelog-table .p-paginator .p-paginator-next,
+.timelog-table .p-paginator .p-paginator-prev {
+  color: #f9f9f9;
+}
+
+.timelog-table .p-paginator .p-highlight {
+  background: #f9d600;
+  border: none;
+  color: #040404;
+}
+
+.error-message {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+  color: #ffb3b3;
+  background: rgba(255, 82, 82, 0.12);
+  border: 1px solid rgba(255, 82, 82, 0.4);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
 @media (max-width: 640px) {
-  .clock-card {
+  .clock-card-content {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .clock-button {
+  .clock-button.p-button {
     align-self: stretch;
     text-align: center;
   }

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,56 +1,74 @@
 <main class="app-shell">
-  <section class="dashboard">
-    <header class="dashboard-header">
-      <h1 class="brand">TIMELOG</h1>
-      <span class="section-label">Dashboard</span>
-    </header>
-
-    <div class="clock-card">
-      <div class="clock-info">
-        <span class="clock-label">Clock In</span>
-        <time class="clock-time" datetime="2024-04-23T08:30">08:30 AM</time>
+  <p-panel styleClass="dashboard">
+    <ng-template pTemplate="header">
+      <div class="dashboard-header">
+        <h1 class="brand">TIMELOG</h1>
+        <span class="section-label">Dashboard</span>
       </div>
-      <button class="clock-button" type="button">Clock In</button>
-    </div>
+    </ng-template>
 
-    <section class="timelog">
-      <h2 class="timelog-title">Time Logs</h2>
-      <table class="timelog-table">
-        <thead>
-          <tr>
-            <th scope="col">Date</th>
-            <th scope="col">Clock In</th>
-            <th scope="col">Clock Out</th>
-            <th scope="col">Duration</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>04/23/2024</td>
-            <td>08:32 AM</td>
-            <td>05:15 PM</td>
-            <td>8h 43m</td>
-          </tr>
-          <tr>
-            <td>04/22/2024</td>
-            <td>08:29 AM</td>
-            <td>05:31 PM</td>
-            <td>9h 02m</td>
-          </tr>
-          <tr>
-            <td>04/21/2024</td>
-            <td>08:34 AM</td>
-            <td>05:11 PM</td>
-            <td>8h 37m</td>
-          </tr>
-          <tr>
-            <td>04/20/2024</td>
-            <td>08:33 AM</td>
-            <td>05:11 PM</td>
-            <td>8h 52m</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-  </section>
+    <div class="dashboard-content">
+      <p-card styleClass="clock-card">
+        <ng-template pTemplate="content">
+          <div class="clock-card-content">
+            <div class="clock-info">
+              <span class="clock-label">Clock In</span>
+              <time class="clock-time" [attr.datetime]="currentTimeIso()">{{ currentTimeText() }}</time>
+            </div>
+            <p-button
+              label="Clock In"
+              styleClass="clock-button"
+              (onClick)="onClockIn()"
+              [loading]="clockInLoading()"
+            ></p-button>
+          </div>
+          <p class="error-message" *ngIf="clockInError() as error">{{ error }}</p>
+        </ng-template>
+      </p-card>
+
+      <section class="timelog">
+        <div class="timelog-header">
+          <h2 class="timelog-title">Time Logs</h2>
+          <p class="timelog-subtitle">BCN-HQ · aferrer@nivel36.es</p>
+        </div>
+        <p-table
+          styleClass="timelog-table"
+          [value]="logs()"
+          [paginator]="true"
+          [rows]="rows()"
+          [first]="first()"
+          [totalRecords]="totalRecords()"
+          [lazy]="true"
+          (onLazyLoad)="loadLogs($event)"
+          [loading]="loading()"
+          dataKey="entryTime"
+          [showCurrentPageReport]="true"
+          currentPageReportTemplate="Mostrando {first} - {last} de {totalRecords}"
+        >
+          <ng-template pTemplate="header">
+            <tr>
+              <th scope="col">Fecha</th>
+              <th scope="col">Entrada</th>
+              <th scope="col">Salida</th>
+              <th scope="col">Duración</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-log>
+            <tr>
+              <td>{{ log.dateDisplay }}</td>
+              <td>{{ log.entryDisplay }}</td>
+              <td>{{ log.exitDisplay }}</td>
+              <td>{{ log.durationDisplay }}</td>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="emptymessage">
+            <tr>
+              <td colspan="4">No hay registros disponibles.</td>
+            </tr>
+          </ng-template>
+        </p-table>
+        <p class="error-message" *ngIf="tableError() as tableError">{{ tableError }}</p>
+      </section>
+    </div>
+  </p-panel>
 </main>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,12 +1,200 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { PanelModule } from 'primeng/panel';
+import { CardModule } from 'primeng/card';
+import { ButtonModule } from 'primeng/button';
+import { TableModule, TableLazyLoadEvent } from 'primeng/table';
+
+type JsonNullable<T> = T | { value?: T | null } | null | undefined;
+
+interface TimeLogApiModel {
+  entryTime: string;
+  exitTime?: JsonNullable<string>;
+}
+
+interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  size: number;
+  number: number;
+}
+
+interface TimeLogRow {
+  entryTime: Date;
+  exitTime: Date | null;
+}
+
+interface TimeLogViewRow {
+  dateDisplay: string;
+  entryDisplay: string;
+  exitDisplay: string;
+  durationDisplay: string;
+  entryTime: Date;
+}
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [],
+  imports: [CommonModule, PanelModule, CardModule, ButtonModule, TableModule],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.css'
+  styleUrl: './app.component.css',
+  providers: [DatePipe]
 })
-export class AppComponent {
-  title = 'frontend';
+export class AppComponent implements OnInit, OnDestroy {
+  private static readonly EMPLOYEE_EMAIL = 'aferrer@nivel36.es';
+  private static readonly WORKSITE_CODE = 'BCN-HQ';
+  private readonly http = inject(HttpClient);
+  private readonly datePipe = inject(DatePipe);
+
+  protected readonly currentTimeText = signal('');
+  protected readonly currentTimeIso = signal('');
+  protected readonly logs = signal<TimeLogViewRow[]>([]);
+  protected readonly loading = signal(false);
+  protected readonly clockInLoading = signal(false);
+  protected readonly clockInError = signal<string | null>(null);
+  protected readonly tableError = signal<string | null>(null);
+  protected totalRecords = signal(0);
+  protected rows = signal(10);
+  protected first = signal(0);
+
+  private readonly baseUrl = `/api/v1/employee/${AppComponent.EMPLOYEE_EMAIL}/timelogs`;
+  private tickId: ReturnType<typeof setInterval> | undefined;
+  private rawLogs: TimeLogRow[] = [];
+
+  ngOnInit(): void {
+    this.updateCurrentTime();
+    this.tickId = setInterval(() => {
+      this.updateCurrentTime();
+    }, 1_000);
+    this.loadLogs();
+  }
+
+  ngOnDestroy(): void {
+    if (this.tickId) {
+      clearInterval(this.tickId);
+    }
+  }
+
+  protected onClockIn(): void {
+    if (this.clockInLoading()) {
+      return;
+    }
+    this.clockInError.set(null);
+    this.clockInLoading.set(true);
+    const params = new HttpParams().set('worksiteCode', AppComponent.WORKSITE_CODE);
+    this.http
+      .post<TimeLogApiModel>(`${this.baseUrl}/clock-in`, null, { params })
+      .subscribe({
+        next: () => {
+          this.loadLogs();
+        },
+        error: (error: HttpErrorResponse) => {
+          this.clockInError.set(this.buildErrorMessage(error));
+          this.clockInLoading.set(false);
+        }
+      });
+  }
+
+  protected loadLogs(event?: TableLazyLoadEvent): void {
+    if (this.loading()) {
+      return;
+    }
+    const pageSize = event?.rows ?? this.rows();
+    const first = event?.first ?? this.first();
+    const page = Math.floor(first / pageSize);
+    this.loading.set(true);
+    this.tableError.set(null);
+
+    const params = new HttpParams()
+      .set('page', page.toString())
+      .set('size', pageSize.toString())
+      .set('sort', 'entryTime,desc');
+
+    this.http.get<PageResponse<TimeLogApiModel>>(`${this.baseUrl}/`, { params }).subscribe({
+      next: (response) => {
+        this.clockInLoading.set(false);
+        this.rows.set(response.size);
+        this.totalRecords.set(response.totalElements);
+        this.first.set(response.number * response.size);
+        this.rawLogs = response.content.map((log) => this.mapToRow(log));
+        this.refreshViewRows();
+        this.loading.set(false);
+      },
+      error: (error: HttpErrorResponse) => {
+        this.loading.set(false);
+        this.clockInLoading.set(false);
+        this.tableError.set(this.buildErrorMessage(error));
+      }
+    });
+  }
+
+  private refreshViewRows(): void {
+    this.logs.set(this.rawLogs.map((log) => this.mapToView(log)));
+  }
+
+  private mapToRow(apiModel: TimeLogApiModel): TimeLogRow {
+    return {
+      entryTime: new Date(apiModel.entryTime),
+      exitTime: this.extractInstant(apiModel.exitTime)
+    };
+  }
+
+  private mapToView(row: TimeLogRow): TimeLogViewRow {
+    const entry = row.entryTime;
+    const exit = row.exitTime;
+    return {
+      entryTime: entry,
+      dateDisplay: this.formatDate(entry, 'dd/MM/yyyy'),
+      entryDisplay: this.formatDate(entry, 'HH:mm'),
+      exitDisplay: exit ? this.formatDate(exit, 'HH:mm') : '—',
+      durationDisplay: this.formatDuration(entry, exit)
+    };
+  }
+
+  private extractInstant(value: JsonNullable<string> | undefined): Date | null {
+    if (!value) {
+      return null;
+    }
+    if (typeof value === 'string') {
+      return value ? new Date(value) : null;
+    }
+    if (typeof value === 'object') {
+      const candidate = value.value;
+      return candidate ? new Date(candidate) : null;
+    }
+    return null;
+  }
+
+  private updateCurrentTime(): void {
+    const now = new Date();
+    this.currentTimeText.set(this.formatDate(now, 'HH:mm:ss'));
+    this.currentTimeIso.set(now.toISOString());
+    if (this.rawLogs.length > 0) {
+      this.refreshViewRows();
+    }
+  }
+
+  private formatDate(date: Date, format: string): string {
+    return this.datePipe.transform(date, format) ?? '';
+  }
+
+  private formatDuration(entry: Date, exit: Date | null): string {
+    const end = exit ?? new Date();
+    const diffMillis = Math.max(end.getTime() - entry.getTime(), 0);
+    const totalMinutes = Math.floor(diffMillis / 60000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours}h ${minutes.toString().padStart(2, '0')}m`;
+  }
+
+  private buildErrorMessage(error: HttpErrorResponse): string {
+    if (error.error?.message) {
+      return error.error.message;
+    }
+    if (typeof error.error === 'string' && error.error.trim().length > 0) {
+      return error.error;
+    }
+    return 'No hemos podido completar la operación. Inténtalo de nuevo más tarde.';
+  }
 }

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,5 +1,7 @@
 import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
 
 export const appConfig: ApplicationConfig = {
-  providers: []
+  providers: [provideHttpClient(withInterceptorsFromDi()), provideAnimations()]
 };


### PR DESCRIPTION
## Summary
- refactor the Angular dashboard into PrimeNG panel, card, button, and table components backed by the time log REST API for aferrer@nivel36.es at BCN-HQ
- surface a live clock, clock-in action, and paginated time log table while keeping the existing dark and yellow theme
- add PrimeNG dependencies and enable Angular animations support required by the new UI widgets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe0ce6c7d88327bf08d58e0067a555