### PR TITLE
Refresh dashboard timelog table after clock actions

### DIFF
--- a/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
+++ b/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
@@ -12,7 +12,7 @@
 						<app-button [disabled]="isClockActionLoading" (click)="onClockAction()"> {{ clockActionLabelKey | translate }} </app-button> 
 					</ng-template> 
 				</app-card>
-				<app-timelog-table > </app-timelog-table>
+				<app-timelog-table [employeeEmail]="employeeEmail" [refreshToken]="tableRefreshToken"></app-timelog-table>
 			</section>
 			<section class="aside">
 				<div class="aside">

--- a/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
+++ b/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
@@ -38,7 +38,8 @@ export class DashboardPageComponent implements OnInit {
 	readonly isAuthenticated$ = this.authService.isAuthenticated$;
 	readonly username$ = this.authService.username$;
 	private latestTimeLog?: TimeLog;
-	private employeeEmail?: string;
+	employeeEmail?: string;
+	tableRefreshToken = 0;
 
 	ngOnInit(): void {
 		this.username$
@@ -67,6 +68,7 @@ export class DashboardPageComponent implements OnInit {
 			next: (timeLog) => {
 				this.latestTimeLog = timeLog;
 				this.clockActionLabelKey = this.getClockActionLabelKey(timeLog);
+				this.tableRefreshToken += 1;
 			},
 			error: () => {
 				this.isClockActionLoading = false;

--- a/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
+++ b/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, DatePipe } from '@angular/common';
-import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, Input, OnChanges, OnInit, SimpleChanges, inject } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -13,8 +13,9 @@ import { TimeLog } from '../../models/timelog';
 	templateUrl: './timelog-table.component.html',
 	styleUrl: './timelog-table.component.css'
 })
-export class TimelogTableComponent implements OnInit {
-	protected readonly employeeEmail = 'aferrer@nivel36.es';
+export class TimelogTableComponent implements OnInit, OnChanges {
+	@Input() employeeEmail?: string;
+	@Input() refreshToken = 0;
 	protected timelogs: TimeLog[] = [];
 	protected isLoading = false;
 	protected error?: string;
@@ -27,7 +28,16 @@ export class TimelogTableComponent implements OnInit {
 		this.loadTimeLogs();
 	}
 
+	ngOnChanges(changes: SimpleChanges): void {
+		if (changes['employeeEmail'] || changes['refreshToken']) {
+			this.loadTimeLogs();
+		}
+	}
+
 	private loadTimeLogs(): void {
+		if (!this.employeeEmail) {
+			return;
+		}
 		this.isLoading = true;
 		this.error = undefined;
 


### PR DESCRIPTION
### Motivation
- The timelog table on the dashboard remained stale after performing clock in / clock out actions, so updated entry/exit times were not visible to the user. 
- The goal is to make the table reload its data for the current employee immediately after a clock action completes.

### Description
- Add `@Input() employeeEmail?: string` and `@Input() refreshToken = 0` to `TimelogTableComponent` and implement `OnChanges` to call `loadTimeLogs()` when inputs change. 
- Guard `loadTimeLogs()` to return early if `employeeEmail` is not set and preserve existing loading/error state handling. 
- Pass `[employeeEmail]=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a0cbabf08327a0a6c882a6f0e3c5)