### PR TITLE
Extract timelog table into component

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -110,56 +110,9 @@
 	box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
 }
 
-.timelog {
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-}
-
-.timelog-title {
-	font-size: 1.25rem;
-	margin: 0;
-	text-transform: uppercase;
-	letter-spacing: 0.12em;
-	color: #f9d600;
-}
-
-.timelog-table {
-	width: 100%;
-	border-collapse: collapse;
-	background-color: #0f0f0f;
-	border-radius: 16px;
-	overflow: hidden;
-	box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.2);
-}
-
-.timelog-table th, .timelog-table td {
-	padding: 1rem 1.5rem;
-	text-align: left;
-}
-
-.timelog-table thead {
-	background-color: rgba(249, 214, 0, 0.12);
-	text-transform: uppercase;
-	letter-spacing: 0.12em;
-	font-size: 0.85rem;
-}
-
-.timelog-table tbody tr:nth-child(odd) {
-	background-color: rgba(255, 255, 255, 0.02);
-}
-
-.timelog-table tbody tr:nth-child(even) {
-	background-color: rgba(255, 255, 255, 0.08);
-}
-
-.timelog-table tbody tr:hover {
-	background-color: rgba(249, 214, 0, 0.18);
-}
-
 @media ( max-width : 640px) {
-	.clock-card {
-		flex-direction: column;
+        .clock-card {
+                flex-direction: column;
 		align-items: flex-start;
 	}
 	.clock-button {

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -14,45 +14,7 @@
 					| translate }}</button>
 				</ng-template> </app-card>
 
-				<section class="timelog">
-					<h2 class="timelog-title">{{ 'timelog.timelogs' | translate }}</h2>
-					<table class="timelog-table">
-						<thead>
-							<tr>
-								<th scope="col">{{ 'timelog.date' | translate }}</th>
-								<th scope="col">{{ 'timelog.clockin' | translate }}</th>
-								<th scope="col">{{ 'timelog.clockout' | translate }}</th>
-								<th scope="col">{{ 'timelog.duration' | translate }}</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>04/23/2024</td>
-								<td>08:32 AM</td>
-								<td>05:15 PM</td>
-								<td>8h 43m</td>
-							</tr>
-							<tr>
-								<td>04/22/2024</td>
-								<td>08:29 AM</td>
-								<td>05:31 PM</td>
-								<td>9h 02m</td>
-							</tr>
-							<tr>
-								<td>04/21/2024</td>
-								<td>08:34 AM</td>
-								<td>05:11 PM</td>
-								<td>8h 37m</td>
-							</tr>
-							<tr>
-								<td>04/20/2024</td>
-								<td>08:33 AM</td>
-								<td>05:11 PM</td>
-								<td>8h 52m</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
+                                <app-timelog-table></app-timelog-table>
 			</section>
 			<section class="aside">
 				<div class="aside">

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -2,11 +2,12 @@ import { Component } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ClockComponent } from './shared/ui/clock/clock.component';
 import { CardComponent } from './shared/ui/card/card.component';
+import { TimelogTableComponent } from './timelog/timelog-table.component';
 
 @Component({
 	selector: 'app-root',
 	standalone: true,
-	imports: [TranslatePipe, ClockComponent, CardComponent],
+        imports: [TranslatePipe, ClockComponent, CardComponent, TimelogTableComponent],
 	templateUrl: './app.component.html',
 	styleUrl: './app.component.css'
 })

