### PR TITLE
refactor(frontend): switch login form to Keycloak redirect

### DIFF
--- a/apps/frontend/src/app/auth/login-form/login-form.component.html
+++ b/apps/frontend/src/app/auth/login-form/login-form.component.html
@@ -1,36 +1,14 @@
-<form class="login-form" [formGroup]="form" (ngSubmit)="submit()">
-  <label class="login-field">
-    <span>{{ 'login.username' | translate }}</span>
-    <input
-      type="text"
-      formControlName="username"
-      autocomplete="username"
-      required
-      [placeholder]="'login.usernamePlaceholder' | translate"
-    />
-  </label>
-
-  <label class="login-field">
-    <span>{{ 'login.password' | translate }}</span>
-    <input
-      type="password"
-      formControlName="password"
-      autocomplete="current-password"
-      required
-      minlength="8"
-      [placeholder]="'login.passwordPlaceholder' | translate"
-    />
-  </label>
-
+<div class="login-form">
   @if (errorMessage) {
     <p class="login-error">{{ errorMessage | translate }}</p>
   }
 
   <app-button
-    [type]="'submit'"
-    [disabled]="form.invalid || isLoading"
+    [type]="'button'"
+    [disabled]="isLoading"
     styleClass="login-submit"
+    (click)="login()"
   >
     {{ isLoading ? ('login.loading' | translate) : ('login.submit' | translate) }}
   </app-button>
-</form>
+</div>

--- a/apps/frontend/src/app/auth/login-form/login-form.component.ts
+++ b/apps/frontend/src/app/auth/login-form/login-form.component.ts
@@ -1,8 +1,6 @@
 import { Component } from "@angular/core";
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
 import { TranslatePipe } from "@ngx-translate/core";
 import { AuthService } from "../../core/auth/auth.service";
-import { Router } from "@angular/router";
 import { ButtonComponent } from '../../shared/ui/button/button.component';
 
 @Component({
@@ -10,34 +8,24 @@ import { ButtonComponent } from '../../shared/ui/button/button.component';
   selector: 'app-login-form',
   templateUrl: './login-form.component.html',
   styleUrls: ['./login-form.component.css'],
-  imports: [ReactiveFormsModule, TranslatePipe, ButtonComponent],
+  imports: [TranslatePipe, ButtonComponent],
 })
 export class LoginFormComponent {
   isLoading = false;
   errorMessage = '';
 
-  readonly form = new FormGroup({
-    username: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
-    password: new FormControl('', {
-      nonNullable: true,
-      validators: [Validators.required, Validators.minLength(8)],
-    }),
-  });
+  constructor(private authService: AuthService) {}
 
-  constructor(private authService: AuthService, private router: Router) {}
-
-  submit(): void {
-    if (this.form.invalid || this.isLoading) return;
+  login(): void {
+    if (this.isLoading) return;
 
     this.isLoading = true;
     this.errorMessage = '';
 
-    const { username, password } = this.form.getRawValue();
-
-    this.authService.login(username, password).subscribe({
-      next: () => this.router.navigate(['/']),
+    this.authService.login().subscribe({
+      next: () => (this.isLoading = false),
       error: () => {
-        this.errorMessage = 'login.error'; // o el texto directo, o clave i18n
+        this.errorMessage = 'login.error';
         this.isLoading = false;
       },
       complete: () => (this.isLoading = false),


### PR DESCRIPTION
### Motivation
- El proyecto consolida la autenticación en Keycloak y debe eliminar el flujo de credenciales locales del formulario de login para forzar la redirección a Keycloak.
- Mantener el manejo de errores en la UI para fallos de inicialización/autenticación de Keycloak en lugar de validaciones de credenciales locales.

### Description
- Replaced the local username/password form in `LoginFormComponent` by removing the `FormGroup` and `ReactiveFormsModule` import and adding a single `login()` action that calls `AuthService.login()` and manages `isLoading`/`errorMessage` state. 
- Updated the template `login-form.component.html` to show only an error block and a single `<app-button>` that triggers `(click)="login()"` and disables while loading. 
- Refactored `AuthService` to use Keycloak: removed HTTP-based `login(username,password)` and storage logic, added a Keycloak-backed `login()` that calls `keycloak.login()`, preserved `getToken()`, `isAuthenticated$`, `username$` and a helper `extractUsername()` to populate username from the Keycloak token. 
- Kept `clearToken()` behavior to reset in-memory auth state so existing guards/interceptors continue to work with the Keycloak token retrieval.

### Testing
- Built the frontend with `npm run build` in `apps/frontend`, and the build completed successfully. 
- Started the dev server with `ng serve` and performed a visual check of the `/login` page via a Playwright script that produced a screenshot artifact. 
- No unit tests were modified; integration was validated by the successful build and manual/automated UI capture (`artifacts/login-keycloak.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0197dc7083279f015571e789c100)