### PR TITLE
Add auth login/logout endpoints and password hashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-crypto</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/src/main/java/es/nivel36/janus/api/JanusExceptionHandler.java
+++ b/src/main/java/es/nivel36/janus/api/JanusExceptionHandler.java
@@ -43,6 +43,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import es.nivel36.janus.service.ResourceAlreadyExistsException;
 import es.nivel36.janus.service.ResourceNotFoundException;
+import es.nivel36.janus.service.auth.AuthenticationFailedException;
 import es.nivel36.janus.service.timelog.ClockOutWithoutClockInException;
 import es.nivel36.janus.service.timelog.EventAlreadyFinalizedException;
 import es.nivel36.janus.service.timelog.TimeLogAlreadyClosedException;
@@ -77,6 +78,7 @@ public class JanusExceptionHandler {
 	private static final URI TYPE_VALIDATION_FAILED = URI.create("urn:problem:validation-failed");
 	private static final URI TYPE_VALIDATION_ERROR = URI.create("urn:problem:validation-error");
 	private static final URI TYPE_CONSTRAINT_VIOLATION = URI.create("urn:problem:constraint-violation");
+	private static final URI TYPE_AUTHENTICATION_FAILED = URI.create("urn:problem:authentication-failed");
 	private static final URI TYPE_INTERNAL_ERROR = URI.create("urn:problem:internal");
 
 	private final Clock clock;
@@ -122,6 +124,17 @@ public class JanusExceptionHandler {
 		pd.setDetail(ex.getMessage());
 		addCommonProps(pd, request);
 		logger.warn("ResourceAlreadyExistsException error {}", pd);
+		return pd;
+	}
+
+	@ExceptionHandler(AuthenticationFailedException.class)
+	ProblemDetail handleAuthenticationFailed(AuthenticationFailedException ex, final HttpServletRequest request) {
+		final ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
+		pd.setType(TYPE_AUTHENTICATION_FAILED);
+		pd.setTitle("Authentication failed");
+		pd.setDetail(ex.getMessage());
+		addCommonProps(pd, request);
+		logger.warn("AuthenticationFailedException error {}", pd);
 		return pd;
 	}
 

--- a/src/main/java/es/nivel36/janus/api/v1/appuser/AppUserController.java
+++ b/src/main/java/es/nivel36/janus/api/v1/appuser/AppUserController.java
@@ -96,7 +96,7 @@ public class AppUserController {
 
 		final Locale locale = Locale.forLanguageTag(request.locale());
 		final AppUser createdAppUser = this.appUserService.createAppUser(request.username(), request.name(),
-				request.surname(), locale, request.timeFormat());
+				request.surname(), request.password(), locale, request.timeFormat());
 		final AppUserResponse response = this.appUserResponseMapper.map(createdAppUser);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}

--- a/src/main/java/es/nivel36/janus/api/v1/appuser/CreateAppUserRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/appuser/CreateAppUserRequest.java
@@ -20,6 +20,7 @@ import es.nivel36.janus.service.appuser.AppUser;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request payload for creating a new {@link AppUser}.
@@ -30,6 +31,8 @@ import jakarta.validation.constraints.Pattern;
  *                   allowed pattern
  * @param surname    the user's surname; must not be blank and must match the
  *                   allowed pattern
+ * @param password   the raw password for the user; must not be blank and must
+ *                   meet minimum length requirements
  * @param locale     the preferred locale of the user expressed as a BCP 47
  *                   language tag (e.g. {@code "en-US"}); must not be blank and
  *                   must match the allowed pattern