--- a/frontend/src/app/timelog/time-log.service.ts
+++ b/frontend/src/app/timelog/time-log.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+
+export interface TimeLogResponse {
+        employeeEmail: string;
+        worksiteCode: string;
+        entryTime: string;
+        exitTime?: string | { present: boolean; value?: string | null } | null;
+}
+
+interface PageResponse<T> {
+        content: T[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class TimeLogService {
+        private readonly baseUrl = '/api/v1/employees';
+
+        constructor(private readonly http: HttpClient) {}
+
+        searchByEmployee(email: string): Observable<TimeLogResponse[]> {
+                const encodedEmail = encodeURIComponent(email);
+                const url = `${this.baseUrl}/${encodedEmail}/timelogs/`;
+
+                return this.http
+                        .get<PageResponse<TimeLogResponse>>(url)
+                        .pipe(map((response) => response.content ?? []));
+        }
+}

--- a/frontend/src/app/timelog/timelog-table.component.css
+++ b/frontend/src/app/timelog/timelog-table.component.css
@@ -1,0 +1,65 @@
+.timelog {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+
+.timelog-title {
+        font-size: 1.25rem;
+        margin: 0;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: #f9d600;
+}
+
+.timelog-table {
+        width: 100%;
+        border-collapse: collapse;
+        background-color: #0f0f0f;
+        border-radius: 16px;
+        overflow: hidden;
+        box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.2);
+}
+
+.timelog-table th,
+.timelog-table td {
+        padding: 1rem 1.5rem;
+        text-align: left;
+}
+
+.timelog-table thead {
+        background-color: rgba(249, 214, 0, 0.12);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 0.85rem;
+}
+
+.timelog-table tbody tr:nth-child(odd) {
+        background-color: rgba(255, 255, 255, 0.02);
+}
+
+.timelog-table tbody tr:nth-child(even) {
+        background-color: rgba(255, 255, 255, 0.08);
+}
+
+.timelog-table tbody tr:hover {
+        background-color: rgba(249, 214, 0, 0.18);
+}
+
+.timelog-message {
+        padding: 1rem 1.5rem;
+        border-radius: 16px;
+        background-color: rgba(255, 255, 255, 0.06);
+        color: #f9f9f9;
+}
+
+.timelog-message.error {
+        background-color: rgba(255, 87, 87, 0.12);
+}
+
+@media (max-width: 640px) {
+        .timelog-table th,
+        .timelog-table td {
+                padding: 0.75rem 1rem;
+        }
+}

--- a/frontend/src/app/timelog/timelog-table.component.html
+++ b/frontend/src/app/timelog/timelog-table.component.html
@@ -1,0 +1,29 @@
+<section class="timelog">
+        <h2 class="timelog-title">{{ 'timelog.timelogs' | translate }}</h2>
+
+        <div *ngIf="error" class="timelog-message error">{{ error }}</div>
+        <div *ngIf="isLoading" class="timelog-message">Loading time logs...</div>
+
+        <table *ngIf="!isLoading && timelogs.length" class="timelog-table">
+                <thead>
+                        <tr>
+                                <th scope="col">{{ 'timelog.date' | translate }}</th>
+                                <th scope="col">{{ 'timelog.clockin' | translate }}</th>
+                                <th scope="col">{{ 'timelog.clockout' | translate }}</th>
+                                <th scope="col">{{ 'timelog.duration' | translate }}</th>
+                        </tr>
+                </thead>
+                <tbody>
+                        <tr *ngFor="let timelog of timelogs">
+                                <td>{{ timelog.entryTime | date: 'MM/dd/yyyy' }}</td>
+                                <td>{{ timelog.entryTime | date: 'hh:mm a' }}</td>
+                                <td>{{ timelog.exitTime ? (timelog.exitTime | date: 'hh:mm a') : '—' }}</td>
+                                <td>{{ timelog.duration || '—' }}</td>
+                        </tr>
+                </tbody>
+        </table>
+
+        <div *ngIf="!isLoading && !timelogs.length && !error" class="timelog-message">
+                No time logs available yet.
+        </div>
+</section>

--- a/frontend/src/app/timelog/timelog-table.component.ts
+++ b/frontend/src/app/timelog/timelog-table.component.ts
@@ -1,0 +1,88 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import { TimeLogResponse, TimeLogService } from './time-log.service';
+
+interface TimeLogView {
+        entryTime: Date;
+        exitTime?: Date;
+        duration?: string;
+}
+
+@Component({
+        selector: 'app-timelog-table',
+        standalone: true,
+        imports: [CommonModule, TranslatePipe, DatePipe],
+        templateUrl: './timelog-table.component.html',
+        styleUrl: './timelog-table.component.css'
+})
+export class TimelogTableComponent implements OnInit {
+        protected readonly employeeEmail = 'aferrer@nivel36.es';
+        protected timelogs: TimeLogView[] = [];
+        protected isLoading = false;
+        protected error?: string;
+
+        private readonly destroyRef = inject(DestroyRef);
+
+        constructor(private readonly timeLogService: TimeLogService) {}
+
+        ngOnInit(): void {
+                this.loadTimeLogs();
+        }
+
+        private loadTimeLogs(): void {
+                this.isLoading = true;
+                this.error = undefined;
+
+                this.timeLogService
+                        .searchByEmployee(this.employeeEmail)
+                        .pipe(takeUntilDestroyed(this.destroyRef))
+                        .subscribe({
+                                next: (response) => {
+                                        this.timelogs = response.map((timelog) => this.mapToView(timelog));
+                                },
+                                error: () => {
+                                        this.error = 'Unable to load time logs at this time.';
+                                },
+                                complete: () => {
+                                        this.isLoading = false;
+                                }
+                        });
+        }
+
+        private mapToView(timeLog: TimeLogResponse): TimeLogView {
+                const entryTime = new Date(timeLog.entryTime);
+                const exitTimeInstant = this.extractExitTime(timeLog.exitTime);
+                const exitTime = exitTimeInstant ? new Date(exitTimeInstant) : undefined;
+
+                return {
+                        entryTime,
+                        exitTime,
+                        duration: exitTime ? this.calculateDuration(entryTime, exitTime) : undefined
+                };
+        }
+
+        private extractExitTime(exitTime: TimeLogResponse['exitTime']): string | null {
+                if (!exitTime) {
+                        return null;
+                }
+                if (typeof exitTime === 'string') {
+                        return exitTime;
+                }
+                if ('present' in exitTime) {
+                        return exitTime.present ? exitTime.value ?? null : null;
+                }
+                return null;
+        }
+
+        private calculateDuration(entryTime: Date, exitTime: Date): string {
+                const milliseconds = Math.max(exitTime.getTime() - entryTime.getTime(), 0);
+                const totalMinutes = Math.floor(milliseconds / 60000);
+                const hours = Math.floor(totalMinutes / 60);
+                const minutes = totalMinutes % 60;
+
+                return `${hours}h ${minutes.toString().padStart(2, '0')}m`;
+        }
+}


### PR DESCRIPTION
## Summary
- replace the inline timelog table in the dashboard with a dedicated standalone component
- load time logs for user aferrer@nivel36.es from the backend search endpoint with duration formatting and error/loading states
- move timelog styling into the new component and turn off Angular CLI analytics to avoid prompts

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f62c5cabc8327aa8e496ca6807c3a)