### PR TITLE
fix(frontend): return UrlTree for unauthorized auth guard redirects

### DIFF
--- a/apps/frontend/src/app/core/auth/auth.guard.ts
+++ b/apps/frontend/src/app/core/auth/auth.guard.ts
@@ -19,7 +19,7 @@ export const authGuard: CanActivateFn = (route, state): ReturnType<CanActivateFn
 
   return authService.isAuthenticated$.pipe(
     take(1),
-    map((isAuthenticated): boolean => {
+    map((isAuthenticated) => {
       if (!isAuthenticated) {
         const targetUrl = state.url ? router.serializeUrl(router.parseUrl(state.url)) : '/';
         void authService.loginWithRedirect(targetUrl);
@@ -37,8 +37,7 @@ export const authGuard: CanActivateFn = (route, state): ReturnType<CanActivateFn
         return true;
       }
 
-      void router.navigateByUrl('/');
-      return false;
+      return router.parseUrl('/login');
     }),
   );
 };


### PR DESCRIPTION
### Motivation
- Prevent recursive router navigation by resolving the guard with a `UrlTree` when a user lacks the required roles so Angular can handle the redirect safely.

### Description
- Replace the imperative `router.navigateByUrl('/')` + `false` with `return router.parseUrl('/login')` in `apps/frontend/src/app/core/auth/auth.guard.ts` so the guard returns a `UrlTree` for unauthorized users.

### Testing
- Ran `npm run build` in `apps/frontend`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35a6b85f08327869d926cd3487ebd)