### PR TITLE
fix(backend): align JWT issuer with janus Keycloak realm

### DIFF
--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8081/auth/realms/mi-realm
+          issuer-uri: http://localhost:8081/auth/realms/janus-realm
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/app}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
### Motivation
- Alinear el `issuer` configurado en el backend con el realm importado en Keycloak para que la validación JWT (`iss`) coincida exactamente con el realm activo.

### Description
- Cambiado `spring.security.oauth2.resourceserver.jwt.issuer-uri` en `apps/backend/src/main/resources/application.yml` de `http://localhost:8081/auth/realms/mi-realm` a `http://localhost:8081/auth/realms/janus-realm`.

### Testing
- Verificaciones automáticas realizadas: `rg -n "issuer-uri" apps/backend/src/main/resources/application.yml` confirmó la nueva URL y la revisión estática de `deploy/docker/keycloak/realm-export.json` confirma `realm: "janus-realm"`, mientras que intentar ejecutar `docker compose -f deploy/docker/compose.dev.yml up -d postgres_keycloak keycloak` falló porque `docker` no está disponible en este entorno (no se pudo validar un `iss` real en tiempo de ejecución).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e018d2dc88327ab76fd2a91093cb8)