### PR TITLE
Fix AppUserControllerIT SQL setup to create `account` and link `app_user`

### DIFF
--- a/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
+++ b/src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java
@@ -43,8 +43,10 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO account(username,password,role) VALUES('jdoe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','USER')", //
+			"INSERT INTO app_user(account_id,name,surname,locale,time_format)" //
+					+ " SELECT id,'John','Doe','en-US','H24' FROM account WHERE username='jdoe'"//
 	})
 	void testFindByUsernameShouldReturnUser() throws Exception {
 		mvc.perform(get(BASE + "/{username}", "jdoe")).andExpect(status().isOk()) //
@@ -70,8 +72,10 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO account(username,password,role) VALUES('jdoe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','USER')", //
+			"INSERT INTO app_user(account_id,name,surname,locale,time_format)" //
+					+ " SELECT id,'John','Doe','en-US','H24' FROM account WHERE username='jdoe'"//
 	})
 	void testCreateAlreadyExistsShouldReturn400() throws Exception {
 		String body = """
@@ -116,8 +120,10 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO account(username,password,role) VALUES('jdoe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','USER')", //
+			"INSERT INTO app_user(account_id,name,surname,locale,time_format)" //
+					+ " SELECT id,'John','Doe','en-US','H24' FROM account WHERE username='jdoe'"//
 	})
 	void testUpdateShouldReturn200AndUpdatedBody() throws Exception {
 		String body = """
@@ -135,8 +141,10 @@ class AppUserControllerIT {
 
 	@Test
 	@Sql(statements = { //
-			"INSERT INTO app_user(username,name,surname,password_hash,locale,time_format) VALUES('jdoe','John','Doe'," //
-					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','en-US','H24')"//
+			"INSERT INTO account(username,password,role) VALUES('jdoe'," //
+					+ "'$2b$12$cdadM110dFEBQcdSThcGLeZ5Xo8W4yRm9FQSb2JiQgVP4CqyFll7m','USER')", //
+			"INSERT INTO app_user(account_id,name,surname,locale,time_format)" //
+					+ " SELECT id,'John','Doe','en-US','H24' FROM account WHERE username='jdoe'"//
 	})
 	void testDeleteShouldReturn204AndRemoveFromList() throws Exception {
 		mvc.perform(delete(BASE + "/{username}", "jdoe")) //


### PR DESCRIPTION
### Motivation
- Integration tests were inserting directly into `app_user` using columns that no longer exist in the schema, causing SQL failures.
- The database schema now models authentication via `account` with `app_user.account_id` as a foreign key, so fixtures must create an `account` first.
- Aligning the test SQL with the current schema ensures `AppUserControllerIT` can set up users reliably.

### Description
- Updated `@Sql` statements in `src/test/java/es/nivel36/janus/api/v1/appuser/AppUserControllerIT.java` to insert an `account` row and then insert the corresponding `app_user` using `INSERT ... SELECT id ... FROM account WHERE username='jdoe'`.
- Replaced previous direct `app_user` inserts (that referenced `username` and `password_hash`) with `account` + `app_user(account_id, ...)` inserts in all affected tests.
- Changes are limited to the test fixture SQL and do not alter production code.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696569b5c35c8327a2a93cf590dabf01)