### PR TITLE
Fix AppUserControllerIT test fixtures

### DIFF
--- a/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
+++ b/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
@@ -43,7 +43,8 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,locale,time_format) VALUES('jdoe','John','Doe','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
 	})
 	void testFindByUsernameShouldReturnUser() throws Exception {
 		mvc.perform(get(BASE + "/{username}", "jdoe")).andExpect(status().isOk()) //
@@ -69,11 +70,12 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,locale,time_format) VALUES('jdoe','John','Doe','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
 	})
 	void testCreateAlreadyExistsShouldReturn400() throws Exception {
 		String body = """
-				  {"username":"jdoe","name":"John","surname":"Doe","locale":"en-US","timeFormat":"H24"}
+				  {"username":"jdoe","name":"John","surname":"Doe","password":"Password1!","locale":"en-US","timeFormat":"H24"}
 				""";
 
 		mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
@@ -83,7 +85,7 @@ class AppUserControllerIT {
 	@Test
 	void testCreateShouldReturn201AndBody() throws Exception {
 		String body = """
-				  {"username":"asmith","name":"Alice","surname":"Smith","locale":"en-GB","timeFormat":"H12"}
+				  {"username":"asmith","name":"Alice","surname":"Smith","password":"Password1!","locale":"en-GB","timeFormat":"H12"}
 				""";
 
 		mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
@@ -100,7 +102,7 @@ class AppUserControllerIT {
 	@Test
 	void testCreateShouldAcceptUsernamesWithAtSign() throws Exception {
 		String body = """
-				  {"username":"alice@example.com","name":"Alice","surname":"Smith","locale":"en-GB","timeFormat":"H12"}
+				  {"username":"alice@example.com","name":"Alice","surname":"Smith","password":"Password1!","locale":"en-GB","timeFormat":"H12"}
 				""";
 
 		mvc.perform(post(BASE).contentType(APPLICATION_JSON).content(body)) //
@@ -114,7 +116,8 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,locale,time_format) VALUES('jdoe','John','Doe','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
 	})
 	void testUpdateShouldReturn200AndUpdatedBody() throws Exception {
 		String body = """
@@ -132,7 +135,8 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,locale,time_format) VALUES('jdoe','John','Doe','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
 	})
 	void testDeleteShouldReturn204AndRemoveFromList() throws Exception {
 		mvc.perform(delete(BASE + "/{username}", "jdoe")) //


### PR DESCRIPTION
### Motivation

- Tests in `AppUserControllerIT` were failing because the `APP_USER` H2 schema requires a non-null `password_hash` column and create requests require a `password` field. 
- The integration tests inserted rows without a `password_hash` and sent create payloads without `password`, causing integrity and validation errors. 

### Description

- Updated `src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java` SQL fixtures to include the `password_hash` column and a bcrypt hash value in all `INSERT` statements. 
- Added the required `password` field (e.g. `"Password1!"`) to all JSON create request bodies used by the tests. 

### Testing

- Ran `mvn -q -Dtest=AppUserControllerIT test` to execute the modified integration tests. 
- All tests in `AppUserControllerIT` completed successfully after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a2cbe991c832796bd6074e7cadebe)