### PR TITLE
Harden Docker Compose deployment: parameterize secrets, add healthchecks, fix stop script messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ access tokens issued by the configured realm (`issuer-uri`).
 - Login/logout UX should call Keycloak endpoints via the frontend Keycloak client.
 - Backend authorization for `/api/**` depends on a valid bearer token only.
 
+
+### Deployment hardening notes
+
+The compose files now support overriding sensitive defaults via environment variables:
+
+- `APP_DB_PASSWORD`
+- `KEYCLOAK_DB_PASSWORD`
+- `KEYCLOAK_ADMIN`
+- `KEYCLOAK_ADMIN_PASSWORD`
+
+If unset, local-development defaults are still applied.
+
+Both postgres services include healthchecks (`pg_isready`), and startup ordering waits for the Keycloak DB to be healthy before launching Keycloak.
+
 ## Docker (quick start/stop)
 
 From the project root, you can use these scripts:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The compose files now support overriding sensitive defaults via environment vari
 
 If unset, local-development defaults are still applied.
 
+`APP_DB_PASSWORD` is also propagated to the backend datasource (`JANUS_DATASOURCE_PASSWORD`) in Docker deployment so database credentials stay aligned.
+
 Both postgres services include healthchecks (`pg_isready`), and startup ordering waits for the Keycloak DB to be healthy before launching Keycloak.
 
 ## Docker (quick start/stop)

--- a/deploy/docker/compose.dev.yml
+++ b/deploy/docker/compose.dev.yml
@@ -4,9 +4,14 @@ services:
     environment:
       POSTGRES_DB: app
       POSTGRES_USER: app
-      POSTGRES_PASSWORD: app
+      POSTGRES_PASSWORD: ${APP_DB_PASSWORD:-app}
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - pg_app:/var/lib/postgresql/data
 
@@ -15,9 +20,14 @@ services:
     environment:
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak
-      POSTGRES_PASSWORD: keycloak
+      POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD:-keycloak}
     ports:
       - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keycloak -d keycloak"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - pg_keycloak:/var/lib/postgresql/data
 
@@ -25,12 +35,12 @@ services:
     image: quay.io/keycloak/keycloak:26.0
     command: ["start-dev", "--import-realm"]
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres_keycloak:5432/keycloak
       KC_DB_USERNAME: keycloak
-      KC_DB_PASSWORD: keycloak
+      KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD:-keycloak}
       KC_HTTP_RELATIVE_PATH: /auth
       KC_PROXY_HEADERS: xforwarded
     ports:
@@ -38,7 +48,8 @@ services:
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     depends_on:
-      - postgres_keycloak
+      postgres_keycloak:
+        condition: service_healthy
 
   grafana:
     image: grafana/grafana:11.2.0

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -18,15 +18,22 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak:8080/auth/realms/janus-realm
     depends_on:
-      - postgres
-      - keycloak
+      postgres:
+        condition: service_healthy
+      keycloak:
+        condition: service_started
 
   postgres:
     image: postgres:16
     environment:
       POSTGRES_DB: app
       POSTGRES_USER: app
-      POSTGRES_PASSWORD: app
+      POSTGRES_PASSWORD: ${APP_DB_PASSWORD:-app}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - pg_app:/var/lib/postgresql/data
 
@@ -35,7 +42,12 @@ services:
     environment:
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak
-      POSTGRES_PASSWORD: keycloak
+      POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD:-keycloak}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keycloak -d keycloak"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - pg_keycloak:/var/lib/postgresql/data
 
@@ -43,18 +55,19 @@ services:
     image: quay.io/keycloak/keycloak:26.0
     command: ["start-dev", "--import-realm"]
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres_keycloak:5432/keycloak
       KC_DB_USERNAME: keycloak
-      KC_DB_PASSWORD: keycloak
+      KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD:-keycloak}
       KC_HTTP_RELATIVE_PATH: /auth
       KC_PROXY_HEADERS: xforwarded
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     depends_on:
-      - postgres_keycloak
+      postgres_keycloak:
+        condition: service_healthy
 
   grafana:
     image: grafana/grafana:11.2.0

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -17,6 +17,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak:8080/auth/realms/janus-realm
+      - JANUS_DATASOURCE_PASSWORD=${APP_DB_PASSWORD:-app}
     depends_on:
       postgres:
         condition: service_healthy

--- a/stop.sh
+++ b/stop.sh
@@ -60,9 +60,9 @@ fi
 
 read -r -a COMPOSE_CMD <<< "$COMPOSE_CMD_STR"
 
-echo "Starting services ($MODE) using: ${COMPOSE_CMD[*]}"
+echo "Stopping services ($MODE) using: ${COMPOSE_CMD[*]}"
 echo "Compose file: $COMPOSE_FILE"
 
 "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" down
 
-echo "Services started successfully."
+echo "Services stopped successfully."


### PR DESCRIPTION
### Motivation

- Improve deployment security and robustness by avoiding hard-coded database and admin credentials and making startup ordering resilient to database readiness. 
- Ensure local dev and prod compose files remain compatible while allowing overrides for sensitive values. 

### Description

- Parameterized sensitive defaults in `deploy/docker/compose.yml` and `deploy/docker/compose.dev.yml` using environment variable overrides: `APP_DB_PASSWORD`, `KEYCLOAK_DB_PASSWORD`, `KEYCLOAK_ADMIN`, and `KEYCLOAK_ADMIN_PASSWORD`. 
- Added `healthcheck` entries (using `pg_isready`) for both Postgres services and updated `depends_on` to wait for the database health where appropriate so Keycloak/backend start after DB readiness. 
- Fixed `stop.sh` informational messages to correctly reflect stopping behavior. 
- Documented the new deployment hardening notes in `README.md` explaining the env-vars and healthcheck behavior. 

### Testing

- Verified shell scripts syntax with `bash -n start.sh stop.sh restart.sh` which succeeded. 
- Parsed both compose files with Ruby YAML loader via `ruby -e "require 'yaml'; ['deploy/docker/compose.yml','deploy/docker/compose.dev.yml'].each{|f| YAML.load_file(f); puts \"#{f}: ok\" }"` which returned `ok` for both files. 
- Attempted to run `docker compose -f deploy/docker/compose.yml config` and `docker compose -f deploy/docker/compose.dev.yml config` but this step could not be executed because `docker` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b712547c4483278739b92e7b7187c3)