### PR TITLE
Internationalize timelog table status messages

### DIFF
--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -1,8 +1,8 @@
 <section class="timelog">
 	<h2 class="timelog-title">{{ 'timelog.timelogs' | translate }}</h2>
 
-	<div *ngIf="error" class="timelog-message error">{{ error }}</div>
-	<div *ngIf="isLoading" class="timelog-message">Loading time	logs...</div>
+	<div *ngIf="errorKey" class="timelog-message error">{{ errorKey | translate }}</div>
+	<div *ngIf="isLoading" class="timelog-message">{{ 'timelog.loading' | translate }}</div>
 
 	<table *ngIf="!isLoading && timelogs.length" class="timelog-table">
 		<thead>
@@ -24,6 +24,6 @@
 		</tbody>
 	</table>
 
-	<div *ngIf="!isLoading && !timelogs.length && !error"
-		class="timelog-message">No time logs available yet.</div>
+	<div *ngIf="!isLoading && !timelogs.length && !errorKey"
+		class="timelog-message">{{ 'timelog.empty' | translate }}</div>
 </section>

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
@@ -32,7 +32,7 @@ export class TimelogTableComponent implements OnInit, OnChanges {
   @Input() refreshToken = 0;
   protected timelogs: TimeLog[] = [];
   protected isLoading = false;
-  protected error?: string;
+  protected errorKey?: string;
 
   private readonly destroyRef = inject(DestroyRef);
   private readonly reload$ = new Subject<void>();
@@ -51,7 +51,7 @@ export class TimelogTableComponent implements OnInit, OnChanges {
           this.isLoading = false;
         },
         error: () => {
-          this.error = 'Unable to load time logs at this time.';
+          this.errorKey = 'timelog.loadError';
           this.isLoading = false;
         },
       });
@@ -66,7 +66,7 @@ export class TimelogTableComponent implements OnInit, OnChanges {
 
   private loadTimeLogs(): void {
     this.isLoading = true;
-    this.error = undefined;
+    this.errorKey = undefined;
     this.reload$.next();
   }
 

--- a/apps/frontend/src/assets/i18n/ca.json
+++ b/apps/frontend/src/assets/i18n/ca.json
@@ -10,6 +10,9 @@
     "clockout": "Sortida",
     "date": "Data",
     "duration": "Duració",
+    "loading": "S'estan carregant els fitxatges...",
+    "empty": "Encara no hi ha fitxatges disponibles.",
+    "loadError": "Ara mateix no es poden carregar els fitxatges.",
     "timelogs": "Fixatges",
     "clockActionPermissionDenied": "No tens permisos per fitxar.",
     "clockActionNetworkError": "No s'ha pogut registrar el fitxatge en aquest moment. Torna-ho a provar."

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -10,6 +10,9 @@
     "clockout": "Clock out",
     "date": "Date",
     "duration": "Duration",
+    "loading": "Loading time logs...",
+    "empty": "No time logs available yet.",
+    "loadError": "Unable to load time logs at this time.",
     "timelogs": "Time logs",
     "clockActionPermissionDenied": "You do not have permission to clock in or out.",
     "clockActionNetworkError": "Unable to register your time action right now. Please try again."

--- a/apps/frontend/src/assets/i18n/es.json
+++ b/apps/frontend/src/assets/i18n/es.json
@@ -10,6 +10,9 @@
     "clockout": "Salida",
     "date": "Fecha",
     "duration": "Duración",
+    "loading": "Cargando fichajes...",
+    "empty": "Todavía no hay fichajes disponibles.",
+    "loadError": "No se pueden cargar los fichajes en este momento.",
     "timelogs": "Fichajes",
     "clockActionPermissionDenied": "No tienes permisos para fichar.",
     "clockActionNetworkError": "No se pudo registrar el fichaje en este momento. Inténtalo de nuevo."


### PR DESCRIPTION
### Motivation
- The timelog table displayed a hardcoded English error message (`Unable to load time logs at this time.`) and other UI states that should follow the user's locale, so make these messages translatable.

### Description
- Replaced the hardcoded error with a translation key by introducing `errorKey` and setting it to `timelog.loadError` in `TimelogTableComponent` (`apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts`).
- Updated the template to render the error, loading and empty states via the `translate` pipe using `timelog.loadError`, `timelog.loading` and `timelog.empty` (`apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html`).
- Added the new translation strings (`loading`, `empty`, `loadError`) to English, Spanish and Catalan catalogs (`apps/frontend/src/assets/i18n/en.json`, `apps/frontend/src/assets/i18n/es.json`, `apps/frontend/src/assets/i18n/ca.json`).

### Testing
- Ran `npm run build` in the frontend; the application bundle was generated successfully and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd29093e648327bdf5a27fca53ad67)