### PR TITLE
Añadir helper para obtener el último timelog de un empleado

### DIFF
--- a/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
+++ b/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
@@ -14,7 +14,7 @@ export class TimeLogService {
    * The `page` parameter follows Spring Data pagination (0-based index).
    */
   searchByEmployee(email: string, page?: number, size?: number): Observable<TimeLog[]> {
-    let params = new HttpParams();
+    let params = new HttpParams().set('sort', 'entryTime,desc');
     if (page != null) {
       params = params.set('page', String(page));
     }
@@ -25,6 +25,17 @@ export class TimeLogService {
     return this.http
       .get<Page<TimeLog>>(`${this.baseUrl}/${encodeURIComponent(email)}/timelogs/`, { params })
       .pipe(map((r) => r.content ?? []));
+  }
+
+  searchLatestByEmployee(email: string): Observable<TimeLog | undefined> {
+    const params = new HttpParams()
+      .set('page', '0')
+      .set('size', '1')
+      .set('sort', 'entryTime,desc');
+
+    return this.http
+      .get<Page<TimeLog>>(`${this.baseUrl}/${encodeURIComponent(email)}/timelogs/`, { params })
+      .pipe(map((r) => r.content?.[0]));
   }
 
   clockIn(email: string, worksiteCode: string): Observable<TimeLog> {


### PR DESCRIPTION
### Motivation
- Asegurar que las búsquedas de timelogs por empleado usan orden consistente por tiempo de entrada (`sort=entryTime,desc`) y ofrecer un helper para recuperar solo la última entrada.

### Description
- En `apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts` se actualizó `searchByEmployee` para añadir explícitamente el parámetro `sort=entryTime,desc` en los `HttpParams` sin cambiar su tipo de retorno (`Observable<TimeLog[]>`).
- Se añadió el método `searchLatestByEmployee(email: string): Observable<TimeLog | undefined>` que reutiliza la ruta `/employees/{email}/timelogs/` con `page=0`, `size=1` y `sort=entryTime,desc`.
- El nuevo método mapea la respuesta paginada para devolver `content[0]` o `undefined` si no hay resultados.

### Testing
- Ejecutado `rg -n "searchByEmployee(email: string, page?: number, size?: number)"` para localizar el punto de cambio y verificar la modificación; la búsqueda encontró el punto esperado.
- Ejecutado `git diff --check` y no mostró advertencias ni conflictos.
- Ejecutado `npm run build` en `apps/frontend` y la compilación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4d59042c8327ab5317020e882d72)