### PR TITLE
feat(frontend): iniciar autenticación Keycloak desde guard con retorno a URL destino

### DIFF
--- a/apps/frontend/src/app/core/auth/auth.service.ts
+++ b/apps/frontend/src/app/core/auth/auth.service.ts
@@ -17,6 +17,12 @@ interface KeycloakClaims {
 	email?: string;
 }
 
+interface LoginRedirectOptions {
+	prompt?: 'none' | 'login' | 'consent';
+	maxAge?: number;
+	idpHint?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
 	private readonly appUserBaseUrl = `${environment.apiUrl}/appusers`;
@@ -38,6 +44,23 @@ export class AuthService {
 			return Promise.reject(new Error('Keycloak is not configured'));
 		}
 		return keycloak.login();
+	}
+
+	loginWithRedirect(redirectUri?: string, options?: LoginRedirectOptions): Promise<void> {
+		if (!keycloak) {
+			return Promise.reject(new Error('Keycloak is not configured'));
+		}
+
+		const resolvedRedirectUri = redirectUri
+			? new URL(redirectUri, window.location.origin).toString()
+			: window.location.href;
+
+		return keycloak.login({
+			redirectUri: resolvedRedirectUri,
+			prompt: options?.prompt,
+			maxAge: options?.maxAge,
+			idpHint: options?.idpHint
+		});
 	}
 
 	logout(): Promise<void> {


### PR DESCRIPTION
### Motivation
- Reemplazar la lógica de enviar al usuario a `/login` cuando no está autenticado por un inicio de sesión directo con Keycloak que preserve la URL objetivo para retorno.
- Mantener la ruta `/login` como pantalla opcional/manual y admitir parámetros OIDC útiles para necesidades futuras.

### Description
- Añadí la interfaz `LoginRedirectOptions` y el método `loginWithRedirect(redirectUri?: string, options?: LoginRedirectOptions)` en `AuthService`, que resuelve `redirectUri` a URL absoluta y llama a `keycloak.login({...})` con `redirectUri`, `prompt`, `maxAge` e `idpHint`.
- Actualicé `authGuard` para que, cuando `isAuthenticated` sea `false`, invoque `authService.loginWithRedirect(state.url)` y devuelva `false` en lugar de crear un `UrlTree` a `/login`.
- El flujo `/login` permanece en la app como punto de entrada opcional/manual, pero el guard ahora dispara el flujo federado de Keycloak para rutas protegidas.

### Testing
- Ejecuté `npm run build` en `apps/frontend` y la compilación falló por un error preexistente en plantilla HTML (`src/app/auth/login-form/login-form.component.html`: cierre inesperado de `div`), por lo que no fue posible validar la compilación completa (fallido).
- Durante el proceso se observó un warning de imports no usados en `login-form` y se corrigió una incompatibilidad de tipos `prompt` en `AuthService` antes de reintentar la compilación; el warning y el error de plantilla son anteriores a estos cambios.
- Se creó el commit con los cambios en `apps/frontend/src/app/core/auth/auth.service.ts` y `apps/frontend/src/app/core/auth/auth.guard.ts` (`feat(frontend): redirigir auth guard a login de Keycloak`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0b19e8cc8327878d6b65ca182f40)