### PR TITLE
Add Angular login screen, auth client and seed user password

### DIFF
--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -2,6 +2,79 @@
 	font-family: "Inter", "Segoe UI", Roboto, sans-serif;
 }
 
+.login {
+	width: min(520px, 100%);
+	margin: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 2rem;
+	color: #f9f9f9;
+}
+
+.login-header {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	text-align: center;
+}
+
+.login-subtitle {
+	margin: 0;
+	color: rgba(249, 249, 249, 0.7);
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	font-size: 0.9rem;
+}
+
+.login-card {
+	background: #0f0f0f;
+	border: 1px solid rgba(249, 214, 0, 0.2);
+	box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.35);
+}
+
+.login-form {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+}
+
+.login-field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	font-size: 0.9rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: rgba(249, 249, 249, 0.68);
+}
+
+.login-field input {
+	border-radius: 16px;
+	border: 1px solid rgba(249, 214, 0, 0.2);
+	background: #050505;
+	color: #f9f9f9;
+	padding: 0.85rem 1rem;
+	font-size: 1rem;
+	letter-spacing: 0.04em;
+}
+
+.login-field input:focus {
+	outline: 2px solid rgba(249, 214, 0, 0.6);
+	outline-offset: 2px;
+}
+
+.login-error {
+	margin: 0;
+	color: #ff6b6b;
+	font-size: 0.9rem;
+	letter-spacing: 0.04em;
+}
+
+.login-submit {
+	width: 100%;
+	justify-content: center;
+}
+
 .aside {
 	width: min(360px, 100%);
 	display: flex;

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,44 +1,90 @@
 <main class="app-shell">
-	<section class="dashboard">
-		<header class="dashboard-header">
-			<h1 class="brand">{{'navigation.janus' | translate }}</h1>
-			<span class="section-label">{{'navigation.dashboard' | translate }}</span>
-		</header>
-		<section class="dashboard-content">
-			<section class="content">
-				<app-card styleClass="clock-in-card" title="{{ 'timelog.clockin' | translate }}"> 
-					<ng-template #cardHeader> 
-						<app-clock styleClass="card-hour-container" timeClass="card-hour" />
-						<app-button>{{'timelog.clockin' | translate }}</app-button> 
-					</ng-template> 
-				</app-card>
-
-				<app-timelog-table/>
-			</section>
-			<section class="aside">
-				<div class="aside">
-					<app-card styleClass="user-card"> 
+	@if (!(isAuthenticated$ | async)) {
+		<section class="login">
+			<header class="login-header">
+				<h1 class="brand">{{ 'navigation.janus' | translate }}</h1>
+				<p class="login-subtitle">{{ 'login.subtitle' | translate }}</p>
+			</header>
+			<app-card styleClass="login-card" title="{{ 'login.title' | translate }}">
+				<form class="login-form" (ngSubmit)="onLogin()" #loginForm="ngForm">
+					<label class="login-field">
+						<span>{{ 'login.username' | translate }}</span>
+						<input
+							type="text"
+							name="username"
+							autocomplete="username"
+							required
+							[(ngModel)]="credentials.username"
+							placeholder="{{ 'login.usernamePlaceholder' | translate }}"
+						/>
+					</label>
+					<label class="login-field">
+						<span>{{ 'login.password' | translate }}</span>
+						<input
+							type="password"
+							name="password"
+							autocomplete="current-password"
+							required
+							minlength="8"
+							[(ngModel)]="credentials.password"
+							placeholder="{{ 'login.passwordPlaceholder' | translate }}"
+						/>
+					</label>
+					@if (errorMessage) {
+						<p class="login-error">{{ errorMessage }}</p>
+					}
+					<app-button
+						[type]="'submit'"
+						[disabled]="loginForm.invalid || isLoading"
+						styleClass="login-submit"
+					>
+						{{ isLoading ? ('login.loading' | translate) : ('login.submit' | translate) }}
+					</app-button>
+				</form>
+			</app-card>
+		</section>
+	} @else {
+		<section class="dashboard">
+			<header class="dashboard-header">
+				<h1 class="brand">{{ 'navigation.janus' | translate }}</h1>
+				<span class="section-label">{{ 'navigation.dashboard' | translate }}</span>
+			</header>
+			<section class="dashboard-content">
+				<section class="content">
+					<app-card styleClass="clock-in-card" title="{{ 'timelog.clockin' | translate }}">
 						<ng-template #cardHeader>
-							<div class="user-card-header-content">
-								<img class="avatar" src="assets/images/user.png" />
-								<span class="user-card-title">{{ 'employee.employee' | translate }}</span>
-							</div>
+							<app-clock styleClass="card-hour-container" timeClass="card-hour" />
+							<app-button>{{ 'timelog.clockin' | translate }}</app-button>
 						</ng-template>
-						<div class="data">
-							<h3>{{ 'employee.fullName' | translate }}</h3>
-							<p>Abel Ferrer Jiménez</p>
-						</div>
-						<div class="data">
-							<h3>{{ 'employee.location' | translate }}</h3>
-							<p>Barcelona Headquarters</p>
-						</div>
-						<div class="data">
-							<h3>{{ 'employee.todaysHour' | translate }}</h3>
-							<p>9:00 - 17:30</p>
-						</div>
 					</app-card>
-				</div>
+
+					<app-timelog-table />
+				</section>
+				<section class="aside">
+					<div class="aside">
+						<app-card styleClass="user-card">
+							<ng-template #cardHeader>
+								<div class="user-card-header-content">
+									<img class="avatar" src="assets/images/user.png" />
+									<span class="user-card-title">{{ 'employee.employee' | translate }}</span>
+								</div>
+							</ng-template>
+							<div class="data">
+								<h3>{{ 'employee.fullName' | translate }}</h3>
+								<p>Abel Ferrer Jiménez</p>
+							</div>
+							<div class="data">
+								<h3>{{ 'employee.location' | translate }}</h3>
+								<p>Barcelona Headquarters</p>
+							</div>
+							<div class="data">
+								<h3>{{ 'employee.todaysHour' | translate }}</h3>
+								<p>9:00 - 17:30</p>
+							</div>
+						</app-card>
+					</div>
+				</section>
 			</section>
 		</section>
-	</section>
+	}
 </main>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,5 +1,8 @@
-import { Component } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
+import { AuthService } from './auth/auth.service';
 import { ClockComponent } from './shared/ui/clock/clock.component';
 import { CardComponent } from './shared/ui/card/card.component';
 import { TimelogTableComponent } from './timelog/timelog-table.component';
@@ -8,10 +11,41 @@ import { ButtonComponent } from './shared/ui/button/button.component';
 @Component({
 	selector: 'app-root',
 	standalone: true,
-	imports: [TranslatePipe, ClockComponent, CardComponent, TimelogTableComponent, ButtonComponent],
+	imports: [
+		AsyncPipe,
+		FormsModule,
+		TranslatePipe,
+		ClockComponent,
+		CardComponent,
+		TimelogTableComponent,
+		ButtonComponent
+	],
 	templateUrl: './app.component.html',
 	styleUrl: './app.component.css'
 })
 export class AppComponent {
 	title = 'frontend';
+	private readonly authService = inject(AuthService);
+	credentials = {
+		username: '',
+		password: ''
+	};
+	errorMessage = '';
+	isLoading = false;
+	readonly isAuthenticated$ = this.authService.isAuthenticated$;
+
+	onLogin(): void {
+		this.errorMessage = '';
+		this.isLoading = true;
+		this.authService.login(this.credentials.username, this.credentials.password).subscribe({
+			next: () => {
+				this.isLoading = false;
+				this.credentials.password = '';
+			},
+			error: (error) => {
+				this.isLoading = false;
+				this.errorMessage = error?.error?.detail ?? 'Unable to sign in. Please try again.';
+			}
+		});
+	}
 }

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,13 +1,14 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
-import { provideHttpClient } from "@angular/common/http";
+import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { provideTranslateService } from "@ngx-translate/core";
 import { provideTranslateHttpLoader } from "@ngx-translate/http-loader";
+import { authInterceptor } from './auth/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
 	providers: [
 		provideBrowserGlobalErrorListeners(),
 		provideZoneChangeDetection({ eventCoalescing: true }),
-		provideHttpClient(),
+		provideHttpClient(withInterceptors([authInterceptor])),
 		provideTranslateService({
 			lang: 'en',
 			fallbackLang: 'en',

--- a/frontend/src/app/auth/auth.interceptor.ts
+++ b/frontend/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,17 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from './auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (request, next) => {
+	const token = inject(AuthService).getToken();
+	if (!token) {
+		return next(request);
+	}
+
+	const withAuth = request.clone({
+		setHeaders: {
+			Authorization: `Bearer ${token}`
+		}
+	});
+	return next(withAuth);
+};

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, map, Observable, tap } from 'rxjs';
+
+interface LoginResponse {
+	token: string;
+	username: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+	private readonly baseUrl = '/api/v1/auth';
+	private readonly tokenStorageKey = 'janus.auth.token';
+	private readonly tokenSubject = new BehaviorSubject<string | null>(this.loadToken());
+	readonly isAuthenticated$ = this.tokenSubject.pipe(map((token) => !!token));
+
+	constructor(private readonly http: HttpClient) {}
+
+	login(username: string, password: string): Observable<void> {
+		return this.http
+			.post<LoginResponse>(`${this.baseUrl}/login`, { username, password })
+			.pipe(
+				tap((response) => this.setToken(response.token)),
+				map(() => undefined)
+			);
+	}
+
+	getToken(): string | null {
+		return this.tokenSubject.value;
+	}
+
+	clearToken(): void {
+		this.tokenSubject.next(null);
+		localStorage.removeItem(this.tokenStorageKey);
+	}
+
+	private setToken(token: string): void {
+		this.tokenSubject.next(token);
+		localStorage.setItem(this.tokenStorageKey, token);
+	}
+
+	private loadToken(): string | null {
+		return localStorage.getItem(this.tokenStorageKey);
+	}
+}

--- a/frontend/src/assets/i18n/ca.json
+++ b/frontend/src/assets/i18n/ca.json
@@ -15,5 +15,15 @@
 		"fullName": "Nom complet",
 		"location": "Lloc",
 		"todaysHour": "Horari"
+	},
+	"login": {
+		"title": "Inicia sessió",
+		"subtitle": "Accedeix al teu panell",
+		"username": "Usuari",
+		"password": "Contrasenya",
+		"usernamePlaceholder": "usuari@empresa.com",
+		"passwordPlaceholder": "Introdueix la contrasenya",
+		"submit": "Entrar",
+		"loading": "Accedint..."
 	}
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -15,5 +15,15 @@
 		"fullName": "Full Name",
 		"location": "Location",
 		"todaysHour": "Today's Hour"
+	},
+	"login": {
+		"title": "Sign in",
+		"subtitle": "Access your dashboard",
+		"username": "Username",
+		"password": "Password",
+		"usernamePlaceholder": "you@company.com",
+		"passwordPlaceholder": "Enter your password",
+		"submit": "Sign in",
+		"loading": "Signing in..."
 	}
 }

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -15,5 +15,15 @@
 		"fullName": "Nombre completo",
 		"location": "Lugar",
 		"todaysHour": "Horario"
