### PR TITLE
Fix frontend Docker image to serve Angular build output

### DIFF
--- a/apps/frontend/.dockerignore
+++ b/apps/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.angular
+.git
+.vscode
+*.log

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -6,3 +6,7 @@ COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
+EXPOSE 80

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -8,5 +8,6 @@ COPY . .
 RUN npm run build
 
 FROM nginx:1.27-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
 EXPOSE 80

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
### Motivation
- The `docker-compose` nginx proxy expects the frontend at `frontend:80`, but the previous frontend image only produced build artifacts and did not serve them at runtime, so the Docker image must be changed to provide an HTTP runtime and the build context kept small.

### Description
- Replace the frontend image with a multi-stage `Dockerfile` that builds the Angular app and then uses `nginx:1.27-alpine` to serve `dist/frontend/browser` on port `80` by copying the build output into `/usr/share/nginx/html`.
- Add `apps/frontend/.dockerignore` to exclude `node_modules`, `dist`, `.angular` and other local files from the Docker build context.
- Verified that `deploy/docker/compose.yml` builds the frontend from `../../apps/frontend` and that `deploy/nginx/conf.d/app.conf` proxies `/` to `frontend:80`, which motivated serving the static files from the container.

### Testing
- Ran `npm run build` in `apps/frontend` and it completed successfully producing the production output at `dist/frontend/browser`.
- Attempted `docker compose -f deploy/docker/compose.yml config` but the `docker` CLI is not available in this environment so compose validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a184f6c888327a1a7c66ab69973f4)