### PR TITLE
Make dashboard clock button dynamic and call clock-in/clock-out endpoints

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -51,10 +51,12 @@
 			</header>
 			<section class="dashboard-content">
 				<section class="content">
-					<app-card styleClass="clock-in-card" title="{{ 'timelog.clockin' | translate }}">
+					<app-card styleClass="clock-in-card" title="{{ clockActionLabelKey | translate }}">
 						<ng-template #cardHeader>
 							<app-clock styleClass="card-hour-container" timeClass="card-hour" />
-							<app-button>{{ 'timelog.clockin' | translate }}</app-button>
+							<app-button [disabled]="isClockActionLoading" (click)="onClockAction()">
+								{{ clockActionLabelKey | translate }}
+							</app-button>
 						</ng-template>
 					</app-card>
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { AuthService } from './auth/auth.service';
@@ -7,6 +7,9 @@ import { ClockComponent } from './shared/ui/clock/clock.component';
 import { CardComponent } from './shared/ui/card/card.component';
 import { TimelogTableComponent } from './timelog/timelog-table.component';
 import { ButtonComponent } from './shared/ui/button/button.component';
+import { TimeLogResponse, TimeLogService } from './timelog/time-log.service';
+import { filter } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
 	selector: 'app-root',
@@ -23,17 +26,36 @@ import { ButtonComponent } from './shared/ui/button/button.component';
 	templateUrl: './app.component.html',
 	styleUrl: './app.component.css'
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
 	title = 'frontend';
 	private readonly authService = inject(AuthService);
+	private readonly timeLogService = inject(TimeLogService);
+	private readonly destroyRef = inject(DestroyRef);
+	private readonly defaultWorksiteCode = 'BCN-HQ';
 	credentials = {
 		username: '',
 		password: ''
 	};
 	errorMessage = '';
 	isLoading = false;
+	clockActionLabelKey = 'timelog.clockin';
+	isClockActionLoading = false;
 	readonly isAuthenticated$ = this.authService.isAuthenticated$;
 	readonly username$ = this.authService.username$;
+	private latestTimeLog?: TimeLogResponse;
+	private employeeEmail?: string;
+
+	ngOnInit(): void {
+		this.username$
+			.pipe(
+				filter((username): username is string => !!username),
+				takeUntilDestroyed(this.destroyRef)
+			)
+			.subscribe((username) => {
+				this.employeeEmail = username;
+				this.refreshLatestTimeLog(username);
+			});
+	}
 
 	onLogin(): void {
 		this.errorMessage = '';
@@ -48,5 +70,77 @@ export class AppComponent {
 				this.errorMessage = error?.error?.detail ?? 'Unable to sign in. Please try again.';
 			}
 		});
+	}
+
+	onClockAction(): void {
+		if (!this.employeeEmail || this.isClockActionLoading) {
+			return;
+		}
+
+		this.isClockActionLoading = true;
+		const worksiteCode = this.latestTimeLog?.worksiteCode ?? this.defaultWorksiteCode;
+		const action$ = this.shouldClockOut()
+			? this.timeLogService.clockOut(this.employeeEmail, worksiteCode)
+			: this.timeLogService.clockIn(this.employeeEmail, worksiteCode);
+
+		action$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+			next: (timeLog) => {
+				this.latestTimeLog = timeLog;
+				this.clockActionLabelKey = this.getClockActionLabelKey(timeLog);
+			},
+			error: () => {
+				this.isClockActionLoading = false;
+			},
+			complete: () => {
+				this.isClockActionLoading = false;
+			}
+		});
+	}
+
+	private refreshLatestTimeLog(username: string): void {
+		this.timeLogService
+			.searchByEmployee(username)
+			.pipe(takeUntilDestroyed(this.destroyRef))
+			.subscribe({
+				next: (response) => {
+					this.latestTimeLog = this.getLatestTimeLog(response);
+					this.clockActionLabelKey = this.getClockActionLabelKey(this.latestTimeLog);
+				}
+			});
+	}
+
+	private shouldClockOut(): boolean {
+		return !!this.latestTimeLog && !this.extractExitTime(this.latestTimeLog.exitTime);
+	}
+
+	private getClockActionLabelKey(timeLog?: TimeLogResponse): string {
+		if (!timeLog) {
+			return 'timelog.clockin';
+		}
+		return this.extractExitTime(timeLog.exitTime) ? 'timelog.clockin' : 'timelog.clockout';
+	}
+
+	private getLatestTimeLog(timeLogs: TimeLogResponse[]): TimeLogResponse | undefined {
+		return timeLogs.reduce<TimeLogResponse | undefined>((latest, current) => {
+			if (!latest) {
+				return current;
+			}
+			return new Date(current.entryTime).getTime() > new Date(latest.entryTime).getTime()
+				? current
+				: latest;
+		}, undefined);
+	}
+
+	private extractExitTime(exitTime: TimeLogResponse['exitTime']): string | null {
+		if (!exitTime) {
+			return null;
+		}
+		if (typeof exitTime === 'string') {
+			return exitTime;
+		}
+		if ('present' in exitTime) {
+			return exitTime.present ? exitTime.value ?? null : null;
+		}
+		return null;
 	}
 }

--- a/frontend/src/app/timelog/time-log.service.ts
+++ b/frontend/src/app/timelog/time-log.service.ts
@@ -28,4 +28,22 @@ export class TimeLogService {
 			.get<PageResponse<TimeLogResponse>>(url)
 			.pipe(map((response) => response.content ?? []));
 	}
+
+	clockIn(email: string, worksiteCode: string): Observable<TimeLogResponse> {
+		const encodedEmail = encodeURIComponent(email);
+		const url = `${this.baseUrl}/${encodedEmail}/timelogs/clock-in`;
+
+		return this.http.post<TimeLogResponse>(url, null, {
+			params: { worksiteCode }
+		});
+	}
+
+	clockOut(email: string, worksiteCode: string): Observable<TimeLogResponse> {
+		const encodedEmail = encodeURIComponent(email);
+		const url = `${this.baseUrl}/${encodedEmail}/timelogs/clock-out`;
+
+		return this.http.post<TimeLogResponse>(url, null, {
+			params: { worksiteCode }
+		});
+	}
 }


### PR DESCRIPTION
### Motivation
- The dashboard always showed a `clock-in` action even when the latest `TimeLog` was open, so the UI must show `clock-out` when the last timelog lacks an exit time.
- The button must invoke the backend to perform `clock-in` or `clock-out` depending on the latest timelog state.

### Description
- Added `clockIn` and `clockOut` methods to `TimeLogService` that call `/timelogs/clock-in` and `/timelogs/clock-out` with the `worksiteCode` parameter.
- Extended `AppComponent` to subscribe to the authenticated username, load the latest timelogs, compute `clockActionLabelKey`, and expose `onClockAction()` which calls `clockIn` or `clockOut` as needed.
- Updated the dashboard template to bind the card title and button label to `clockActionLabelKey` and wire the button to `onClockAction()` with a loading disable state.
- Defaulted to `BCN-HQ` when no worksite is available from the latest timelog and implemented robust extraction of the `exitTime` field.

### Testing
- Application frontend compiled and the dev server was started successfully with `ng serve` (build completed).
- A Playwright screenshot attempt was executed to validate the UI, but the browser process crashed with a SIGSEGV so the screenshot step failed.
- No backend or unit test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695acebd73d883279a237bcbf5ca25ab)