### PR TITLE
Rollback auth state on appUser fetch failure during login

### DIFF
--- a/frontend/src/app/core/auth/auth.service.ts
+++ b/frontend/src/app/core/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, map, Observable, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, map, Observable, switchMap, tap, throwError } from 'rxjs';
 
 interface LoginResponse {
 	token: string;
@@ -41,7 +41,11 @@ export class AuthService {
 				}),
 				switchMap((response) => this.fetchAppUser(response.username)),
 				tap((appUser) => this.setAppUser(appUser)),
-				map(() => undefined)
+				map(() => undefined),
+				catchError((error) => {
+					this.clearToken();
+					return throwError(() => error);
+				})
 			);
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent leaving partially-authenticated state when fetching the `AppUserResponse` fails after a successful login response.  
- Ensure the `login()` `Observable` propagates errors to the caller so components can display the appropriate message.  
- Provide a rollback path that clears `token`, `username`, and `appUser` when downstream user fetch fails.  

### Description
- Added `catchError` and `throwError` imports from `rxjs` and updated `frontend/src/app/core/auth/auth.service.ts`.  
- Enhanced `login()` to `catchError` and call `clearToken()` on error, then rethrow the error with `throwError(() => error)`.  
- Kept existing behavior that sets token/username on the login response and sets `appUser` only after the `fetchAppUser()` succeeds.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e44357fdc8327a57d7b004d71f160)