### PR TITLE
Add shared button component

### DIFF
--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -91,32 +91,9 @@
 	font-weight: 700;
 }
 
-.clock-button {
-	background-color: #040404;
-	color: #f9d600;
-	border: none;
-	border-radius: 999px;
-	padding: 0.75rem 2.5rem;
-	font-size: 1rem;
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.1em;
-	cursor: pointer;
-	transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.clock-button:hover, .clock-button:focus-visible {
-	transform: translateY(-2px);
-	box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
-}
-
 @media ( max-width : 640px) {
         .clock-card {
                 flex-direction: column;
-		align-items: flex-start;
-	}
-	.clock-button {
-		align-self: stretch;
-		text-align: center;
-	}
+                align-items: flex-start;
+        }
 }

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -10,9 +10,8 @@
 					title="{{ 'timelog.clockin' | translate }}"> <ng-template
 					#cardHeader> <app-clock
 					styleClass="card-hour-container" timeClass="card-hour"></app-clock>
-				<button class="clock-button" type="button">{{'timelog.clockin'
-					| translate }}</button>
-				</ng-template> </app-card>
+                                <app-button>{{'timelog.clockin' | translate }}</app-button>
+                                </ng-template> </app-card>
 
                                 <app-timelog-table></app-timelog-table>
 			</section>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,13 +3,14 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { ClockComponent } from './shared/ui/clock/clock.component';
 import { CardComponent } from './shared/ui/card/card.component';
 import { TimelogTableComponent } from './timelog/timelog-table.component';
+import { ButtonComponent } from './shared/ui/button/button.component';
 
 @Component({
-	selector: 'app-root',
-	standalone: true,
-        imports: [TranslatePipe, ClockComponent, CardComponent, TimelogTableComponent],
-	templateUrl: './app.component.html',
-	styleUrl: './app.component.css'
+        selector: 'app-root',
+        standalone: true,
+        imports: [TranslatePipe, ClockComponent, CardComponent, TimelogTableComponent, ButtonComponent],
+        templateUrl: './app.component.html',
+        styleUrl: './app.component.css'
 })
 export class AppComponent {
 	title = 'frontend';

--- a/frontend/src/app/shared/ui/button/button.component.css
+++ b/frontend/src/app/shared/ui/button/button.component.css
@@ -1,0 +1,82 @@
+:host {
+        display: inline-block;
+}
+
+.app-button {
+        background-color: #040404;
+        color: #f9d600;
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 2.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        text-decoration: none;
+}
+
+.app-button:hover,
+.app-button:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.app-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+        transform: none;
+}
+
+.button-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.1rem;
+}
+
+.button-label {
+        display: inline-flex;
+        align-items: center;
+}
+
+.button--default {
+        background-color: #040404;
+        color: #f9d600;
+}
+
+.button--error {
+        background-color: #7f1d1d;
+        color: #fff;
+}
+
+.button--info {
+        background-color: #0f172a;
+        color: #e0f2fe;
+}
+
+.button--success {
+        background-color: #14532d;
+        color: #e2fbe8;
+}
+
+.button--neutral {
+        background-color: #1f2937;
+        color: #f3f4f6;
+}
+
+@media (max-width: 640px) {
+        :host {
+                width: 100%;
+        }
+
+        .app-button {
+                width: 100%;
+                justify-content: center;
+        }
+}

--- a/frontend/src/app/shared/ui/button/button.component.html
+++ b/frontend/src/app/shared/ui/button/button.component.html
@@ -1,0 +1,11 @@
+<button
+        class="app-button {{ variantClass }} {{ styleClass }}"
+        [attr.type]="type"
+        [disabled]="disabled"
+>
+        <span *ngIf="hasIconOnLeft" class="button-icon" aria-hidden="true">{{ icon }}</span>
+        <span class="button-label">
+                <ng-content></ng-content>
+        </span>
+        <span *ngIf="hasIconOnRight" class="button-icon" aria-hidden="true">{{ icon }}</span>
+</button>

--- a/frontend/src/app/shared/ui/button/button.component.spec.ts
+++ b/frontend/src/app/shared/ui/button/button.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ButtonComponent } from './button.component';
+
+describe('ButtonComponent', () => {
+        let fixture: ComponentFixture<ButtonComponent>;
+        let component: ButtonComponent;
+
+        beforeEach(async () => {
+                await TestBed.configureTestingModule({
+                        imports: [ButtonComponent],
+                }).compileComponents();
+
+                fixture = TestBed.createComponent(ButtonComponent);
+                component = fixture.componentInstance;
+                fixture.detectChanges();
+        });
+
+        it('should create', () => {
+                expect(component).toBeTruthy();
+        });
+
+        it('should render the default variant with the default type', () => {
+                const buttonEl: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+                expect(buttonEl.type).toBe('button');
+                expect(buttonEl.classList).toContain('button--default');
+        });
+
+        it('should apply the requested variant and show icons in the right position', () => {
+                component.variant = 'error';
+                component.icon = '⚠';
+                component.iconPosition = 'right';
+                fixture.detectChanges();
+
+                const buttonEl: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+                expect(buttonEl.classList).toContain('button--error');
+
+                const icons = buttonEl.querySelectorAll('.button-icon');
+                expect(icons.length).toBe(1);
+                expect(icons[0].textContent?.trim()).toBe('⚠');
+        });
+});

--- a/frontend/src/app/shared/ui/button/button.component.ts
+++ b/frontend/src/app/shared/ui/button/button.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input } from '@angular/core';
+
+type ButtonVariant = 'default' | 'error' | 'info' | 'success' | 'neutral';
+
+type ButtonType = 'button' | 'submit' | 'reset';
+
+type IconPosition = 'left' | 'right';
+
+@Component({
+        selector: 'app-button',
+        standalone: true,
+        templateUrl: './button.component.html',
+        styleUrl: './button.component.css',
+})
+export class ButtonComponent {
+        @Input() variant: ButtonVariant = 'default';
+        @Input() type: ButtonType = 'button';
+        @Input() icon: string | null = null;
+        @Input() iconPosition: IconPosition = 'left';
+        @Input() disabled = false;
+        @Input() styleClass = '';
+
+        get variantClass(): string {
+                return `button--${this.variant}`;
+        }
+
+        get hasIconOnLeft(): boolean {
+                return !!this.icon && this.iconPosition === 'left';
+        }
+
+        get hasIconOnRight(): boolean {
+                return !!this.icon && this.iconPosition === 'right';
+        }
+}


### PR DESCRIPTION
## Summary
- add a reusable button component in shared UI with support for icons and variants
- swap the dashboard clock-in button to use the new shared component while preserving the existing default style
- include unit coverage for the button component

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f65f2a36c8327b54e4479a1b69492)