### PR TITLE
feat(frontend): localize forbidden page

### DIFF
--- a/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.html
+++ b/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.html
@@ -1,7 +1,7 @@
 <div class="forbidden-container">
   <h1>403</h1>
-  <h2>Acceso denegado</h2>
-  <p>No tienes permisos para acceder a esta página.</p>
+  <h2>{{ 'forbidden.title' | translate }}</h2>
+  <p>{{ 'forbidden.message' | translate }}</p>
 
-  <button routerLink="/">Volver al inicio</button>
+  <button routerLink="/">{{ 'forbidden.backToHome' | translate }}</button>
 </div>

--- a/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.spec.ts
+++ b/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.spec.ts
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
 
 import { ForbiddenComponent } from './forbidden.component';
 
@@ -12,6 +13,7 @@ describe('Forbidden', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ForbiddenComponent],
+      providers: [provideTranslateService()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ForbiddenComponent);

--- a/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.spec.ts
+++ b/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.spec.ts
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 
 import { ForbiddenComponent } from './forbidden.component';
@@ -13,7 +14,7 @@ describe('Forbidden', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ForbiddenComponent],
-      providers: [provideTranslateService()],
+      providers: [provideRouter([]), provideTranslateService()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ForbiddenComponent);

--- a/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.ts
+++ b/apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.ts
@@ -2,10 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-forbidden',
-  imports: [],
+  imports: [RouterLink, TranslatePipe],
   templateUrl: './forbidden.component.html',
   styleUrl: './forbidden.component.css',
 })

--- a/apps/frontend/src/assets/i18n/ca.json
+++ b/apps/frontend/src/assets/i18n/ca.json
@@ -30,5 +30,10 @@
     "submit": "Entrar",
     "loading": "Accedint...",
     "error": "No s'ha pogut iniciar sessió. Comprova les credencials i torna-ho a provar."
+  },
+  "forbidden": {
+    "title": "Accés denegat",
+    "message": "No tens permisos per accedir a aquesta pàgina.",
+    "backToHome": "Torna a l'inici"
   }
 }

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -30,5 +30,10 @@
     "submit": "Sign in",
     "loading": "Signing in...",
     "error": "Unable to sign in. Please check your credentials and try again."
+  },
+  "forbidden": {
+    "title": "Access denied",
+    "message": "You do not have permission to access this page.",
+    "backToHome": "Back to home"
   }
 }

--- a/apps/frontend/src/assets/i18n/es.json
+++ b/apps/frontend/src/assets/i18n/es.json
@@ -30,5 +30,10 @@
     "submit": "Entrar",
     "loading": "Accediendo...",
     "error": "No se pudo iniciar sesión. Verifica tus credenciales e inténtalo de nuevo."
+  },
+  "forbidden": {
+    "title": "Acceso denegado",
+    "message": "No tienes permisos para acceder a esta página.",
+    "backToHome": "Volver al inicio"
   }
 }


### PR DESCRIPTION
### Motivation
- The forbidden page contained hard-coded Spanish text while the application supports multiple locales (`en`, `es`, `ca`), so it needed to use the translation system.
- Tests and components that render the page must work under the app's i18n setup and in unit tests that expect the translate service to be available.

### Description
- Replaced hard-coded strings in `apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.html` with translation keys (`forbidden.title`, `forbidden.message`, `forbidden.backToHome`).
- Added `TranslatePipe` and `RouterLink` to `ForbiddenComponent` imports in `apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.ts` so the template compiles when using translation and router directives.
- Added `forbidden` translations to all supported locale files: `apps/frontend/src/assets/i18n/en.json`, `apps/frontend/src/assets/i18n/es.json`, and `apps/frontend/src/assets/i18n/ca.json`.
- Updated the component spec `apps/frontend/src/app/core/error-pages/forbidden/forbidden.component.spec.ts` to provide the translation service during setup using `provideTranslateService()`.

### Testing
- Ran `npm run build` in `apps/frontend` and the application build completed successfully.
- Attempted `npm test -- --watch=false --browsers=ChromeHeadless` but the test run could not launch `ChromeHeadless` because the binary is not available in the environment, so unit tests could not be executed here; the spec was adjusted to register the translate service to allow tests to pass when run in CI with a proper headless browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0f6f65408327a094f3eeb31b5517)