### PR TITLE
Allow @ in app user usernames

### DIFF
--- a/src/main/java/es/nivel36/janus/api/v1/appuser/AppUserController.java
+++ b/src/main/java/es/nivel36/janus/api/v1/appuser/AppUserController.java
@@ -73,8 +73,8 @@ public class AppUserController {
          */
         @GetMapping("/{username}")
         public ResponseEntity<AppUserResponse> findAppUser(final @PathVariable("username") //
-        @Pattern(regexp = "[A-Za-z0-9_.-]{3,50}", //
-                        message = "username must contain only letters, digits, dots, underscores or hyphens (3-50 characters)") //
+        @Pattern(regexp = "[A-Za-z0-9_.@-]{3,50}", //
+                        message = "username must contain only letters, digits, dots, underscores, hyphens or at signs (3-50 characters)") //
         String username) {
                 logger.debug("Find app user ACTION performed");
 
@@ -112,8 +112,8 @@ public class AppUserController {
          */
         @PutMapping("/{username}")
         public ResponseEntity<AppUserResponse> updateAppUser(final @PathVariable("username") //
-        @Pattern(regexp = "[A-Za-z0-9_.-]{3,50}", //
-                        message = "username must contain only letters, digits, dots, underscores or hyphens (3-50 characters)") //
+        @Pattern(regexp = "[A-Za-z0-9_.@-]{3,50}", //
+                        message = "username must contain only letters, digits, dots, underscores, hyphens or at signs (3-50 characters)") //
         String username, @Valid @RequestBody final UpdateAppUserRequest request) {
                 logger.debug("Update app user ACTION performed");
 
@@ -132,8 +132,8 @@ public class AppUserController {
          */
         @DeleteMapping("/{username}")
         public ResponseEntity<Void> deleteAppUser(final @PathVariable("username") //
-        @Pattern(regexp = "[A-Za-z0-9_.-]{3,50}", //
-                        message = "username must contain only letters, digits, dots, underscores or hyphens (3-50 characters)") //
+        @Pattern(regexp = "[A-Za-z0-9_.@-]{3,50}", //
+                        message = "username must contain only letters, digits, dots, underscores, hyphens or at signs (3-50 characters)") //
         String username) {
                 logger.debug("Delete app user ACTION performed");
 

--- a/src/main/java/es/nivel36/janus/api/v1/appuser/CreateAppUserRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/appuser/CreateAppUserRequest.java
@@ -38,8 +38,8 @@ import jakarta.validation.constraints.Pattern;
  */
 public record CreateAppUserRequest( //
                 @NotBlank(message = "username must not be blank") //
-                @Pattern(regexp = "[A-Za-z0-9_.-]{3,50}", //
-                                message = "username must contain only letters, digits, dots, underscores or hyphens (3-50 characters)") //
+                @Pattern(regexp = "[A-Za-z0-9_.@-]{3,50}", //
+                                message = "username must contain only letters, digits, dots, underscores, hyphens or at signs (3-50 characters)") //
                 String username, //
 
                 @NotBlank(message = "name must not be blank") //

--- a/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
+++ b/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
@@ -98,6 +98,21 @@ class AppUserControllerIT {
         }
 
         @Test
+        void testCreateShouldAcceptUsernamesWithAtSign() throws Exception {
+                String body = """
+                                  {"username":"alice@example.com","name":"Alice","surname":"Smith","locale":"en-GB","timeFormat":"H12"}
+                                """;
+
+                mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
+                                .andExpect(status().isCreated()) //
+                                .andExpect(jsonPath("$.username").value("alice@example.com"));
+
+                mvc.perform(get(BASE + "/{username}", "alice@example.com")) //
+                                .andExpect(status().isOk()) //
+                                .andExpect(jsonPath("$.username").value("alice@example.com"));
+        }
+
+        @Test
         @Sql(statements = { //
                         "INSERT INTO app_user(username,name,surname,locale,time_format) VALUES('jdoe','John','Doe','en-US','H24')"//
         })


### PR DESCRIPTION
## Summary
- allow application usernames to include @ by updating validation on requests and path variables
- add integration coverage for creating and retrieving users whose usernames contain @ symbols

## Testing
- mvn test *(fails: frontend build missing dependency `luxon` during npm build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932071461f48327ba88d44e4e440643)