### PR TITLE
Translate login error message and add i18n keys

### DIFF
--- a/frontend/src/app/auth/login-form/login-form.component.html
+++ b/frontend/src/app/auth/login-form/login-form.component.html
@@ -23,7 +23,7 @@
   </label>
 
   @if (errorMessage) {
-    <p class="login-error">{{ errorMessage }}</p>
+    <p class="login-error">{{ errorMessage | translate }}</p>
   }
 
   <app-button

--- a/frontend/src/assets/i18n/ca.json
+++ b/frontend/src/assets/i18n/ca.json
@@ -24,6 +24,7 @@
 		"usernamePlaceholder": "usuari@empresa.com",
 		"passwordPlaceholder": "Introdueix la contrasenya",
 		"submit": "Entrar",
-		"loading": "Accedint..."
+		"loading": "Accedint...",
+		"error": "No s'ha pogut iniciar sessió. Comprova les credencials i torna-ho a provar."
 	}
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -24,6 +24,7 @@
 		"usernamePlaceholder": "you@company.com",
 		"passwordPlaceholder": "Enter your password",
 		"submit": "Sign in",
-		"loading": "Signing in..."
+		"loading": "Signing in...",
+		"error": "Unable to sign in. Please check your credentials and try again."
 	}
 }

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -24,6 +24,7 @@
 		"usernamePlaceholder": "usuario@empresa.com",
 		"passwordPlaceholder": "Introduce tu contraseña",
 		"submit": "Entrar",
-		"loading": "Accediendo..."
+		"loading": "Accediendo...",
+		"error": "No se pudo iniciar sesión. Verifica tus credenciales e inténtalo de nuevo."
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure the login error shown in the UI is passed through the translation pipeline rather than displayed raw.
- Provide a localized `login.error` message so the translated string is available for English, Spanish, and Catalan users.

### Description
- Apply the translation pipe to the error display in `frontend/src/app/auth/login-form/login-form.component.html` by changing the output to `{{ errorMessage | translate }}`.
- Add the `login.error` key to `frontend/src/assets/i18n/en.json`, `frontend/src/assets/i18n/es.json`, and `frontend/src/assets/i18n/ca.json` with appropriate localized strings.
- Small JSON formatting adjustments to accommodate the new keys in each locale file.

### Testing
- No automated tests were run for this change.
- Changes were committed and staged in the repository but no CI results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e22ecda288327b524e351c5c0411b)