+	},
+	"login": {
+		"title": "Iniciar sesión",
+		"subtitle": "Accede a tu panel",
+		"username": "Usuario",
+		"password": "Contraseña",
+		"usernamePlaceholder": "usuario@empresa.com",
+		"passwordPlaceholder": "Introduce tu contraseña",
+		"submit": "Entrar",
+		"loading": "Accediendo..."
 	}
 }

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -10,7 +10,8 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
-INSERT INTO app_user (username, name, surname, locale, time_format) VALUES ('aferrer@nivel36.es', 'Abel', 'Ferrer Jiménez', 'es_ES', 'H24');
+INSERT INTO app_user (username, name, surname, password_hash, locale, time_format)
+VALUES ('aferrer@nivel36.es', 'Abel', 'Ferrer Jiménez', '$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m', 'es_ES', 'H24');
 
 INSERT INTO schedule (code, name) VALUES ('STD-WH-AUG-VAR', 'Standard Work Hours with August Variation');
 


### PR DESCRIPTION
### Motivation
- Add a frontend sign-in flow that authenticates against the existing backend and reveals the current dashboard after successful login. 
- Persist a session token on the client and attach it to backend requests to secure API calls. 
- Ensure a seeded application user has a usable password so manual testing is possible. 
- Provide localized copy for the new login screen in `en`, `es` and `ca`.

### Description
- Added a login form to `frontend/src/app/app.component.*` that posts credentials to `POST /api/v1/auth/login` and conditionally shows the dashboard when authenticated. 
- Implemented client-side auth plumbing: `AuthService` (stores token in `localStorage` under `janus.auth.token`) and `authInterceptor` which adds `Authorization: Bearer <token>` to outgoing requests, and registered the interceptor via `provideHttpClient(withInterceptors([authInterceptor]))`. 
- Seeded the default user in `src/main/resources/sql/data.sql` by adding a `password_hash` (bcrypt) for `aferrer@nivel36.es` corresponding to the password `Janus2024!`. 
- Added styles and i18n strings for the login UI (`frontend/src/assets/i18n/en.json`, `es.json`, `ca.json`) and updated `app.config.ts` to provide the HTTP interceptor.

### Testing
- Built and served the frontend with `npm start` (Angular dev server), and the application bundle generation completed successfully. 
- Captured an automated screenshot of the login screen using a Playwright script which saved `artifacts/login-screen.png`. 
- No new unit or integration tests were added to the repo as part of this change. 
- The TypeScript build errors observed during development were resolved and the dev server rebuild succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695976f885588327bb946b452b1da544)