### PR TITLE
Fix 0-based pagination usage in employee timelog search

### DIFF
--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
@@ -109,7 +109,7 @@ export class DashboardPageComponent implements OnInit {
 
   private refreshLatestTimeLog(username: string): void {
     this.timeLogService
-      .searchByEmployee(username, 1, 5)
+      .searchByEmployee(username, 0, 5)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {

--- a/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
+++ b/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
@@ -10,6 +10,9 @@ export class TimeLogService {
 
 	constructor(private readonly http: HttpClient) { }
 
+	/**
+	 * The `page` parameter follows Spring Data pagination (0-based index).
+	 */
 	searchByEmployee(email: string, page?: number, size?: number): Observable<TimeLog[]> {
 	  let params = new HttpParams();
 	  if (page != null) params = params.set('page', String(page));


### PR DESCRIPTION
### Motivation
- The dashboard requested page `1` when fetching an employee's timelogs, but the backend pagination follows Spring Data's 0-based convention, so the first page must be requested as `0` to get the expected results.

### Description
- Updated the dashboard latest timelog fetch to call `searchByEmployee(username, 0, 5)` and added an inline doc comment to `TimeLogService.searchByEmployee` noting that the `page` parameter is Spring Data 0-based, and reviewed other frontend usages to ensure no other 1-based calls exist.

### Testing
- Verified usages with `rg "searchByEmployee\(" apps/frontend/src/app -n`, checked working tree with `git status --short`, and committed the changes with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1dc2c10c83278dfa256c9f84deb4)