### PR TITLE
feat(frontend): show permission feedback on clock action

### DIFF
--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.css
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.css
@@ -93,3 +93,15 @@
 		align-items: flex-start;
 	}
 }
+
+
+.clock-action-feedback {
+	margin: 1rem 0 0;
+	padding: 0.625rem 0.875rem;
+	border-radius: 0.625rem;
+	background-color: rgba(204, 59, 59, 0.16);
+	border: 1px solid rgba(204, 59, 59, 0.48);
+	color: #ffd8d8;
+	font-size: 0.875rem;
+	font-weight: 500;
+}

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
@@ -22,6 +22,13 @@
                                 {{ clockActionLabelKey | translate }}
                             </app-button>
                         }
+
+                        @if (clockActionFeedbackKey) {
+                            <p class="clock-action-feedback" role="status" aria-live="polite">
+                                {{ clockActionFeedbackKey | translate }}
+                            </p>
+                        }
+
                     </ng-template>
                 </app-card>
 

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
@@ -39,12 +39,17 @@ export class DashboardPageComponent implements OnInit {
   private readonly defaultWorksiteCode = 'BCN-HQ';
 
   clockActionLabelKey = 'timelog.clockin';
+  clockActionFeedbackKey?: string;
   isClockActionLoading = false;
 
   readonly isAuthenticated$ = this.authService.isAuthenticated$;
   readonly username$ = this.authService.username$;
   readonly canClockInOut$ = this.authService.permissions$.pipe(
-    map((permissions) => permissions.realmRoles.includes('JANUS_USER')),
+    map(
+      (permissions) =>
+        permissions.realmRoles.includes('timelog_user') ||
+        (permissions.clientRoles[KEYCLOAK_CLIENT_ID] ?? []).includes('timelog_user'),
+    ),
   );
 
   private latestTimeLog?: TimeLog;
@@ -74,9 +79,11 @@ export class DashboardPageComponent implements OnInit {
       !this.authService.hasRealmRole('timelog_user') &&
       !this.authService.hasClientRole(KEYCLOAK_CLIENT_ID, 'timelog_user')
     ) {
+      this.clockActionFeedbackKey = 'timelog.clockActionPermissionDenied';
       return;
     }
 
+    this.clockActionFeedbackKey = undefined;
     this.isClockActionLoading = true;
 
     try {
@@ -92,9 +99,11 @@ export class DashboardPageComponent implements OnInit {
         next: (timeLog) => {
           this.latestTimeLog = timeLog;
           this.clockActionLabelKey = this.getClockActionLabelKey(timeLog);
+          this.clockActionFeedbackKey = undefined;
           this.tableRefreshToken += 1;
         },
         error: () => {
+          this.clockActionFeedbackKey = 'timelog.clockActionNetworkError';
           this.isClockActionLoading = false;
         },
         complete: () => {

--- a/apps/frontend/src/assets/i18n/ca.json
+++ b/apps/frontend/src/assets/i18n/ca.json
@@ -8,7 +8,9 @@
 		"clockout": "Sortida",
 		"date": "Data",
 		"duration": "Duració",
-		"timelogs": "Fixatges"
+		"timelogs": "Fixatges",
+		"clockActionPermissionDenied": "No tens permisos per fitxar.",
+		"clockActionNetworkError": "No s'ha pogut registrar el fitxatge en aquest moment. Torna-ho a provar."
 	},
 	"employee": {
 		"employee": "Empleat",

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -8,7 +8,9 @@
 		"clockout": "Clock out",
 		"date": "Date",
 		"duration": "Duration",
-		"timelogs": "Time logs"
+		"timelogs": "Time logs",
+		"clockActionPermissionDenied": "You do not have permission to clock in or out.",
+		"clockActionNetworkError": "Unable to register your time action right now. Please try again."
 	},
 	"employee": {
 		"employee": "Employee",

--- a/apps/frontend/src/assets/i18n/es.json
+++ b/apps/frontend/src/assets/i18n/es.json
@@ -8,7 +8,9 @@
 		"clockout": "Salida",
 		"date": "Fecha",
 		"duration": "Duración",
-		"timelogs": "Fichajes"
+		"timelogs": "Fichajes",
+		"clockActionPermissionDenied": "No tienes permisos para fichar.",
+		"clockActionNetworkError": "No se pudo registrar el fichaje en este momento. Inténtalo de nuevo."
 	},
 	"employee": {
 		"employee": "Empleado",


### PR DESCRIPTION
### Motivation
- Provide explicit UI feedback when `onClockAction()` returns early due to missing timelog permissions. 
- Distinguish network/request failures from permission-denied so users see different messages for each case. 
- Keep the clock action button hidden/disabled for users without the `timelog_user` role to avoid useless clicks.

### Description
- Added `clockActionFeedbackKey?: string` to `DashboardPageComponent` and set it to `'timelog.clockActionPermissionDenied'` before the early `return` in `onClockAction()`.
- Updated `canClockInOut$` to check for the `timelog_user` realm role or client role (`KEYCLOAK_CLIENT_ID`) and aligned the template so the button is hidden when unauthorized.
- Set `clockActionFeedbackKey = 'timelog.clockActionNetworkError'` on request error and clear the feedback on successful responses; preserved the early `return` guard.
- Added an inline feedback element in `dashboard-page.component.html`, styles in `dashboard-page.component.css`, and new translation keys in `apps/frontend/src/assets/i18n/en.json`, `es.json`, and `ca.json`.

### Testing
- Ran `npm run build` in `apps/frontend` and the build completed successfully.
- Started the dev server (`npm run start`) which compiled and served in watch mode.
- Attempted an automated Playwright screenshot to validate the UI, but the Chromium run crashed (`TargetClosedError` / `SIGSEGV`) so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cc8a9e9c8327bb89f148cbd6bc80)