### PR TITLE
fix(frontend): correct login form template; add Keycloak claims/permissions and route guard checks

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -3,12 +3,16 @@ import { AUTH_ROUTES } from './auth/auth.routes';
 import { authGuard } from './core/auth/auth.guard';
 
 export const appRoutes: Routes = [
-	{
-		path: '',
-		canActivate: [authGuard],
-		loadComponent: () =>
-			import('./features/dashboard/pages/dashboard-page.component')
-				.then(m => m.DashboardPageComponent),
-	},
-	...AUTH_ROUTES,
+  {
+    path: '',
+    canActivate: [authGuard],
+    data: {
+      clientRole: { clientId: 'janus-frontend', role: 'timelog_user' },
+    },
+    loadComponent: () =>
+      import('./features/dashboard/pages/dashboard-page.component').then(
+        (m) => m.DashboardPageComponent,
+      ),
+  },
+  ...AUTH_ROUTES,
 ];

--- a/apps/frontend/src/app/auth/login-form/login-form.component.html
+++ b/apps/frontend/src/app/auth/login-form/login-form.component.html
@@ -7,8 +7,7 @@
     [type]="'submit'"
     [disabled]="isLoading"
     styleClass="login-submit"
-    (click)="login()"
   >
     {{ isLoading ? ('login.loading' | translate) : ('login.submit' | translate) }}
   </app-button>
-</div>
+</form>

--- a/apps/frontend/src/app/core/auth/auth.guard.ts
+++ b/apps/frontend/src/app/core/auth/auth.guard.ts
@@ -4,20 +4,41 @@ import { map, take } from 'rxjs';
 
 import { AuthService } from './auth.service';
 
-export const authGuard: CanActivateFn = (_route, state): ReturnType<CanActivateFn> => {
-	const authService = inject(AuthService);
-	const router = inject(Router);
+interface RouteRoleData {
+  realmRole?: string;
+  clientRole?: {
+    clientId: string;
+    role: string;
+  };
+}
 
-	return authService.isAuthenticated$.pipe(
-		take(1),
-		map((isAuthenticated): boolean => {
-			if (isAuthenticated) {
-				return true;
-			}
+export const authGuard: CanActivateFn = (route, state): ReturnType<CanActivateFn> => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  const roleData = route.data as RouteRoleData | undefined;
 
-			const targetUrl = state.url ? router.serializeUrl(router.parseUrl(state.url)) : '/';
-			void authService.loginWithRedirect(targetUrl);
-			return false;
-		})
-	);
+  return authService.isAuthenticated$.pipe(
+    take(1),
+    map((isAuthenticated): boolean => {
+      if (!isAuthenticated) {
+        const targetUrl = state.url ? router.serializeUrl(router.parseUrl(state.url)) : '/';
+        void authService.loginWithRedirect(targetUrl);
+        return false;
+      }
+
+      const hasRealmRole = roleData?.realmRole
+        ? authService.hasRealmRole(roleData.realmRole)
+        : true;
+      const hasClientRole = roleData?.clientRole
+        ? authService.hasClientRole(roleData.clientRole.clientId, roleData.clientRole.role)
+        : true;
+
+      if (hasRealmRole && hasClientRole) {
+        return true;
+      }
+
+      void router.navigateByUrl('/');
+      return false;
+    }),
+  );
 };

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
@@ -1,73 +1,63 @@
 <main class="app-shell">
-	<section class="dashboard">
-		<header class="dashboard-header">
-			<h1 class="brand">
-				{{ 'navigation.janus' | translate }}
-			</h1>
-			<span class="section-label">
-				{{ 'navigation.dashboard' | translate }}
-			</span>
-		</header>
+  <section class="dashboard">
+    <header class="dashboard-header">
+      <h1 class="brand">
+        {{ 'navigation.janus' | translate }}
+      </h1>
+      <span class="section-label">
+        {{ 'navigation.dashboard' | translate }}
+      </span>
+    </header>
 
-		<section class="dashboard-content">
-			<!-- MAIN CONTENT -->
-			<section class="content">
-				<app-card
-					styleClass="clock-in-card"
-					[title]="clockActionLabelKey | translate">
+    <section class="dashboard-content">
+      <!-- MAIN CONTENT -->
+      <section class="content">
+        <app-card styleClass="clock-in-card" [title]="clockActionLabelKey | translate">
+          <ng-template #cardHeader>
+            <app-clock styleClass="card-hour-container" timeClass="card-hour"> </app-clock>
 
