### PR TITLE
Unificar realm e issuer de Keycloak en configuración de despliegue

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ mvn clean install
 java -jar Janus.jar
 ```
 
+## Realm configuration (single source of truth)
+
+Use **`janus-realm`** as the unique Keycloak realm across all components to keep token issuer validation aligned:
+
+- Docker backend issuer: `deploy/docker/compose.yml` (`SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI`)
+- Frontend Keycloak config: `apps/frontend/src/environments/environment.ts` and `environment.prod.ts`
+- Imported Keycloak realm: `deploy/docker/keycloak/realm-export.json`
+
+If you ever change the realm, update all three places in the same commit.
+
 ## Docker (quick start/stop)
 
 From the project root, you can use these scripts:

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       # issuer interno (docker) con /auth
-      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak:8080/auth/realms/mi-realm
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak:8080/auth/realms/janus-realm
     depends_on:
       - postgres
       - keycloak


### PR DESCRIPTION
### Motivation

- Evitar desalineaciones entre el issuer del backend, la configuración del frontend y el realm importado en Keycloak que pueden romper la validación de tokens.
- Normalizar un único valor de realm para todo el despliegue y así facilitar cambios futuros.
- Hacer explícito el punto único de verdad (single source of truth) para el `realm` en la documentación del proyecto.

### Description

- Actualiza `deploy/docker/compose.yml` para que la variable `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI` apunte a `http://keycloak:8080/auth/realms/janus-realm` en lugar de `mi-realm`.
- Añade una sección en `README.md` titulada "Realm configuration (single source of truth)" que documenta que el realm único es `janus-realm` y enumera los archivos a mantener sincronizados: `deploy/docker/compose.yml`, `apps/frontend/src/environments/environment.ts`, `apps/frontend/src/environments/environment.prod.ts` y `deploy/docker/keycloak/realm-export.json`.
- Verifica que `apps/frontend/src/environments/environment.ts`, `apps/frontend/src/environments/environment.prod.ts` y `deploy/docker/keycloak/realm-export.json` ya usan `janus-realm` y por tanto quedan consistentes con el cambio.

### Testing

- Ejecuté `rg -n "mi-realm|janus-realm|SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI|realm" deploy/docker/compose.yml apps/frontend/src/environments/environment*.ts deploy/docker/keycloak/realm-export.json README.md` y la búsqueda devolvió las referencias esperadas (coincidencias con `janus-realm`).
- Inspeccioné los archivos con `sed`/`nl` para confirmar las líneas modificadas y existentes en `deploy/docker/compose.yml`, `apps/frontend/src/environments/environment*.ts` y `deploy/docker/keycloak/realm-export.json`, y todas las comprobaciones automatizadas fueron satisfactorias.
- Ejecuté `git status --short` para verificar el estado del repositorio y las modificaciones quedaron preparadas y confirmadas en un commit exitoso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1916a260832786f0bf8ab13abae0)