### PR TITLE
Configure frontend Keycloak realm, client, and environment URLs

### DIFF
--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -3,8 +3,8 @@ export const environment = {
 	apiBaseUrl: '/api',
 	apiUrl: '/api/v1',
 	keycloak: {
-		url: '',
-		realm: '',
-		clientId: ''
+		url: '/auth',
+		realm: 'janus-realm',
+		clientId: 'janus-spa'
 	}
 };

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -3,8 +3,8 @@ export const environment = {
 	apiBaseUrl: '/api',
 	apiUrl: 'http://localhost:8080/api/v1',
 	keycloak: {
-		url: '',
-		realm: '',
-		clientId: ''
+		url: 'http://localhost:8081/auth',
+		realm: 'janus-realm',
+		clientId: 'janus-spa'
 	}
 };


### PR DESCRIPTION
### Motivation
- Ensure the frontend Keycloak configuration uses the correct realm and client identifiers that match the Keycloak export so authentication works end-to-end.
- Use a local Keycloak URL for development and a proxied/relative URL for production so deployments behind a reverse proxy (nginx) work without changing code.

### Description
- Updated `apps/frontend/src/environments/environment.ts` to set `keycloak.url = 'http://localhost:8081/auth'`, `keycloak.realm = 'janus-realm'`, and `keycloak.clientId = 'janus-spa'` for local development.
- Updated `apps/frontend/src/environments/environment.prod.ts` to set `keycloak.url = '/auth'`, `keycloak.realm = 'janus-realm'`, and `keycloak.clientId = 'janus-spa'` for production.
- Verified the configured `realm` and `clientId` match the client entry in `deploy/docker/keycloak/realm-export.json`.

### Testing
- Ran a Python validation script that parsed `deploy/docker/keycloak/realm-export.json` and confirmed the `realm` and `clientId` in both environment files match the exported values, and this check succeeded.
- Inspected the modified files to ensure the expected URL and identifier values are present, and the inspection showed the correct updates.
- Performed a diff to confirm only the intended environment entries were changed and the diff matched the expected modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e018807d083279a0b348c0277ef21)