-					<ng-template #cardHeader>
-						<app-clock
-							styleClass="card-hour-container"
-							timeClass="card-hour">
-						</app-clock>
+            <app-button
+              *ngIf="canClockInOut$ | async"
+              [disabled]="isClockActionLoading"
+              (click)="onClockAction()"
+            >
+              {{ clockActionLabelKey | translate }}
+            </app-button>
+          </ng-template>
+        </app-card>
 
-						<app-button
-							[disabled]="isClockActionLoading"
-							(click)="onClockAction()">
-							{{ clockActionLabelKey | translate }}
-						</app-button>
-					</ng-template>
+        <app-timelog-table [employeeEmail]="employeeEmail" [refreshToken]="tableRefreshToken">
+        </app-timelog-table>
+      </section>
 
-				</app-card>
+      <!-- ASIDE -->
+      <section class="aside">
+        <app-card styleClass="user-card">
+          <ng-template #cardHeader>
+            <div class="user-card-header-content">
+              <img class="avatar" src="assets/images/user.png" alt="User avatar" />
+              <span class="user-card-title">
+                {{ 'employee.employee' | translate }}
+              </span>
+            </div>
+          </ng-template>
 
-				<app-timelog-table
-					[employeeEmail]="employeeEmail"
-					[refreshToken]="tableRefreshToken">
-				</app-timelog-table>
-			</section>
+          <div class="data">
+            <h3>{{ 'employee.fullName' | translate }}</h3>
+            <p>{{ username$ | async }}</p>
+          </div>
 
-			<!-- ASIDE -->
-			<section class="aside">
-				<app-card styleClass="user-card">
-					<ng-template #cardHeader>
-						<div class="user-card-header-content">
-							<img
-								class="avatar"
-								src="assets/images/user.png"
-								alt="User avatar" />
-							<span class="user-card-title">
-								{{ 'employee.employee' | translate }}
-							</span>
-						</div>
-					</ng-template>
+          <div class="data">
+            <h3>{{ 'employee.location' | translate }}</h3>
+            <p>Barcelona Headquarters</p>
+          </div>
 
-					<div class="data">
-						<h3>{{ 'employee.fullName' | translate }}</h3>
-						<p>{{ username$ | async }}</p>
-					</div>
-
-					<div class="data">
-						<h3>{{ 'employee.location' | translate }}</h3>
-						<p>Barcelona Headquarters</p>
-					</div>
-
-					<div class="data">
-						<h3>{{ 'employee.todaysHour' | translate }}</h3>
-						<p>9:00 - 17:30</p>
-					</div>
-				</app-card>
-			</section>
-		</section>
-	</section>
+          <div class="data">
+            <h3>{{ 'employee.todaysHour' | translate }}</h3>
+            <p>9:00 - 17:30</p>
+          </div>
+        </app-card>
+      </section>
+    </section>
+  </section>
 </main>

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
@@ -1,8 +1,8 @@
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgIf } from '@angular/common';
 import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
