### PR TITLE
Fix login redirect loop after authentication

### DIFF
--- a/apps/frontend/src/app/auth/login-form/login-form.component.ts
+++ b/apps/frontend/src/app/auth/login-form/login-form.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 
 import { AuthService } from '../../core/auth/auth.service';
@@ -16,7 +15,7 @@ export class LoginFormComponent {
   isLoading = false;
   errorMessage = '';
 
-  constructor(private authService: AuthService, private router: Router) {}
+  constructor(private authService: AuthService) {}
 
   submit(): void {
     if (this.isLoading) return;
@@ -25,8 +24,7 @@ export class LoginFormComponent {
     this.errorMessage = '';
 
     void this.authService
-      .login()
-      .then(() => this.router.navigate(['/']))
+      .loginWithRedirect('/')
       .catch(() => {
         this.errorMessage = 'login.error';
       })

--- a/apps/frontend/src/app/auth/login-page/login-page.component.ts
+++ b/apps/frontend/src/app/auth/login-page/login-page.component.ts
@@ -1,17 +1,30 @@
-import { Component } from '@angular/core';
-import { LoginFormComponent } from '../login-form/login-form.component';
-import { CardComponent } from '../../shared/ui/card/card.component'
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
+import { take } from 'rxjs';
+
+import { AuthService } from '../../core/auth/auth.service';
+import { LoginFormComponent } from '../login-form/login-form.component';
+import { CardComponent } from '../../shared/ui/card/card.component';
 
 @Component({
   standalone: true,
   selector: 'app-login-page',
   templateUrl: './login-page.component.html',
   styleUrls: ['./login-page.component.css'],
-  imports: [
-    LoginFormComponent,
-    CardComponent,
-    TranslatePipe
-  ],
+  imports: [LoginFormComponent, CardComponent, TranslatePipe],
 })
-export class LoginPageComponent {}
+export class LoginPageComponent implements OnInit {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.authService.isAuthenticated$.pipe(take(1)).subscribe((isAuthenticated) => {
+      if (isAuthenticated) {
+        void this.router.navigate(['/']);
+      }
+    });
+  }
+}


### PR DESCRIPTION
### Motivation

- The app could enter a cyclic redirect where authenticating on `/login` returned the user to `/login` and re-triggered the flow, so the user never reached the app root.

### Description

- Updated `LoginFormComponent` to call `loginWithRedirect('/')` instead of `login()` so Keycloak returns users to the app root after authentication and removed the now-unused `Router` injection in `login-form.component.ts`.
- Added a defensive redirect in `LoginPageComponent` that subscribes to `isAuthenticated$` and navigates to `/` when the user is already authenticated to avoid landing on `/login` after a successful callback.
- Modified files: `apps/frontend/src/app/auth/login-form/login-form.component.ts` and `apps/frontend/src/app/auth/login-page/login-page.component.ts`.

### Testing

- Ran `npm run build` in `apps/frontend` and the production build completed successfully.
- Verified changes were committed to the repository with the message `Fix login redirect loop after authentication` and a PR was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3748de55c8327a4f833e3c764a2ee)