### PR TITLE
Actualizar interceptor de auth para omitir endpoints de Keycloak y adjuntar token Keycloak solo a APIs protegidas

### DIFF
--- a/apps/frontend/src/app/core/auth/auth.interceptor.ts
+++ b/apps/frontend/src/app/core/auth/auth.interceptor.ts
@@ -1,13 +1,34 @@
 import { HttpInterceptorFn } from '@angular/common/http';
-import { inject } from '@angular/core';
-import { AuthService } from './auth.service';
+import { keycloak } from '../../auth/keycloak';
+import { environment } from '../../../environments/environment';
+
+function isKeycloakRequest(url: string): boolean {
+	const keycloakUrl = environment.keycloak.url?.trim();
+	if (!keycloakUrl) {
+		return false;
+	}
+
+	return url.startsWith(keycloakUrl);
+}
+
+function isProtectedApiRequest(url: string): boolean {
+	if (url.startsWith(environment.apiUrl) || url.startsWith(environment.apiBaseUrl)) {
+		return true;
+	}
+
+	if (!globalThis.location?.origin) {
+		return false;
+	}
+
+	return url.startsWith(`${globalThis.location.origin}${environment.apiBaseUrl}`);
+}
 
 export const authInterceptor: HttpInterceptorFn = (request, next) => {
-	if (request.url.endsWith('/auth/login')) {
+	if (isKeycloakRequest(request.url) || !isProtectedApiRequest(request.url)) {
 		return next(request);
 	}
 
-	const token = inject(AuthService).getToken();
+	const token = keycloak?.token;
 	if (!token) {
 		return next(request);
 	}


### PR DESCRIPTION
### Motivation
- Evitar enviar el token a endpoints de Keycloak (incluyendo rutas OIDC) y dejar de depender de una excepción hard-coded para `/auth/login`.
- Asegurar que el header `Authorization: Bearer <token>` solo se añada a las llamadas hacia la API protegida del backend.

### Description
- Reemplacé la condición `request.url.endsWith('/auth/login')` por una exclusión genérica `isKeycloakRequest(url)` que usa `environment.keycloak.url` como prefijo.
- Añadí la comprobación `isProtectedApiRequest(url)` que limita la inyección del token a URLs que coincidan con `environment.apiUrl` o `environment.apiBaseUrl` (incluye variante absoluta con `location.origin`).
- Cambié la fuente del token a `keycloak?.token` (desde `apps/frontend/src/app/auth/keycloak.ts`) y quité la dependencia directa de `AuthService.getToken()` en el interceptor.

### Testing
- Ejecuté `npm run build` en `apps/frontend`, y la compilación falló por resolución de dependencias debido a que el módulo `keycloak-js` no pudo resolverse, por lo que no se generó un bundle exitoso.
- No se ejecutaron tests unitarios adicionales en este entorno debido al fallo de build relacionado con `keycloak-js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0183cd4c83279aa0c136985c96c3)