### PR TITLE
Extract SaltGenerator utility and use in AppUserService

### DIFF
--- a/src/main/java/es/nivel36/janus/service/appuser/AppUserService.java
+++ b/src/main/java/es/nivel36/janus/service/appuser/AppUserService.java
@@ -15,8 +15,6 @@
  */
 package es.nivel36.janus.service.appuser;
 
-import java.security.SecureRandom;
-import java.util.Base64;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -30,6 +28,7 @@ import es.nivel36.janus.service.ResourceAlreadyExistsException;
 import es.nivel36.janus.service.ResourceNotFoundException;
 import es.nivel36.janus.service.TimeFormat;
 import es.nivel36.janus.service.auth.AuthenticationFailedException;
+import es.nivel36.janus.util.SaltGenerator;
 import es.nivel36.janus.util.Strings;
 
 /**
@@ -51,7 +50,6 @@ public class AppUserService {
 
 	private static final Logger logger = LoggerFactory.getLogger(AppUserService.class);
 	private static final int PASSWORD_SALT_BYTES = 16;
-	private static final SecureRandom secureRandom = new SecureRandom();
 
 	/**
 	 * Repository used to access {@link AppUser} persistence operations.
@@ -136,7 +134,7 @@ public class AppUserService {
 			throw new ResourceAlreadyExistsException("Application user with username " + username + " already exists");
 		}
 
-		final String passwordSalt = generatePasswordSalt();
+		final String passwordSalt = SaltGenerator.generateBase64UrlSalt(PASSWORD_SALT_BYTES);
 		final String passwordHash = this.passwordEncoder.encode(password + passwordSalt);
 		final AppUser appUser = new AppUser(username.trim(), name.trim(), surname.trim(), passwordHash, passwordSalt,
 				locale, timeFormat);
@@ -221,12 +219,6 @@ public class AppUserService {
 			throw new AuthenticationFailedException("Invalid username or password.");
 		}
 		return appUser;
-	}
-
-	private static String generatePasswordSalt() {
-		final byte[] salt = new byte[PASSWORD_SALT_BYTES];
-		secureRandom.nextBytes(salt);
-		return Base64.getUrlEncoder().withoutPadding().encodeToString(salt);
 	}
 
 	private AppUser findAppUser(final String username) {

--- a/src/main/java/es/nivel36/janus/util/SaltGenerator.java
+++ b/src/main/java/es/nivel36/janus/util/SaltGenerator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.util;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Utility for generating random salts.
+ */
+public final class SaltGenerator {
+
+	private static final SecureRandom secureRandom = new SecureRandom();
+
+	private SaltGenerator() {
+	}
+
+	/**
+	 * Generates a Base64 URL-safe salt with the requested number of bytes.
+	 *
+	 * @param bytes number of random bytes to generate. Must be greater than zero.
+	 *
+	 * @return Base64 URL-safe salt string without padding.
+	 *
+	 * @throws IllegalArgumentException if {@code bytes} is less than 1.
+	 */
+	public static String generateBase64UrlSalt(final int bytes) {
+		if (bytes < 1) {
+			throw new IllegalArgumentException("bytes must be greater than zero.");
+		}
+		final byte[] salt = new byte[bytes];
+		secureRandom.nextBytes(salt);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(salt);
+	}
+}


### PR DESCRIPTION
### Motivation
- Decouple random salt generation from `AppUserService` so the responsibility is centralized and reusable.
- Improve code organization and single-responsibility by moving salt logic into the `es.nivel36.janus.util` package.
- Expose a documented, reusable API for generating Base64 URL-safe salts.

### Description
- Add `es.nivel36.janus.util.SaltGenerator` with `generateBase64UrlSalt(int)` that uses `SecureRandom` and returns a Base64 URL-safe string without padding.
- Replace the private salt generation in `AppUserService` with `SaltGenerator.generateBase64UrlSalt(PASSWORD_SALT_BYTES)` and remove the former helper method and related imports.
- Adjust imports in `AppUserService` to reference the new utility and clean up unused `SecureRandom`/`Base64` usage.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa6b5af1483278171e773cf2f1204)