### PR TITLE
Translate Docker helper script messages to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ mvn clean install
 java -jar Janus.jar
 ```
 
+## Docker (quick start/stop)
+
+From the project root, you can use these scripts:
+
+```bash
+./start.sh    # docker compose up -d --build
+./stop.sh     # docker compose down
+./restart.sh  # stop + start
+```
+
 ## Usage
 
 Access the application via a web browser:

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$ROOT_DIR/stop.sh"
+"$ROOT_DIR/start.sh"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$ROOT_DIR/deploy/docker/compose.yml"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "Compose file not found at: $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo "Docker Compose not found (docker compose or docker-compose)." >&2
+  exit 1
+fi
+
+echo "Starting services with ${COMPOSE_CMD[*]} using $COMPOSE_FILE"
+"${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" up -d --build
+
+echo "Services started successfully."

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$ROOT_DIR/deploy/docker/compose.yml"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "Compose file not found at: $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo "Docker Compose not found (docker compose or docker-compose)." >&2
+  exit 1
+fi
+
+echo "Stopping services with ${COMPOSE_CMD[*]} using $COMPOSE_FILE"
+"${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" down
+
+echo "Services stopped successfully."


### PR DESCRIPTION
### Motivation

- Translate user-facing messages in the root Docker helper scripts and README to English for consistency and wider accessibility.

### Description

- Replaced Spanish error and status strings with English in `start.sh` (compose file missing, compose-not-found, startup status, success message). 
- Replaced Spanish error and status strings with English in `stop.sh` (compose file missing, compose-not-found, shutdown status, success message). 
- Updated the Docker helper section in `README.md` to English (`Docker (quick start/stop)` and the one-line usage text). 
- Preserved existing behavior for Compose detection and commands (`docker compose` vs `docker-compose`) and left `restart.sh` unchanged.

### Testing

- Ran shell syntax checks with `bash -n start.sh stop.sh restart.sh` which completed successfully. 
- Changes were committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2198eea083278c97ed9f84527b9e)