### PR TITLE
Refactor schedule mapping into application DTOs

### DIFF
--- a/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleRequestMapper.java
+++ b/src/main/java/es/nivel36/janus/api/v1/schedule/ScheduleRequestMapper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.schedule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import es.nivel36.janus.service.schedule.dto.CreateScheduleDefinition;
+import es.nivel36.janus.service.schedule.dto.ScheduleRuleDefinition;
+import es.nivel36.janus.service.schedule.dto.ScheduleRuleTimeRangeDefinition;
+import es.nivel36.janus.service.schedule.dto.UpdateScheduleDefinition;
+
+/**
+ * Maps schedule-related HTTP requests into domain-neutral DTOs that can be
+ * consumed by the application layer.
+ */
+@Component
+public class ScheduleRequestMapper {
+
+	/**
+	 * Builds a {@link CreateScheduleDefinition} from the incoming request payload.
+	 *
+	 * @param request validated request describing the schedule to create; must not
+	 *                be {@code null}
+	 * @return a domain-neutral DTO
+	 */
+	public CreateScheduleDefinition toCreateDefinition(final CreateScheduleRequest request) {
+		Objects.requireNonNull(request, "request can't be null");
+		final List<ScheduleRuleDefinition> ruleDefinitions = this.toRuleDefinitions(request.rules());
+		return new CreateScheduleDefinition(request.code(), request.name(), ruleDefinitions);
+	}
+
+	/**
+	 * Builds an {@link UpdateScheduleDefinition} from the incoming request payload.
+	 *
+	 * @param request validated request describing the schedule to update; must not
+	 *                be {@code null}
+	 * @return a domain-neutral DTO
+	 */
+	public UpdateScheduleDefinition toUpdateDefinition(final UpdateScheduleRequest request) {
+		Objects.requireNonNull(request, "request can't be null");
+		final List<ScheduleRuleDefinition> ruleDefinitions = this.toRuleDefinitions(request.rules());
+		return new UpdateScheduleDefinition(request.name(), ruleDefinitions);
+	}
+
+	private List<ScheduleRuleDefinition> toRuleDefinitions(final List<ScheduleRuleRequest> rules) {
+		if (rules == null) {
+			return Collections.emptyList();
+		}
+		return rules.stream() //
+				.filter(Objects::nonNull) //
+				.map(this::toRuleDefinition) //
+				.toList();
+	}
+
+	private ScheduleRuleDefinition toRuleDefinition(final ScheduleRuleRequest ruleRequest) {
+		final List<ScheduleRuleTimeRangeDefinition> dayOfWeekRanges = this
+				.toRuleTimeRangeDefinitions(ruleRequest.dayOfWeekRanges());
+		return new ScheduleRuleDefinition(ruleRequest.name(), ruleRequest.startDate(), ruleRequest.endDate(),
+				dayOfWeekRanges);
+	}
+
+	private List<ScheduleRuleTimeRangeDefinition> toRuleTimeRangeDefinitions(
+			final List<ScheduleRuleTimeRangeRequest> timeRanges) {
+		if (timeRanges == null) {
+			return Collections.emptyList();
+		}
+		return timeRanges.stream() //
+				.filter(Objects::nonNull) //
+				.map(this::toRuleTimeRangeDefinition) //
+				.toList();
+	}
+
+	private ScheduleRuleTimeRangeDefinition toRuleTimeRangeDefinition(final ScheduleRuleTimeRangeRequest request) {
+		final ScheduleTimeRangeRequest timeRange = request.timeRange();
+		return new ScheduleRuleTimeRangeDefinition(request.dayOfWeek(), request.effectiveWorkHours(),
+				timeRange.startTime(), timeRange.endTime());
+	}
+}

--- a/src/main/java/es/nivel36/janus/service/schedule/dto/CreateScheduleDefinition.java
+++ b/src/main/java/es/nivel36/janus/service/schedule/dto/CreateScheduleDefinition.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.schedule.dto;
+
+import java.util.List;
+
+/**
+ * Domain-neutral DTO describing the data required to create a schedule.
+ *
+ * @param code  unique business identifier assigned to the schedule
+ * @param name  human readable name describing the schedule
+ * @param rules collection of rule definitions associated with the schedule
+ */
+public record CreateScheduleDefinition( //
+		String code, //
+		String name, //
+		List<ScheduleRuleDefinition> rules) {
+}

--- a/src/main/java/es/nivel36/janus/service/schedule/dto/ScheduleRuleDefinition.java
+++ b/src/main/java/es/nivel36/janus/service/schedule/dto/ScheduleRuleDefinition.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.schedule.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Domain-neutral DTO describing a schedule rule without exposing entities.
+ *
+ * @param name            human readable name of the rule
+ * @param startDate       optional start date delimiting when the rule becomes
+ *                        active
+ * @param endDate         optional end date delimiting when the rule stops being
+ *                        active
+ * @param dayOfWeekRanges day specific working ranges that compose the rule
+ */
+public record ScheduleRuleDefinition( //
+		String name, //
+		LocalDate startDate, //
+		LocalDate endDate, //
+		List<ScheduleRuleTimeRangeDefinition> dayOfWeekRanges) {
+}

--- a/src/main/java/es/nivel36/janus/service/schedule/dto/ScheduleRuleTimeRangeDefinition.java
+++ b/src/main/java/es/nivel36/janus/service/schedule/dto/ScheduleRuleTimeRangeDefinition.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.schedule.dto;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalTime;
+
+/**
+ * Domain-neutral DTO describing the timing constraints of a rule for a
+ * particular day of the week.
+ *
+ * @param dayOfWeek          the day of the week when the shift starts
+ * @param effectiveWorkHours intended working duration for the range
+ * @param startTime          lower bound for the allowed time window
+ * @param endTime            upper bound for the allowed time window
+ */
+public record ScheduleRuleTimeRangeDefinition( //
+		DayOfWeek dayOfWeek, //
+		Duration effectiveWorkHours, //
+		LocalTime startTime, //
+		LocalTime endTime) {
+}

--- a/src/main/java/es/nivel36/janus/service/schedule/dto/UpdateScheduleDefinition.java
+++ b/src/main/java/es/nivel36/janus/service/schedule/dto/UpdateScheduleDefinition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.schedule.dto;
+
+import java.util.List;
+
+/**
+ * Domain-neutral DTO describing the data required to update a schedule.
+ *
+ * @param name  new human readable name describing the schedule
+ * @param rules collection of rule definitions that replace the previous ones
+ */
+public record UpdateScheduleDefinition( //
+		String name, //
+		List<ScheduleRuleDefinition> rules) {
+}


### PR DESCRIPTION
## Summary
- add a dedicated request mapper to build domain-neutral schedule definitions from create and update payloads
- introduce DTOs for schedule rules and day-of-week ranges to decouple the API layer from entities
- move Schedule aggregation responsibilities into ScheduleService when creating or updating schedules

## Testing
- mvn -q -DskipTests compile *(fails: Maven Central returned HTTP 502 for org.apache:apache:pom:33)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694692433ed08327a2170b68dfe4c421)