### PR TITLE
Persist AppUserResponse after login in Angular frontend

### DIFF
--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,21 +1,33 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, map, Observable, tap } from 'rxjs';
+import { BehaviorSubject, map, Observable, switchMap, tap } from 'rxjs';
 
 interface LoginResponse {
 	token: string;
 	username: string;
 }
 
+interface AppUserResponse {
+	username: string;
+	name: string;
+	surname: string;
+	locale: string;
+	timeFormat: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
 	private readonly baseUrl = '/api/v1/auth';
+	private readonly appUserBaseUrl = '/api/v1/appusers';
 	private readonly tokenStorageKey = 'janus.auth.token';
 	private readonly usernameStorageKey = 'janus.auth.username';
+	private readonly appUserStorageKey = 'janus.auth.user';
 	private readonly tokenSubject = new BehaviorSubject<string | null>(this.loadToken());
 	private readonly usernameSubject = new BehaviorSubject<string | null>(this.loadUsername());
+	private readonly appUserSubject = new BehaviorSubject<AppUserResponse | null>(this.loadAppUser());
 	readonly isAuthenticated$ = this.tokenSubject.pipe(map((token) => !!token));
 	readonly username$ = this.usernameSubject.asObservable();
+	readonly appUser$ = this.appUserSubject.asObservable();
 
 	constructor(private readonly http: HttpClient) {}
 
@@ -27,6 +39,8 @@ export class AuthService {
 					this.setToken(response.token);
 					this.setUsername(response.username);
 				}),
+				switchMap((response) => this.fetchAppUser(response.username)),
+				tap((appUser) => this.setAppUser(appUser)),
 				map(() => undefined)
 			);
 	}
@@ -38,8 +52,10 @@ export class AuthService {
 	clearToken(): void {
 		this.tokenSubject.next(null);
 		this.usernameSubject.next(null);
+		this.appUserSubject.next(null);
 		localStorage.removeItem(this.tokenStorageKey);
 		localStorage.removeItem(this.usernameStorageKey);
+		localStorage.removeItem(this.appUserStorageKey);
 	}
 
 	private setToken(token: string): void {
@@ -52,11 +68,33 @@ export class AuthService {
 		localStorage.setItem(this.usernameStorageKey, username);
 	}
 
+	private fetchAppUser(username: string): Observable<AppUserResponse> {
+		return this.http.get<AppUserResponse>(`${this.appUserBaseUrl}/${encodeURIComponent(username)}`);
+	}
+
+	private setAppUser(appUser: AppUserResponse): void {
+		this.appUserSubject.next(appUser);
+		localStorage.setItem(this.appUserStorageKey, JSON.stringify(appUser));
+	}
+
 	private loadToken(): string | null {
 		return localStorage.getItem(this.tokenStorageKey);
 	}
 
 	private loadUsername(): string | null {
 		return localStorage.getItem(this.usernameStorageKey);
+	}
+
+	private loadAppUser(): AppUserResponse | null {
+		const stored = localStorage.getItem(this.appUserStorageKey);
+		if (!stored) {
+			return null;
+		}
+		try {
+			return JSON.parse(stored) as AppUserResponse;
+		} catch {
+			localStorage.removeItem(this.appUserStorageKey);
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Make the authenticated user's `AppUserResponse` available client-side for session and UI usage.
- Persist user profile/preferences so they remain available across page reloads.
- Expose the app user data via an observable to allow other components to react to it.

### Description
- Added `AppUserResponse` interface and `appUserBaseUrl`/`appUserStorageKey` constants in `AuthService`.
- Introduced an `appUserSubject` and public `appUser$` observable initialized from `loadAppUser()` stored in local storage.
- Updated `login()` to `switchMap` from the `LoginResponse` to fetch the full app user via `GET /api/v1/appusers/{username}` and store it with `setAppUser()`.
- Implemented `fetchAppUser()`, `setAppUser()`, and `loadAppUser()` helpers and updated `clearToken()` to also clear stored app user data.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695acbc56c6c83279dfb27e7f4bb89a4)