### PR TITLE
fix(frontend): redirect unauthorized users to /login via UrlTree in authGuard

### DIFF
--- a/apps/frontend/src/app/core/auth/auth.guard.ts
+++ b/apps/frontend/src/app/core/auth/auth.guard.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
 import { map, take } from 'rxjs';
 
 import { AuthService } from './auth.service';
@@ -19,7 +19,7 @@ export const authGuard: CanActivateFn = (route, state): ReturnType<CanActivateFn
 
   return authService.isAuthenticated$.pipe(
     take(1),
-    map((isAuthenticated): boolean => {
+    map((isAuthenticated): boolean | UrlTree => {
       if (!isAuthenticated) {
         const targetUrl = state.url ? router.serializeUrl(router.parseUrl(state.url)) : '/';
         void authService.loginWithRedirect(targetUrl);
@@ -37,8 +37,7 @@ export const authGuard: CanActivateFn = (route, state): ReturnType<CanActivateFn
         return true;
       }
 
-      void router.navigateByUrl('/');
-      return false;
+      return router.parseUrl('/login');
     }),
   );
 };


### PR DESCRIPTION
### Motivation
- Evitar que al volver de Keycloak la aplicación entre en un bucle de navegación sobre la ruta protegida y quede en blanco cuando el usuario está autenticado pero no tiene los roles requeridos.

### Description
- Cambiado en `apps/frontend/src/app/core/auth/auth.guard.ts` la importación y uso de `UrlTree` y la firma del `map` para devolver `boolean | UrlTree`, reemplazando el `router.navigateByUrl('/')` por `return router.parseUrl('/login')` para que el enrutador realice el redireccionamiento desde el propio guard.

### Testing
- Ejecutado `cd apps/frontend && npm run build` y la compilación de la aplicación frontend completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34dfb57888327bf901ab3a70e9e45)