### PR TITLE
refactor(frontend): extract shared user card component

### DIFF
--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.css
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.css
@@ -57,43 +57,6 @@
 	text-transform: uppercase;
 }
 
-.clock-card {
-	background-color: #f9d600;
-	color: #040404;
-	border-radius: 20px;
-	padding: 2.5rem;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: 2rem;
-	box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.25);
-}
-
-.clock-info {
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
-}
-
-.clock-label {
-	text-transform: uppercase;
-	font-weight: 600;
-	letter-spacing: 0.18em;
-	font-size: 0.9rem;
-}
-
-.clock-time {
-	font-size: clamp(2.5rem, 5vw + 1rem, 3.5rem);
-	font-weight: 700;
-}
-
-@media ( max-width : 640px) {
-	.clock-card {
-		flex-direction: column;
-		align-items: flex-start;
-	}
-}
-
 
 .clock-action-feedback {
 	margin: 1rem 0 0;

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
@@ -40,31 +40,7 @@
 
             <!-- ASIDE -->
             <section class="aside">
-                <app-card styleClass="user-card">
-                    <ng-template #cardHeader>
-                        <div class="user-card-header-content">
-                            <img class="avatar" src="assets/images/user.png" alt="User avatar" />
-                            <span class="user-card-title">
-                                {{ 'employee.employee' | translate }}
-                            </span>
-                        </div>
-                    </ng-template>
-
-                    <div class="data">
-                        <h3>{{ 'employee.fullName' | translate }}</h3>
-                        <p>{{ fullName$ | async }}</p>
-                    </div>
-
-                    <div class="data">
-                        <h3>{{ 'employee.location' | translate }}</h3>
-                        <p>Barcelona Headquarters</p>
-                    </div>
-
-                    <div class="data">
-                        <h3>{{ 'employee.todaysHour' | translate }}</h3>
-                        <p>9:00 - 17:30</p>
-                    </div>
-                </app-card>
+                <app-user-card [fullName]="fullName$ | async"></app-user-card>
             </section>
         </section>
     </section>

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -11,11 +11,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AuthService } from '../../../core/auth/auth.service';
 import { ClockComponent } from '../../../shared/ui/clock/clock.component';
 import { CardComponent } from '../../../shared/ui/card/card.component';
+import { UserCardComponent } from '../../../shared/ui/user-card/user-card.component';
 import { TimelogTableComponent } from '../../timelogs/components/timelog-table/timelog-table.component';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { TimeLogService } from '../../timelogs/services/timelog-api.service';
 import { TimeLog } from '../../timelogs/models/timelog';
