### PR TITLE
Add auth guard for dashboard route

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
 import { AUTH_ROUTES } from './auth/auth.routes';
+import { authGuard } from './core/auth/auth.guard';
 
 export const appRoutes: Routes = [
 	{
 		path: '',
+		canActivate: [authGuard],
 		loadComponent: () =>
 			import('./features/dashboard/pages/dashboard-page.component')
 				.then(m => m.DashboardPageComponent),

--- a/frontend/src/app/core/auth/auth.guard.ts
+++ b/frontend/src/app/core/auth/auth.guard.ts
@@ -1,0 +1,17 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { map, take } from 'rxjs';
+
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = (): ReturnType<CanActivateFn> => {
+	const authService = inject(AuthService);
+	const router = inject(Router);
+
+	return authService.isAuthenticated$.pipe(
+		take(1),
+		map((isAuthenticated): boolean | UrlTree =>
+			isAuthenticated ? true : router.createUrlTree(['/login'])
+		)
+	);
+};


### PR DESCRIPTION
### Motivation
- Ensure the dashboard is only accessible when a valid session exists and redirect unauthenticated users to `/login`.
- Gate routing using the reactive authentication state provided by `AuthService.isAuthenticated$`.
- Make the guard complete after the first emission to avoid hanging route resolution by using `take(1)`.

### Description
- Add `frontend/src/app/core/auth/auth.guard.ts` which exports `authGuard` that injects `AuthService` and `Router` and maps `isAuthenticated$` to either `true` or `router.createUrlTree(['/login'])`.
- Protect the root dashboard route in `frontend/src/app/app.routes.ts` by adding `canActivate: [authGuard]` to the `path: ''` route.
- Leave `frontend/src/app/auth/auth.routes.ts` unchanged so the `/login` route remains available.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656b8c7538832793d32811d3250891)