### PR TITLE
fix(frontend): align role checks with configured Keycloak client id

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -1,13 +1,14 @@
 import { Routes } from '@angular/router';
 import { AUTH_ROUTES } from './auth/auth.routes';
 import { authGuard } from './core/auth/auth.guard';
+import { KEYCLOAK_CLIENT_ID } from './core/auth/keycloak.constants';
 
 export const appRoutes: Routes = [
   {
     path: '',
     canActivate: [authGuard],
     data: {
-      clientRole: { clientId: 'janus-frontend', role: 'timelog_user' },
+      clientRole: { clientId: KEYCLOAK_CLIENT_ID, role: 'timelog_user' },
     },
     loadComponent: () =>
       import('./features/dashboard/pages/dashboard-page.component').then(

--- a/apps/frontend/src/app/core/auth/keycloak.constants.ts
+++ b/apps/frontend/src/app/core/auth/keycloak.constants.ts
@@ -1,0 +1,3 @@
+import { environment } from '../../../environments/environment';
+
+export const KEYCLOAK_CLIENT_ID = environment.keycloak.clientId;

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
@@ -12,6 +12,7 @@ import { TimelogTableComponent } from '../../timelogs/components/timelog-table/t
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { TimeLogService } from '../../timelogs/services/timelog-api.service';
 import { TimeLog } from '../../timelogs/models/timelog';
+import { KEYCLOAK_CLIENT_ID } from '../../../core/auth/keycloak.constants';
 
 @Component({
   selector: 'app-dashboard-page',
@@ -44,7 +45,7 @@ export class DashboardPageComponent implements OnInit {
     map(
       (permissions) =>
         permissions.realmRoles.includes('timelog_user') ||
-        (permissions.clientRoles['janus-frontend'] ?? []).includes('timelog_user'),
+        (permissions.clientRoles[KEYCLOAK_CLIENT_ID] ?? []).includes('timelog_user'),
     ),
   );
 
@@ -73,7 +74,7 @@ export class DashboardPageComponent implements OnInit {
 
     if (
       !this.authService.hasRealmRole('timelog_user') &&
-      !this.authService.hasClientRole('janus-frontend', 'timelog_user')
+      !this.authService.hasClientRole(KEYCLOAK_CLIENT_ID, 'timelog_user')
     ) {
       return;
     }


### PR DESCRIPTION
### Motivation
- Keycloak realm export defines the SPA client as `janus-spa` while some frontend checks used the hardcoded `janus-frontend`, causing client-role lookups to misalign.
- Centralize the client id so role checks and route metadata always use the same configured value and avoid future divergence.

### Description
- Added `apps/frontend/src/app/core/auth/keycloak.constants.ts` which exports `KEYCLOAK_CLIENT_ID` from `environment.keycloak.clientId`.
- Updated `apps/frontend/src/app/app.routes.ts` to use `KEYCLOAK_CLIENT_ID` for the route `clientRole.clientId` instead of the literal `janus-frontend`.
- Updated `apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts` to use `KEYCLOAK_CLIENT_ID` in `permissions.clientRoles[...]` lookups and in calls to `hasClientRole(...)`.
- Left `apps/frontend/src/environments/environment.ts` and `environment.prod.ts` as the source of truth (they already contain `clientId: 'janus-spa'`).

### Testing
- Ran the frontend build with `npm --prefix apps/frontend run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35a6eeac48327a8cc5253fd9caa67)