-import { KEYCLOAK_CLIENT_ID } from '../../../core/auth/keycloak.constants';
 
 @Component({
   selector: 'app-dashboard-page',
@@ -26,6 +26,7 @@ import { KEYCLOAK_CLIENT_ID } from '../../../core/auth/keycloak.constants';
     TranslatePipe,
     ClockComponent,
     CardComponent,
+    UserCardComponent,
     TimelogTableComponent,
     ButtonComponent,
   ],
@@ -42,14 +43,16 @@ export class DashboardPageComponent implements OnInit {
   clockActionFeedbackKey?: string;
   isClockActionLoading = false;
 
-  readonly isAuthenticated$ = this.authService.isAuthenticated$;
   readonly username$ = this.authService.username$;
   readonly canClockInOut$ = this.authService.permissions$.pipe(
     map((permissions) => permissions.realmRoles.includes('JANUS_USER')),
   );
 
   readonly fullName$ = this.authService.claims$.pipe(
-    map((c) => `${c?.given_name ?? ''} ${c?.family_name ?? ''}`.trim()),
+    map((c) => {
+      const claimFullName = `${c?.given_name ?? ''} ${c?.family_name ?? ''}`.trim();
+      return claimFullName || c?.name || c?.preferred_username || '';
+    }),
     distinctUntilChanged(),
   );
 

--- a/apps/frontend/src/app/shared/ui/user-card/user-card.component.css
+++ b/apps/frontend/src/app/shared/ui/user-card/user-card.component.css
@@ -1,0 +1,44 @@
+.user-card-header-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.avatar {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  object-fit: cover;
+  background-color: rgba(19, 19, 19, 0.12);
+}
+
+.user-card-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.data {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.data h3,
+.data p {
+  margin: 0;
+}
+
+.data h3 {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.data p {
+  font-size: 1rem;
+  font-weight: 600;
+}

--- a/apps/frontend/src/app/shared/ui/user-card/user-card.component.html
+++ b/apps/frontend/src/app/shared/ui/user-card/user-card.component.html
@@ -1,0 +1,25 @@
+<app-card styleClass="user-card">
+  <ng-template #cardHeader>
+    <div class="user-card-header-content">
+      <img class="avatar" [src]="avatarSrc" [alt]="avatarAlt" />
+      <span class="user-card-title">
+        {{ 'employee.employee' | translate }}
+      </span>
+    </div>
+  </ng-template>
+
+  <div class="data">
+    <h3>{{ 'employee.fullName' | translate }}</h3>
+    <p>{{ fullName || '—' }}</p>
+  </div>
+
+  <div class="data">
+    <h3>{{ 'employee.location' | translate }}</h3>
+    <p>{{ location }}</p>
+  </div>
+
+  <div class="data">
+    <h3>{{ 'employee.todaysHour' | translate }}</h3>
+    <p>{{ todaysHour }}</p>
+  </div>
+</app-card>

--- a/apps/frontend/src/app/shared/ui/user-card/user-card.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/user-card/user-card.component.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+
+import { UserCardComponent } from './user-card.component';
+
+describe('UserCardComponent', () => {
+  let component: UserCardComponent;
+  let fixture: ComponentFixture<UserCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserCardComponent],
+      providers: [provideTranslateService()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserCardComponent);
+    component = fixture.componentInstance;
+    component.fullName = 'Jane Doe';
+    fixture.detectChanges();
+  });
+
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the provided user data', () => {
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.textContent).toContain('Jane Doe');
+    expect(element.textContent).toContain('Barcelona Headquarters');
+    expect(element.textContent).toContain('9:00 - 17:30');
+  });
+});

--- a/apps/frontend/src/app/shared/ui/user-card/user-card.component.ts
+++ b/apps/frontend/src/app/shared/ui/user-card/user-card.component.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component, Input } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { CardComponent } from '../card/card.component';
+
+@Component({
+  selector: 'app-user-card',
+  standalone: true,
+  imports: [CardComponent, TranslatePipe],
+  templateUrl: './user-card.component.html',
+  styleUrl: './user-card.component.css',
+})
+export class UserCardComponent {
+  @Input() fullName: string | null = null;
+  @Input() location = 'Barcelona Headquarters';
+  @Input() todaysHour = '9:00 - 17:30';
+  @Input() avatarSrc = 'assets/images/user.png';
+  @Input() avatarAlt = 'User avatar';
+}


### PR DESCRIPTION
### Motivation
- Separar la tarjeta de usuario del markup del dashboard para convertirla en un componente reutilizable que pueda usarse desde múltiples pantallas. 

### Description
- Añadido componente standalone `app-user-card` en `apps/frontend/src/app/shared/ui/user-card/` con entradas (`fullName`, `location`, `todaysHour`, `avatarSrc`, `avatarAlt`) y sus propios template y estilos. 
- Reemplazado el markup inline de la user card en el dashboard para usar `<app-user-card [fullName]="fullName$ | async"></app-user-card>`. 
- Ajustado `DashboardPageComponent` para importar `UserCardComponent` y mejorar el cálculo del nombre completo con fallbacks desde los claims. 
- Eliminados estilos redundantes del CSS del dashboard y añadida una spec básica `user-card.component.spec.ts` para cubrir el renderizado del componente. 

### Testing
- Ejecutado `npm run build` y la build del frontend completó correctamente. 
- Ejecutado `npm run test -- --watch=false --browsers=ChromeHeadless` pero los tests unitarios no pudieron ejecutarse en este entorno porque no hay un binario de `ChromeHeadless` disponible, por lo que la ejecución de Karma falló por esa razón.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bae98ba06483278dce7b96b88fd439)