### PR TITLE
Add required and minLength validators to login form

### DIFF
--- a/frontend/src/app/auth/login-form/login-form.component.ts
+++ b/frontend/src/app/auth/login-form/login-form.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
 import { TranslatePipe } from "@ngx-translate/core";
 import { AuthService } from "../../core/auth/auth.service";
 import { Router } from "@angular/router";
@@ -17,8 +17,11 @@ export class LoginFormComponent {
   errorMessage = '';
 
   readonly form = new FormGroup({
-    username: new FormControl('', { nonNullable: true }),
-    password: new FormControl('', { nonNullable: true }),
+    username: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    password: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.minLength(8)],
+    }),
   });
 
   constructor(private authService: AuthService, private router: Router) {}


### PR DESCRIPTION
### Motivation
- Añadir validación del lado del cliente a los campos de inicio de sesión para evitar envíos inválidos.
- Asegurar que el botón `login-submit` permanezca deshabilitado cuando el formulario sea inválido.

### Description
- Importar `Validators` desde `@angular/forms` en `login-form.component.ts`.
- Añadir `Validators.required` a `username` y `Validators.required` + `Validators.minLength(8)` a `password` dentro del `FormGroup`.
- No se modificó la plantilla ya que el botón está ligado a `form.invalid || isLoading`, por lo que con estos validadores quedará deshabilitado cuando corresponda.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e22e02ef48327b5a7f79fd81c46ef)