-import { filter, firstValueFrom } from 'rxjs';
+import { filter, firstValueFrom, map } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { AuthService } from '../../../core/auth/auth.service';
@@ -14,131 +14,144 @@ import { TimeLogService } from '../../timelogs/services/timelog-api.service';
 import { TimeLog } from '../../timelogs/models/timelog';
 
 @Component({
-	selector: 'app-dashboard-page',
-	standalone: true,
-	imports: [
-		AsyncPipe,
-		FormsModule,
-		TranslatePipe,
-		ClockComponent,
-		CardComponent,
-		TimelogTableComponent,
-		ButtonComponent
-	],
-	templateUrl: './dashboard-page.component.html',
-	styleUrl: './dashboard-page.component.css'
+  selector: 'app-dashboard-page',
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    NgIf,
+    FormsModule,
+    TranslatePipe,
+    ClockComponent,
+    CardComponent,
+    TimelogTableComponent,
+    ButtonComponent,
+  ],
+  templateUrl: './dashboard-page.component.html',
+  styleUrl: './dashboard-page.component.css',
 })
 export class DashboardPageComponent implements OnInit {
-	private readonly authService = inject(AuthService);
-	private readonly timeLogService = inject(TimeLogService);
-	private readonly destroyRef = inject(DestroyRef);
-	private readonly defaultWorksiteCode = 'BCN-HQ';
+  private readonly authService = inject(AuthService);
+  private readonly timeLogService = inject(TimeLogService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly defaultWorksiteCode = 'BCN-HQ';
 
-	clockActionLabelKey = 'timelog.clockin';
-	isClockActionLoading = false;
+  clockActionLabelKey = 'timelog.clockin';
+  isClockActionLoading = false;
 
-	readonly isAuthenticated$ = this.authService.isAuthenticated$;
-	readonly username$ = this.authService.username$;
+  readonly isAuthenticated$ = this.authService.isAuthenticated$;
+  readonly username$ = this.authService.username$;
+  readonly canClockInOut$ = this.authService.permissions$.pipe(
+    map(
+      (permissions) =>
+        permissions.realmRoles.includes('timelog_user') ||
+        (permissions.clientRoles['janus-frontend'] ?? []).includes('timelog_user'),
+    ),
+  );
 
-	private latestTimeLog?: TimeLog;
+  private latestTimeLog?: TimeLog;
 
-	tableRefreshToken = 0;
+  tableRefreshToken = 0;
 
-	employeeEmail!: string;
+  employeeEmail!: string;
 
-	ngOnInit(): void {
-	  this.username$
-	    .pipe(
-	      filter((username): username is string => !!username),
-	      takeUntilDestroyed(this.destroyRef)
-	    )
-	    .subscribe((username) => {
-	      this.employeeEmail = username;
-	      this.refreshLatestTimeLog(username);
-	    });
-	}
+  ngOnInit(): void {
+    this.username$
+      .pipe(
+        filter((username): username is string => !!username),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((username) => {
+        this.employeeEmail = username;
+        this.refreshLatestTimeLog(username);
+      });
+  }
 
-	async onClockAction(): Promise<void> {
-		if (this.isClockActionLoading) {
-			return;
-		}
+  async onClockAction(): Promise<void> {
+    if (this.isClockActionLoading) {
+      return;
+    }
 
-		this.isClockActionLoading = true;
+    if (
+      !this.authService.hasRealmRole('timelog_user') &&
+      !this.authService.hasClientRole('janus-frontend', 'timelog_user')
+    ) {
+      return;
+    }
 
-		try {
-			const email = await firstValueFrom(
-				this.username$.pipe(filter((u): u is string => !!u))
-			);
+    this.isClockActionLoading = true;
 
-			const worksiteCode = this.latestTimeLog?.worksiteCode ?? this.defaultWorksiteCode;
+    try {
+      const email = await firstValueFrom(this.username$.pipe(filter((u): u is string => !!u)));
 
-			const action$ = this.shouldClockOut()
-				? this.timeLogService.clockOut(email, worksiteCode)
-				: this.timeLogService.clockIn(email, worksiteCode);
+      const worksiteCode = this.latestTimeLog?.worksiteCode ?? this.defaultWorksiteCode;
 
-			action$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-				next: (timeLog) => {
-					this.latestTimeLog = timeLog;
-					this.clockActionLabelKey = this.getClockActionLabelKey(timeLog);
-					this.tableRefreshToken += 1;
-				},
-				error: () => {
-					this.isClockActionLoading = false;
-				},
-				complete: () => {
-					this.isClockActionLoading = false;
-				}
-			});
-		} catch {
-			this.isClockActionLoading = false;
-		}
-	}
+      const action$ = this.shouldClockOut()
+        ? this.timeLogService.clockOut(email, worksiteCode)
+        : this.timeLogService.clockIn(email, worksiteCode);
 
-	private refreshLatestTimeLog(username: string): void {
-		this.timeLogService
-			.searchByEmployee(username, 1, 5)
-			.pipe(takeUntilDestroyed(this.destroyRef))
-			.subscribe({
-				next: (response) => {
-					this.latestTimeLog = this.getLatestTimeLog(response);
-					this.clockActionLabelKey = this.getClockActionLabelKey(this.latestTimeLog);
-				},
-				error: () => {
-					this.latestTimeLog = undefined;
-					this.clockActionLabelKey = 'timelog.clockin';
-				}
-			});
-	}
+      action$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+        next: (timeLog) => {
+          this.latestTimeLog = timeLog;
+          this.clockActionLabelKey = this.getClockActionLabelKey(timeLog);
+          this.tableRefreshToken += 1;
+        },
+        error: () => {
+          this.isClockActionLoading = false;
+        },
+        complete: () => {
+          this.isClockActionLoading = false;
+        },
+      });
+    } catch {
+      this.isClockActionLoading = false;
+    }
+  }
 
