### PR TITLE
Harden security headers and error handling

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/JanusExceptionHandler.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/JanusExceptionHandler.java
@@ -218,7 +218,7 @@ public class JanusExceptionHandler {
 		final ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		pd.setType(TYPE_INVALID_DATE_TIME);
 		pd.setTitle("Invalid date/time format");
-		pd.setDetail("Failed to parse date/time: " + ex.getParsedString());
+		pd.setDetail("The provided date/time value does not match the expected ISO-8601 format.");
 		addCommonProps(pd, request);
 		logger.warn("DateTimeParseException error {}", pd);
 		return pd;
@@ -229,7 +229,7 @@ public class JanusExceptionHandler {
 		final ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		pd.setType(TYPE_INVALID_DATE_TIME);
 		pd.setTitle("Invalid date/time format");
-		pd.setDetail("Failed to parse date/time: " + ex.getMessage());
+		pd.setDetail("The provided date/time value is not valid for the requested operation.");
 		addCommonProps(pd, request);
 		logger.warn("DateTimeException error {}", pd);
 		return pd;
@@ -240,7 +240,7 @@ public class JanusExceptionHandler {
 		final ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		pd.setType(TYPE_MALFORMED_REQUEST);
 		pd.setTitle("Malformed request");
-		pd.setDetail(ex.getMostSpecificCause().getMessage());
+		pd.setDetail("The request body could not be parsed. Check JSON syntax, field types and required fields.");
 		addCommonProps(pd, request);
 		logger.warn("HttpMessageNotReadableException error {}", pd);
 		return pd;

--- a/apps/backend/src/main/java/es/nivel36/janus/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/config/SecurityConfig.java
@@ -28,6 +28,7 @@ import org.springframework.security.config.annotation.web.configurers.CsrfConfig
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -35,11 +36,22 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class SecurityConfig {
 
+	private static final String API_CONTENT_SECURITY_POLICY = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
+	private static final String API_PERMISSIONS_POLICY = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+
 	@Bean
 	SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
 		return http.cors(Customizer.withDefaults()) //
 				.csrf(CsrfConfigurer::disable) //
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //
+				.headers(headers -> { //
+					headers.contentTypeOptions(Customizer.withDefaults()); //
+					headers.frameOptions(frameOptions -> frameOptions.deny()); //
+					headers.referrerPolicy(referrer -> referrer.policy(ReferrerPolicy.NO_REFERRER)); //
+					headers.permissionsPolicy(permissions -> permissions.policy(API_PERMISSIONS_POLICY)); //
+					headers.contentSecurityPolicy(csp -> csp.policyDirectives(API_CONTENT_SECURITY_POLICY)); //
+					headers.cacheControl(Customizer.withDefaults()); //
+				}) //
 				.authorizeHttpRequests(this::getAuthorizations) //
 				.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults())) //
 				.exceptionHandling(exception -> exception
@@ -59,7 +71,9 @@ public class SecurityConfig {
 		final CorsConfiguration config = new CorsConfiguration();
 		config.setAllowedOrigins(allowedOrigins);
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-		config.setAllowedHeaders(List.of("*"));
+		config.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "Origin"));
+		config.setAllowCredentials(false);
+		config.setMaxAge(3600L);
 
 		final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/api/**", config);

--- a/apps/frontend/src/assets/silent-check-sso.html
+++ b/apps/frontend/src/assets/silent-check-sso.html
@@ -1,8 +1,6 @@
 <!doctype html>
 <html>
     <body>
-        <script>
-            parent.postMessage(location.href, location.origin);
-        </script>
+        <script src="/assets/silent-check-sso.js"></script>
     </body>
 </html>

--- a/apps/frontend/src/assets/silent-check-sso.js
+++ b/apps/frontend/src/assets/silent-check-sso.js
@@ -1,0 +1,1 @@
+parent.postMessage(location.href, location.origin);

--- a/deploy/nginx/conf.d/app.conf
+++ b/deploy/nginx/conf.d/app.conf
@@ -6,16 +6,32 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
-  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; form-action 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; script-src-elem 'self'; style-src 'self' 'unsafe-inline'" always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
   add_header X-Content-Type-Options "nosniff" always;
-  add_header X-Frame-Options "DENY" always;
   add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
   add_header Cross-Origin-Opener-Policy "same-origin" always;
   add_header Cross-Origin-Resource-Policy "same-origin" always;
 
+  location = /assets/silent-check-sso.html {
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    try_files $uri =404;
+  }
+
   # Front SPA
   location / {
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; form-action 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; script-src-elem 'self'; style-src 'self' 'unsafe-inline'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
     try_files $uri $uri/ /index.html;
   }
 

--- a/deploy/nginx/conf.d/app.conf
+++ b/deploy/nginx/conf.d/app.conf
@@ -6,7 +6,7 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
-  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" always;
+  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; form-action 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; script-src-elem 'self'; style-src 'self' 'unsafe-inline'" always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "DENY" always;

--- a/deploy/nginx/conf.d/app.conf
+++ b/deploy/nginx/conf.d/app.conf
@@ -1,9 +1,18 @@
 server {
   listen 80;
   server_name _;
+  server_tokens off;
 
   root /usr/share/nginx/html;
   index index.html;
+
+  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+  add_header Cross-Origin-Opener-Policy "same-origin" always;
+  add_header Cross-Origin-Resource-Policy "same-origin" always;
 
   # Front SPA
   location / {


### PR DESCRIPTION
### Motivation
- Mejorar la protección contra XSS, clickjacking y fugas de información en las respuestas HTTP y en el proxy nginx; además evitar que los errores de parsing expongan detalles internos que puedan ayudar a un atacante.

### Description
- Añade cabeceras de seguridad y una política CSP restrictiva para la API en `apps/backend/src/main/java/es/nivel36/janus/config/SecurityConfig.java` y endurece las reglas CORS (headers permitidos, sin credenciales, `maxAge`).
- Reduce el detalle de los mensajes de error de parseo/fecha en `apps/backend/src/main/java/es/nivel36/janus/api/JanusExceptionHandler.java` para evitar filtrado de información sensible en `ProblemDetail`.
- Endurece la configuración de nginx en `deploy/nginx/conf.d/app.conf` añadiendo `Content-Security-Policy`, `Referrer-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Permissions-Policy`, `COOP` y `CORP`, y oculta `server_tokens`.
- Extrae el script inline de comprobación SSO a un asset estático (`apps/frontend/src/assets/silent-check-sso.js`) y actualiza `apps/frontend/src/assets/silent-check-sso.html` para cumplir la CSP (mover `parent.postMessage` fuera del HTML inline).

### Testing
- Ejecuté `./mvnw test` en `apps/backend` y todos los tests unitarios e integración locales pasaron (68 tests, 0 fallos). 
- Ejecuté `npm run build` en `apps/frontend` y la aplicación se compiló y generó el `dist` correctamente. 
- Intenté `nginx -t -c /workspace/janus/deploy/nginx/conf.d/app.conf` pero el binario `nginx` no está disponible en este entorno, por lo que la validación del contenedor nginx no pudo realizarse aquí.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc162ad788327b4f94b16e4b08028)