### PR TITLE
Show logged-in username on dashboard

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -71,7 +71,7 @@
 							</ng-template>
 							<div class="data">
 								<h3>{{ 'employee.fullName' | translate }}</h3>
-								<p>Abel Ferrer Jiménez</p>
+								<p>{{ (username$ | async) || '' }}</p>
 							</div>
 							<div class="data">
 								<h3>{{ 'employee.location' | translate }}</h3>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -33,6 +33,7 @@ export class AppComponent {
 	errorMessage = '';
 	isLoading = false;
 	readonly isAuthenticated$ = this.authService.isAuthenticated$;
+	readonly username$ = this.authService.username$;
 
 	onLogin(): void {
 		this.errorMessage = '';


### PR DESCRIPTION
### Motivation
- Replace the hard-coded name on the dashboard user card with the actual name of the user who has logged in.

### Description
- Store the logged-in username in `AuthService` and persist it under the `janus.auth.username` key in `localStorage`.
- Expose a `username$` observable from `AuthService` and add `username$` to `AppComponent` for template binding.
- Replace the hard-coded `Abel Ferrer Jiménez` in `frontend/src/app/app.component.html` with `{{ (username$ | async) || '' }}` and clear the stored username in `clearToken`.

### Testing
- Built and served the frontend using `npm run start` / `ng serve`, and the application bundle was generated successfully.
- Executed a Playwright script that populated `localStorage` with `janus.auth.token` and `janus.auth.username` and captured a screenshot at `artifacts/dashboard-username.png` showing the username rendered.
- No automated unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac9a2b4b4832787b11c9575f90d56)