@@ -51,6 +54,10 @@ public record CreateAppUserRequest( //
 		@Pattern(regexp = "^[\\p{L} .,'-]{1,255}$", //
 				message = "surname must contain only letters, spaces, dots, commas, apostrophes or hyphens (max 255)") //
 		String surname, //
+
+		@NotBlank(message = "password must not be blank") //
+		@Size(min = 8, max = 72, message = "password must be between 8 and 72 characters") //
+		String password, //
 
 		@NotBlank(message = "locale must not be blank") //
 		@Pattern(regexp = "^[a-z]{2,3}-[A-Z]{2}$", //

--- a/src/main/java/es/nivel36/janus/api/v1/auth/AuthController.java
+++ b/src/main/java/es/nivel36/janus/api/v1/auth/AuthController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.auth;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import es.nivel36.janus.service.auth.AuthService;
+import es.nivel36.janus.util.Strings;
+import jakarta.validation.Valid;
+
+/**
+ * REST controller exposing authentication endpoints.
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+	private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final AuthService authService;
+
+	public AuthController(final AuthService authService) {
+		this.authService = Objects.requireNonNull(authService, "authService cannot be null");
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<LoginResponse> login(@Valid @RequestBody final LoginRequest request) {
+		logger.debug("Login ACTION performed");
+		final String token = this.authService.login(request.username(), request.password());
+		return ResponseEntity.ok(new LoginResponse(token, request.username()));
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(@RequestHeader("Authorization") final String authorization) {
+		logger.debug("Logout ACTION performed");
+		final String token = extractBearerToken(authorization);
+		this.authService.logout(token);
+		return ResponseEntity.noContent().build();
+	}
+
+	private String extractBearerToken(final String authorization) {
+		Strings.requireNonBlank(authorization, "Authorization header must not be blank.");
+		if (!authorization.startsWith(BEARER_PREFIX)) {
+			throw new IllegalArgumentException("Authorization header must use Bearer scheme.");
+		}
+		final String token = authorization.substring(BEARER_PREFIX.length()).trim();
+		return Strings.requireNonBlank(token, "Authorization token must not be blank.");
+	}
+}

--- a/src/main/java/es/nivel36/janus/api/v1/auth/LoginRequest.java
+++ b/src/main/java/es/nivel36/janus/api/v1/auth/LoginRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request payload for authenticating a user.
+ *
+ * @param username user's username
+ * @param password raw password
+ */
+public record LoginRequest( //
+		@NotBlank(message = "username must not be blank") //
+		@Pattern(regexp = "[A-Za-z0-9_.@-]{3,50}", //
+				message = "username must contain only letters, digits, dots, underscores, hyphens or at signs (3-50 characters)") //
+		String username, //
+
+		@NotBlank(message = "password must not be blank") //
+		@Size(min = 8, max = 72, message = "password must be between 8 and 72 characters") //
+		String password //
+) {
+}

--- a/src/main/java/es/nivel36/janus/api/v1/auth/LoginResponse.java
+++ b/src/main/java/es/nivel36/janus/api/v1/auth/LoginResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.auth;
+
+/**
+ * Response payload returned after a successful login.
+ *
+ * @param token    session token to be used as a bearer token
+ * @param username authenticated username
+ */
+public record LoginResponse(String token, String username) {
+}

--- a/src/main/java/es/nivel36/janus/config/SecurityConfig.java
+++ b/src/main/java/es/nivel36/janus/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Security-related bean configuration.
+ */
+@Configuration
+public class SecurityConfig {
+
+	/**
+	 * Provides a {@link PasswordEncoder} for hashing and verifying passwords.
+	 *
+	 * @return configured password encoder
+	 */
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/es/nivel36/janus/service/appuser/AppUser.java
+++ b/src/main/java/es/nivel36/janus/service/appuser/AppUser.java
@@ -98,6 +98,17 @@ public class AppUser implements Serializable {
 	private String surname;
 
 	/**
+	 * Hashed password for the user.
+	 *
+	 * <p>
+	 * This value should never store plain text passwords.
+	 * </p>
+	 */
+	@NotEmpty
+	@Column(nullable = false)
+	private String passwordHash;
+
+	/**
 	 * Preferred locale of the user.
 	 *
 	 * <p>
@@ -139,6 +150,8 @@ public class AppUser implements Serializable {
 	 *                   blank.
 	 * @param name       the first name of the user. Can't be {@code null} or blank.
 	 * @param surname    the surname of the user. Can't be {@code null} or blank.
+	 * @param passwordHash hashed password for the user. Can't be {@code null} or
+	 *                   blank.
 	 * @param locale     the preferred {@link Locale} of the user. Can't be
 	 *                   {@code null}.
 	 * @param timeFormat the preferred {@link TimeFormat} of the user. Can't be
@@ -148,11 +161,12 @@ public class AppUser implements Serializable {
 	 * @throws IllegalArgumentException if {@code username}, {@code name} or
 	 *                                  {@code surname} is blank
 	 */
-	public AppUser(final String username, final String name, final String surname, final Locale locale,
-			final TimeFormat timeFormat) {
+	public AppUser(final String username, final String name, final String surname, final String passwordHash,
+			final Locale locale, final TimeFormat timeFormat) {
 		this.username = Strings.requireNonBlank(username, "username can't be null or blank");
 		this.name = Strings.requireNonBlank(name, "name can't be null or blank");
 		this.surname = Strings.requireNonBlank(surname, "surname can't be null or blank");
+		this.passwordHash = Strings.requireNonBlank(passwordHash, "passwordHash can't be null or blank");
 		this.locale = Objects.requireNonNull(locale, "locale can't be null");
 		this.timeFormat = Objects.requireNonNull(timeFormat, "timeFormat can't be null");
 	}
@@ -220,6 +234,14 @@ public class AppUser implements Serializable {
 	 */
 	public String getSurname() {
 		return surname;
+	}
+
+	String getPasswordHash() {
+		return passwordHash;
+	}
+
+	void setPasswordHash(final String passwordHash) {
+		this.passwordHash = Strings.requireNonBlank(passwordHash, "passwordHash can't be null or blank");
 	}
 
 	/**

--- a/src/main/java/es/nivel36/janus/service/auth/AuthService.java
+++ b/src/main/java/es/nivel36/janus/service/auth/AuthService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.auth;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import es.nivel36.janus.service.appuser.AppUser;
+import es.nivel36.janus.service.appuser.AppUserService;
+import es.nivel36.janus.util.Strings;
+
+/**
+ * Handles login/logout operations backed by in-memory sessions.
+ */
+@Service
+public class AuthService {
+
+	private static final Logger logger = LoggerFactory.getLogger(AuthService.class);
+
+	private final AppUserService appUserService;
+	private final Clock clock;
+	private final Map<String, AuthSession> sessions = new ConcurrentHashMap<>();
+
+	public AuthService(final AppUserService appUserService, final Clock clock) {
+		this.appUserService = Objects.requireNonNull(appUserService, "appUserService cannot be null");
+		this.clock = Objects.requireNonNull(clock, "clock cannot be null");
+	}
+
+	public String login(final String username, final String password) {
+		final AppUser appUser = this.appUserService.authenticate(username, password);
+		final String token = UUID.randomUUID().toString();
+		final AuthSession session = new AuthSession(appUser.getUsername(), Instant.now(clock));
+		this.sessions.put(token, session);
+		logger.info("Auth session created for user {}", appUser.getUsername());
+		return token;
+	}
+
+	public void logout(final String token) {
+		Strings.requireNonBlank(token, "token cannot be null or blank.");
+		final AuthSession removed = this.sessions.remove(token);
+		if (removed == null) {
+			throw new AuthenticationFailedException("Session not found or already logged out.");
+		}
+		logger.info("Auth session removed for user {}", removed.username());
+	}
+}

--- a/src/main/java/es/nivel36/janus/service/auth/AuthSession.java
+++ b/src/main/java/es/nivel36/janus/service/auth/AuthSession.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.auth;
+
+import java.time.Instant;
+
+/**
+ * Represents an in-memory authenticated session.
+ *
+ * @param username  authenticated username
+ * @param createdAt timestamp when the session was created
+ */
+public record AuthSession(String username, Instant createdAt) {
+}

--- a/src/main/java/es/nivel36/janus/service/auth/AuthenticationFailedException.java
+++ b/src/main/java/es/nivel36/janus/service/auth/AuthenticationFailedException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.auth;
+
+/**
+ * Signals authentication failures such as invalid credentials or session tokens.
+ */
+public class AuthenticationFailedException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public AuthenticationFailedException(final String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
### Motivation
- Introduce a simple backend authentication mechanism to support user login and logout flows.
- Store passwords securely by hashing instead of keeping plain text in the database.
- Provide an in-memory session/token mechanism for short-term authenticated access.
- Surface authentication errors consistently through the existing problem-detail handler.

### Description
- Added `spring-security-crypto` dependency and a `SecurityConfig` that exposes a `PasswordEncoder` bean.
- Extended `AppUser` to store a `passwordHash` and updated constructors/accessors accordingly, and updated `CreateAppUserRequest` to accept a `password`.
- Updated `AppUserService` to hash passwords on creation and added an `authenticate` method that verifies credentials using `PasswordEncoder`.
- Implemented `AuthService` (in-memory sessions), `AuthController` with `/api/v1/auth/login` and `/api/v1/auth/logout`, DTOs `LoginRequest`/`LoginResponse`, `AuthSession` record, and `AuthenticationFailedException`, and wired `JanusExceptionHandler` to return `401` on auth failures.

### Testing
- No automated tests were executed as part of this change.
- Compilation or CI checks were not run in this rollout.
- Manual validation is recommended: create a user via `POST /api/v1/appusers`, then `POST /api/v1/auth/login` and use the returned token in `Authorization: Bearer <token>` for `POST /api/v1/auth/logout`.
- Additional unit/integration tests should be added to cover `AppUserService.authenticate`, `AuthService` session lifecycle, and controller endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959714f60848327b2b123624fb37d62)