### PR TITLE
Rename TimeLogResponse component worksiteTimeZone to worksiteZoneId

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/timelog/TimeLogResponse.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/timelog/TimeLogResponse.java
@@ -45,7 +45,7 @@ import es.nivel36.janus.service.worksite.Worksite;
  * @param exitTime       the timestamp when the employee clocked out; may be
  *                       absent if the employee is still working;
  */
-public record TimeLogResponse(String employeeEmail, String worksiteCode, ZoneId worksiteTimeZone, Instant entryTime,
+public record TimeLogResponse(String employeeEmail, String worksiteCode, ZoneId worksiteZoneId, Instant entryTime,
 		@JsonInclude(JsonInclude.Include.NON_ABSENT) JsonNullable<Instant> exitTime,
 		JsonNullable<DurationResponse> workTime) {
 }

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/timelog/TimeLogResponseMapper.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/timelog/TimeLogResponseMapper.java
@@ -53,7 +53,7 @@ public class TimeLogResponseMapper implements Mapper<TimeLog, TimeLogResponse> {
 		final String employeeEmail = employee.getEmail();
 		final String worksiteCode = worksite.getCode();
 
-		final ZoneId worksiteTimeZone = worksite.getTimeZone();
+		final ZoneId worksiteZoneId = worksite.getTimeZone();
 
 		final Instant entryTime = entity.getEntryTime();
 		final Instant exitTimeValue = entity.getExitTime();
@@ -63,7 +63,7 @@ public class TimeLogResponseMapper implements Mapper<TimeLog, TimeLogResponse> {
 		final DurationResponse workDurationResponse = mapWorkDuration(workDurationValue);
 		final JsonNullable<DurationResponse> workTime = toJsonNullable(workDurationResponse);
 
-		return new TimeLogResponse(employeeEmail, worksiteCode, worksiteTimeZone, entryTime, exitTime, workTime);
+		return new TimeLogResponse(employeeEmail, worksiteCode, worksiteZoneId, entryTime, exitTime, workTime);
 	}
 
 	private DurationResponse mapWorkDuration(final Duration duration) {


### PR DESCRIPTION
### Motivation
- Alinear el nombre serializado del campo de la respuesta con el contrato/frontend, exponiendo `worksiteZoneId` en lugar de `worksiteTimeZone`.

### Description
- Renombrado el componente del record en `apps/backend/src/main/java/es/nivel36/janus/api/v1/timelog/TimeLogResponse.java` de `worksiteTimeZone` a `worksiteZoneId` y actualizado el mapper en `apps/backend/src/main/java/es/nivel36/janus/api/v1/timelog/TimeLogResponseMapper.java` para construir el record con el nuevo nombre; el modelo frontend en `apps/frontend/src/app/features/timelogs/models/timelog.ts` ya usa `worksiteZoneId` y no requirió cambios.

### Testing
- Ejecuté `./mvnw test` en `apps/backend` y todos los tests automatizados finalizaron con éxito (`BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1be8d6c083278caef61ad84e5712)