### PR TITLE
chore(frontend): remove unused login-form CSS selectors

### DIFF
--- a/apps/frontend/src/app/auth/login-form/login-form.component.css
+++ b/apps/frontend/src/app/auth/login-form/login-form.component.css
@@ -4,31 +4,6 @@
 	gap: 1.5rem;
 }
 
-.login-field {
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
-	font-size: 0.9rem;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
-	color: rgba(249, 249, 249, 0.68);
-}
-
-.login-field input {
-	border-radius: 16px;
-	border: 1px solid rgba(249, 214, 0, 0.2);
-	background: #050505;
-	color: #f9f9f9;
-	padding: 0.85rem 1rem;
-	font-size: 1rem;
-	letter-spacing: 0.04em;
-}
-
-.login-field input:focus {
-	outline: 2px solid rgba(249, 214, 0, 0.6);
-	outline-offset: 2px;
-}
-
 .login-error {
 	margin: 0;
 	color: #ff6b6b;


### PR DESCRIPTION
### Motivation
- Limpiar estilos muertos del componente de login para evitar selectores huérfanos y reducir el CSS mantenido en `apps/frontend/src/app/auth/login-form/login-form.component.css`.

### Description
- Eliminadas las reglas `.login-field`, `.login-field input` y `.login-field input:focus` del archivo `login-form.component.css` y se preservaron únicamente `.login-form`, `.login-error` y `.login-submit` que son referenciadas por la plantilla actual.
- No se realizaron cambios en el template `login-form.component.html` más allá de validar las clases usadas.

### Testing
- Ejecutado `rg -n "login-field|login-form|login-error|login-submit"` para confirmar que solo quedan las clases activas en los archivos del componente, y la verificación pasó.
- Ejecutado `npm run ng -- lint` que falló porque el proyecto Angular no tiene un target `lint` configurado, por lo que no hay linter disponible en este entorno.
- Ejecutado `npm run build` en `apps/frontend` y la compilación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2250ae44832797b9193e31705fc9)