### PR TITLE
Align Keycloak realm export with janus-realm

### DIFF
--- a/deploy/docker/keycloak/realm-export.json
+++ b/deploy/docker/keycloak/realm-export.json
@@ -1,5 +1,5 @@
 {
-  "realm": "Nivel36-realm",
+  "realm": "janus-realm",
   "enabled": true,
 
   "roles": {


### PR DESCRIPTION
### Motivation
- Ensure the Keycloak realm exported in the repo matches the application configuration so the realm import and JWT issuer references resolve correctly.

### Description
- Replaced the realm name in `deploy/docker/keycloak/realm-export.json` from `Nivel36-realm` to `janus-realm` so it matches application configuration.
- Verified the existing `clients`, `roles` and `users` entries remain coherent under the renamed realm (client `janus-spa`, role `JANUS_USER`, user with `realmRoles: ["JANUS_USER"]`).
- Confirmed application configuration already points to `janus-realm` in `apps/frontend/src/environments/environment.ts`, `apps/frontend/src/environments/environment.prod.ts`, and in the Docker Compose issuer URI `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI` in `deploy/docker/compose.yml`.
- Documented local reimport steps to get a clean Keycloak import by removing the `pg_keycloak` volume and restarting the compose stack (to be run locally where Docker is available).

### Testing
- Inspected the modified export with `sed`/`nl` and searched for expected fields with `rg`, confirming the realm value is now `janus-realm` and `clients`/`roles`/`users` are present, and these checks succeeded.
- Verified `apps/frontend/src/environments/environment.ts` and `apps/frontend/src/environments/environment.prod.ts` contain `realm: 'janus-realm'`, and confirmed the compose file issuer URI includes `/realms/janus-realm`, and these checks succeeded.
- Attempted to run `docker compose -f deploy/docker/compose.yml down` to perform a clean reimport, but the Docker CLI is not available in this environment (`bash: command not found: docker`), so the runtime reimport test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3544d9b3483278b3517414ba79a34)