### PR TITLE
Fix frontend Angular build issues with Keycloak bootstrapping

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -17,6 +17,7 @@
 				"@ngx-translate/core": "^17.0.0",
 				"@ngx-translate/http-loader": "^17.0.0",
 				"@primeuix/themes": "^1.2.5",
+				"keycloak-js": "^26.2.3",
 				"luxon": "^3.7.2",
 				"primeng": "^20.2.0",
 				"rxjs": "^7.8.1",
@@ -6584,6 +6585,15 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/keycloak-js": {
+			"version": "26.2.3",
+			"resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.3.tgz",
+			"integrity": "sha512-widjzw/9T6bHRgEp6H/Se3NCCarU7u5CwFKBcwtu7xfA1IfdZb+7Q7/KGusAnBo34Vtls8Oz9vzSqkQvQ7+b4Q==",
+			"license": "Apache-2.0",
+			"workspaces": [
+				"test"
+			]
 		},
 		"node_modules/listr2": {
 			"version": "9.0.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -31,6 +31,7 @@
 		"@ngx-translate/core": "^17.0.0",
 		"@ngx-translate/http-loader": "^17.0.0",
 		"@primeuix/themes": "^1.2.5",
+		"keycloak-js": "^26.2.3",
 		"luxon": "^3.7.2",
 		"primeng": "^20.2.0",
 		"rxjs": "^7.8.1",

--- a/apps/frontend/src/app/auth/keycloak.ts
+++ b/apps/frontend/src/app/auth/keycloak.ts
@@ -1,0 +1,24 @@
+import Keycloak, { type KeycloakConfig } from 'keycloak-js';
+
+import { environment } from '../../environments/environment';
+
+const keycloakConfig: KeycloakConfig = {
+	url: environment.keycloak.url,
+	realm: environment.keycloak.realm,
+	clientId: environment.keycloak.clientId
+};
+
+const hasValidConfig = Object.values(keycloakConfig).every((value) => Boolean(value));
+
+export const keycloak = hasValidConfig ? new Keycloak(keycloakConfig) : null;
+
+export function initKeycloak(): Promise<boolean> {
+	if (!keycloak) {
+		return Promise.resolve(false);
+	}
+
+	return keycloak.init({
+		onLoad: 'check-sso',
+		pkceMethod: 'S256'
+	});
+}

--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,10 @@
 export const environment = {
 	production: true,
-	apiUrl: '/api/v1'
+	apiBaseUrl: '/api',
+	apiUrl: '/api/v1',
+	keycloak: {
+		url: '',
+		realm: '',
+		clientId: ''
+	}
 };

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -1,4 +1,10 @@
 export const environment = {
 	production: false,
-	apiUrl: 'http://localhost:8080/api/v1'
+	apiBaseUrl: '/api',
+	apiUrl: 'http://localhost:8080/api/v1',
+	keycloak: {
+		url: '',
+		realm: '',
+		clientId: ''
+	}
 };

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -1,6 +1,19 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
+import { initKeycloak } from './app/auth/keycloak';
 
-bootstrapApplication(AppComponent, appConfig)
-	.catch((err) => console.error(err));
+initKeycloak()
+	.catch((error) => {
+		console.warn('Keycloak initialization skipped or failed', error);
+		return false;
+	})
+	.then((authenticated: boolean) => {
+		if (authenticated) {
+			console.info('Authenticated with Keycloak.');
+		}
+
+		return bootstrapApplication(AppComponent, appConfig);
+	})
+	.catch((error) => console.error(error));


### PR DESCRIPTION
### Motivation
- Resolve Angular build errors caused by a missing `keycloak-js` module, malformed environment objects that produced TS1005, and an implicitly-typed callback parameter in the bootstrap flow that produced TS7006.

### Description
- Add the `keycloak-js` dependency to `apps/frontend/package.json` to provide Keycloak runtime and types.
- Add `apps/frontend/src/app/auth/keycloak.ts` which constructs a `KeycloakConfig` from `environment`, only instantiates `Keycloak` when config values exist, and exposes `initKeycloak()` returning `Promise<boolean>`.
- Update `apps/frontend/src/main.ts` to call `initKeycloak()` before `bootstrapApplication`, handle initialization failures, and explicitly type the `authenticated` callback as `boolean`.
- Fix `apps/frontend/src/environments/environment.ts` and `apps/frontend/src/environments/environment.prod.ts` to include `apiBaseUrl` and a `keycloak` config object with valid object syntax.

### Testing
- Ran `npm run build` in `apps/frontend` and the Angular build completed successfully, producing the application bundle at `/workspace/janus/apps/frontend/dist/frontend`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfc61d9648327bec43c289037256e)