### PR TITLE
Add per-user password salt to login hashing

### DIFF
--- a/src/main/java/es/nivel36/janus/service/appuser/AppUser.java
+++ b/src/main/java/es/nivel36/janus/service/appuser/AppUser.java
@@ -109,6 +109,13 @@ public class AppUser implements Serializable {
 	private String passwordHash;
 
 	/**
+	 * Salt used when hashing the user's password.
+	 */
+	@NotEmpty
+	@Column(nullable = false)
+	private String passwordSalt;
+
+	/**
 	 * Preferred locale of the user.
 	 *
 	 * <p>
@@ -151,7 +158,9 @@ public class AppUser implements Serializable {
 	 * @param name       the first name of the user. Can't be {@code null} or blank.
 	 * @param surname    the surname of the user. Can't be {@code null} or blank.
 	 * @param passwordHash hashed password for the user. Can't be {@code null} or
-	 *                   blank.
+	 *                     blank.
+	 * @param passwordSalt salt used when hashing the password. Can't be
+	 *                     {@code null} or blank.
 	 * @param locale     the preferred {@link Locale} of the user. Can't be
 	 *                   {@code null}.
 	 * @param timeFormat the preferred {@link TimeFormat} of the user. Can't be
@@ -162,11 +171,12 @@ public class AppUser implements Serializable {
 	 *                                  {@code surname} is blank
 	 */
 	public AppUser(final String username, final String name, final String surname, final String passwordHash,
-			final Locale locale, final TimeFormat timeFormat) {
+			final String passwordSalt, final Locale locale, final TimeFormat timeFormat) {
 		this.username = Strings.requireNonBlank(username, "username can't be null or blank");
 		this.name = Strings.requireNonBlank(name, "name can't be null or blank");
 		this.surname = Strings.requireNonBlank(surname, "surname can't be null or blank");
 		this.passwordHash = Strings.requireNonBlank(passwordHash, "passwordHash can't be null or blank");
+		this.passwordSalt = Strings.requireNonBlank(passwordSalt, "passwordSalt can't be null or blank");
 		this.locale = Objects.requireNonNull(locale, "locale can't be null");
 		this.timeFormat = Objects.requireNonNull(timeFormat, "timeFormat can't be null");
 	}
@@ -242,6 +252,14 @@ public class AppUser implements Serializable {
 
 	void setPasswordHash(final String passwordHash) {
 		this.passwordHash = Strings.requireNonBlank(passwordHash, "passwordHash can't be null or blank");
+	}
+
+	String getPasswordSalt() {
+		return passwordSalt;
+	}
+
+	void setPasswordSalt(final String passwordSalt) {
+		this.passwordSalt = Strings.requireNonBlank(passwordSalt, "passwordSalt can't be null or blank");
 	}
 
 	/**

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -10,8 +10,8 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
-INSERT INTO app_user (username, name, surname, password_hash, locale, time_format)
-VALUES ('aferrer@nivel36.es', 'Abel', 'Ferrer Jiménez', '$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m', 'es_ES', 'H24');
+INSERT INTO app_user (username, name, surname, password_hash, password_salt, locale, time_format)
+VALUES ('aferrer@nivel36.es', 'Abel', 'Ferrer Jiménez', '$2a$10$rAL4g3rX9675DtxK4bbM1uNkfrtFOgv73T5G68o1.qFpKO9H/wXOm', 's4lt-test', 'es_ES', 'H24');
 
 INSERT INTO schedule (code, name) VALUES ('STD-WH-AUG-VAR', 'Standard Work Hours with August Variation');
 

--- a/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
+++ b/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
@@ -43,8 +43,8 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,password_salt,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2a$10$rAL4g3rX9675DtxK4bbM1uNkfrtFOgv73T5G68o1.qFpKO9H/wXOm','s4lt-test','en-US','H24')"//
 	})
 	void testFindByUsernameShouldReturnUser() throws Exception {
 		mvc.perform(get(BASE + "/{username}", "jdoe")).andExpect(status().isOk()) //
@@ -70,8 +70,8 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,password_salt,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2a$10$rAL4g3rX9675DtxK4bbM1uNkfrtFOgv73T5G68o1.qFpKO9H/wXOm','s4lt-test','en-US','H24')"//
 	})
 	void testCreateAlreadyExistsShouldReturn400() throws Exception {
 		String body = """
@@ -116,8 +116,8 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,password_salt,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2a$10$rAL4g3rX9675DtxK4bbM1uNkfrtFOgv73T5G68o1.qFpKO9H/wXOm','s4lt-test','en-US','H24')"//
 	})
 	void testUpdateShouldReturn200AndUpdatedBody() throws Exception {
 		String body = """
@@ -135,8 +135,8 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO app_user(username,name,surname,password_hash,password_salt,locale,time_format) VALUES('jdoe','John','Doe'," //
+					+ "'$2a$10$rAL4g3rX9675DtxK4bbM1uNkfrtFOgv73T5G68o1.qFpKO9H/wXOm','s4lt-test','en-US','H24')"//
 	})
 	void testDeleteShouldReturn204AndRemoveFromList() throws Exception {
 		mvc.perform(delete(BASE + "/{username}", "jdoe")) //


### PR DESCRIPTION
### Motivation
- Improve password storage security by introducing a per-user salt used when hashing user passwords.
- Keep hashing/verification behavior explicit so existing `PasswordEncoder` usage is preserved while adding salting protection.
- Update database seed data and test fixtures to reflect the new `password_salt` column and deterministic test values.

### Description
- Add a `passwordSalt` field to the `AppUser` entity with constructor, getter and setter support and database column `password_salt`.
- Generate a random Base64 URL-safe salt in `AppUserService`, store it on user creation, and compute the stored hash with `passwordEncoder.encode(password + salt)` while verifying with `passwordEncoder.matches(password + salt, hash)`.
- Update `src/main/resources/sql/data.sql` and `AppUserControllerIT` test SQL fixtures to include the `password_salt` column and use a fixed salt/hash for tests.
- Introduce constants and helpers (`PASSWORD_SALT_BYTES`, `generatePasswordSalt()`) and add required imports (`SecureRandom`, `Base64`).

### Testing
- Ran the full Maven test suite with `mvn test` and the build finished `BUILD SUCCESS`.
- All automated tests passed: `Tests run: 64, Failures: 0, Errors: 0, Skipped: 0`.
- Integration tests that insert `password_salt` fixtures were updated and executed successfully.
- No additional automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a38e5bcd88327bf01803803ccaf6d)