### PR TITLE
fix(nginx): preserve /api prefix when proxying backend

### DIFF
--- a/deploy/nginx/conf.d/app.conf
+++ b/deploy/nginx/conf.d/app.conf
@@ -12,7 +12,7 @@ server {
 
   # API Spring Boot
   location /api/ {
-    proxy_pass http://backend:8080/;
+    proxy_pass http://backend:8080;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### Motivation
- Evitar que Nginx elimine el prefijo `/api` al proxy_pass para que rutas como `/api/v1/employees/...` lleguen al backend exactamente con el mismo path y mantener consistencia con `apiUrl: '/api/v1'` del frontend.

### Description
- Cambiado `deploy/nginx/conf.d/app.conf` en el bloque `location /api/` para usar `proxy_pass http://backend:8080;` (sin slash final), preservando el path original en las solicitudes proxyeadas.

### Testing
- Verifiqué la coincidencia entre la configuración y el frontend ejecutando `rg -n "apiUrl|apiBaseUrl" apps/frontend/src/environments/environment.prod.ts deploy/nginx/conf.d/app.conf`, y el resultado es consistente con la intención del cambio.
- Inspeccioné el diff y confirmé el cambio con `git diff` y `git commit`, y el commit se creó correctamente.
- Intenté comprobaciones runtime con `nginx -v` y `docker --version`, pero ambas herramientas no están disponibles en el entorno y por tanto esas verificaciones no pudieron ejecutarse.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1d01c33c8327a169282e36f18383)