### PR TITLE
Protect closed time logs during clock out

### DIFF
--- a/src/main/java/es/nivel36/janus/service/timelog/TimeLogRepository.java
+++ b/src/main/java/es/nivel36/janus/service/timelog/TimeLogRepository.java
@@ -107,8 +107,21 @@ interface TimeLogRepository extends JpaRepository<TimeLog, Long> {
 	 * @return an {@link Optional} containing the most recent time log, or empty if
 	 *         none exist
 	 */
-	@EntityGraph(attributePaths = { "employee", "worksite" })
-	TimeLog findTopByEmployeeAndWorksiteOrderByEntryTimeDesc(Employee employee, Worksite worksite);
+        @EntityGraph(attributePaths = { "employee", "worksite" })
+        TimeLog findTopByEmployeeAndWorksiteOrderByEntryTimeDesc(Employee employee, Worksite worksite);
+
+        /**
+         * Finds the most recent {@link TimeLog} for the specified employee and
+         * worksite that has not been closed yet (i.e. {@code exitTime IS NULL}),
+         * ordered by {@code entryTime} descending.
+         *
+         * @param employee the employee whose last open time log is to be found
+         * @param worksite the worksite to filter by
+         * @return the most recent open time log, or {@code null} if none exist
+         */
+        @EntityGraph(attributePaths = { "employee", "worksite" })
+        TimeLog findTopByEmployeeAndWorksiteAndExitTimeIsNullOrderByEntryTimeDesc(Employee employee,
+                        Worksite worksite);
 
 	/**
 	 * Retrieves all {@link TimeLog} records for a given employee, with pagination.


### PR DESCRIPTION
## Summary
- avoid overwriting previously closed time logs by only closing the latest open log and enforcing exit-after-entry checks
- add repository helper to fetch the most recent open log for an employee/worksite

## Testing
- mvn test -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbe5690788327be255d7f98892c0d)