### PR TITLE
Configure Angular environment URLs and enable backend CORS

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/config/CorsConfig.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/config/CorsConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Configures CORS rules for API endpoints.
+ */
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+	private final List<String> allowedOrigins;
+
+	public CorsConfig(@Value("${janus.cors.allowed-origins:http://localhost:4200}") List<String> allowedOrigins) {
+		this.allowedOrigins = allowedOrigins;
+	}
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry
+			.addMapping("/api/**")
+			.allowedOrigins(allowedOrigins.toArray(String[]::new))
+			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+			.allowedHeaders("*")
+			.allowCredentials(true);
+	}
+}

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -57,3 +57,6 @@ logging:
     console: "%d{HH:mm:ss.SSS} [%-5level] %logger{36} - %msg%n"
   level:
     es.nivel36.janus: TRACE
+janus:
+  cors:
+    allowed-origins: ${JANUS_CORS_ALLOWED_ORIGINS:http://localhost:4200}

--- a/apps/frontend/angular.json
+++ b/apps/frontend/angular.json
@@ -47,7 +47,13 @@
 									"maximumError": "8kB"
 								}
 							],
-							"outputHashing": "all"
+							"outputHashing": "all",
+							"fileReplacements": [
+								{
+									"replace": "src/environments/environment.ts",
+									"with": "src/environments/environment.prod.ts"
+								}
+							]
 						},
 						"development": {
 							"optimization": false,

--- a/apps/frontend/src/app/core/auth/auth.service.ts
+++ b/apps/frontend/src/app/core/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, catchError, map, Observable, switchMap, tap, throwError } from 'rxjs';
+import { environment } from '../../../environments/environment';
 
 interface LoginResponse {
 	token: string;
@@ -17,8 +18,8 @@ interface AppUserResponse {
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-	private readonly baseUrl = '/api/v1/auth';
-	private readonly appUserBaseUrl = '/api/v1/appusers';
+	private readonly baseUrl = `${environment.apiUrl}/auth`;
+	private readonly appUserBaseUrl = `${environment.apiUrl}/appusers`;
 	private readonly tokenStorageKey = 'janus.auth.token';
 	private readonly usernameStorageKey = 'janus.auth.username';
 	private readonly appUserStorageKey = 'janus.auth.user';

--- a/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
+++ b/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
@@ -2,10 +2,11 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { TimeLog } from '../models/timelog';
+import { environment } from '../../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class TimeLogService {
-	private readonly baseUrl = '/api/v1/employees';
+	private readonly baseUrl = `${environment.apiUrl}/employees`;
 
 	constructor(private readonly http: HttpClient) { }
 

--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+	production: true,
+	apiUrl: '/api/v1'
+};

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+	production: false,
+	apiUrl: 'http://localhost:8080/api/v1'
+};


### PR DESCRIPTION
### Motivation

- Separar las URLs de API por entorno porque Angular ya no se sirve desde el Spring Boot y los servicios debían dejar de usar rutas hardcodeadas. 
- Asegurar que la build de producción de Angular reemplace `environment.ts` por `environment.prod.ts` para ajustar `apiUrl` en tiempo de build. 
- Permitir llamadas desde el frontend cuando se sirve en otro origen añadiendo CORS configurable en el backend.

### Description

- Añadí los ficheros de entorno `apps/frontend/src/environments/environment.ts` (dev) y `apps/frontend/src/environments/environment.prod.ts` (prod) que exponen `apiUrl`.
- Actualicé los servicios para consumir la variable de entorno: `apps/frontend/src/app/core/auth/auth.service.ts` y `apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts` importan ahora `environment` y usan `${environment.apiUrl}` en lugar de rutas hardcodeadas.
- Aseguré el `fileReplacements` en `apps/frontend/angular.json` bajo `build.configurations.production` para que `environment.ts` sea reemplazado por `environment.prod.ts` en builds de producción.
- Añadí configuración CORS en el backend con `apps/backend/src/main/java/es/nivel36/janus/config/CorsConfig.java` y la propiedad `janus.cors.allowed-origins` en `apps/backend/src/main/resources/application.yml`, conectada a la variable de entorno `JANUS_CORS_ALLOWED_ORIGINS`.

### Testing

- Ejecuté `npm run build -- --configuration production` en `apps/frontend` y la build produjo el bundle de salida correctamente.
- Ejecuté `./mvnw -q test -DskipITs` en `apps/backend` y las pruebas unitarias terminaron sin errores.
- Verifiqué que el bundle de producción contiene la `apiUrl` de producción (`"/api/v1"`) y que los servicios del frontend ahora referencian `environment.apiUrl`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cba44fad0832789506013b6f794c2)