-	private shouldClockOut(): boolean {
-		return !!this.latestTimeLog && !this.extractExitTime(this.latestTimeLog.exitTime);
-	}
+  private refreshLatestTimeLog(username: string): void {
+    this.timeLogService
+      .searchByEmployee(username, 1, 5)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          this.latestTimeLog = this.getLatestTimeLog(response);
+          this.clockActionLabelKey = this.getClockActionLabelKey(this.latestTimeLog);
+        },
+        error: () => {
+          this.latestTimeLog = undefined;
+          this.clockActionLabelKey = 'timelog.clockin';
+        },
+      });
+  }
 
-	private getClockActionLabelKey(timeLog?: TimeLog): string {
-		if (!timeLog) {
-			return 'timelog.clockin';
-		}
-		return this.extractExitTime(timeLog.exitTime) ? 'timelog.clockin' : 'timelog.clockout';
-	}
+  private shouldClockOut(): boolean {
+    return !!this.latestTimeLog && !this.extractExitTime(this.latestTimeLog.exitTime);
+  }
 
-	private getLatestTimeLog(timeLogs: TimeLog[]): TimeLog | undefined {
-		return timeLogs.reduce<TimeLog | undefined>((latest, current) => {
-			if (!latest) {
-				return current;
-			}
-			return new Date(current.entryTime).getTime() > new Date(latest.entryTime).getTime()
-				? current
-				: latest;
-		}, undefined);
-	}
+  private getClockActionLabelKey(timeLog?: TimeLog): string {
+    if (!timeLog) {
+      return 'timelog.clockin';
+    }
+    return this.extractExitTime(timeLog.exitTime) ? 'timelog.clockin' : 'timelog.clockout';
+  }
 
-	private extractExitTime(exitTime: TimeLog['exitTime']): string | null {
-		if (!exitTime) {
-			return null;
-		}
-		if (typeof exitTime === 'string') {
-			return exitTime;
-		}
-		return exitTime ?? null;
-	}
+  private getLatestTimeLog(timeLogs: TimeLog[]): TimeLog | undefined {
+    return timeLogs.reduce<TimeLog | undefined>((latest, current) => {
+      if (!latest) {
+        return current;
+      }
+      return new Date(current.entryTime).getTime() > new Date(latest.entryTime).getTime()
+        ? current
+        : latest;
+    }, undefined);
+  }
+
+  private extractExitTime(exitTime: TimeLog['exitTime']): string | null {
+    if (!exitTime) {
+      return null;
+    }
+    if (typeof exitTime === 'string') {
+      return exitTime;
+    }
+    return exitTime ?? null;
+  }
 }


### PR DESCRIPTION
### Motivation
- Fix a broken login template that prevented Angular compilation and restore a successful build. 
- Surface richer Keycloak identity/authorization data in the app and enable route-level role checks so navigation and UI can be conditioned by realm/client roles.
- Condition dashboard clock in/out UI and actions on the effective permissions of the signed-in user.

### Description
- Fixed the `login-form` template by replacing an invalid `</div>` with `</form>` and removed the nonexistent `(click)="login()"` from the submit button to rely on `(ngSubmit)="submit()"`.
- Extended `AuthService` to publish `claims$`, `userProfile$` and `permissions$`, added `getClaims()`, `getUserProfile()`, `hasRealmRole()` and `hasClientRole()`, implemented `extractPermissions()` and `loadUserProfile()`, and wired Keycloak event handlers to sync state.
- Updated `auth.guard` to accept route `data` containing `realmRole` and `clientRole` and to allow/redirect based on `AuthService` role checks.
- Added `clientRole` data to the root route in `app.routes` for the `timelog_user` client role.
- Updated dashboard component and template to expose `canClockInOut$`, use `*ngIf` to hide the clock button when unauthorized, and guard the `onClockAction()` call with role checks.

### Testing
- Before the fix, `npm run build` in `apps/frontend` failed due to the malformed login template (Angular template error). 
- After applying the template fix and related removals, `npm run build` in `apps/frontend` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0be303648327ae800f37449fc86c)