### PR TITLE
refactor: reuse successful timelog responses in clock card

### DIFF
--- a/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.ts
@@ -6,9 +6,10 @@ import { Component, DestroyRef, inject, input, output } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
 import {
-  ReplaySubject,
+  Observable,
   Subject,
   catchError,
+  defer,
   distinctUntilChanged,
   exhaustMap,
   filter,
@@ -32,7 +33,7 @@ import { TimeLogService } from '../../services/timelog-api.service';
  * Result of a clocking action.
  */
 type ClockActionResult =
-  | { type: 'success'; timeLog: TimeLog }
+  | { type: 'success'; employeeEmail: string; timeLog: TimeLog }
   | { type: 'permissionDenied'; feedbackKey: string }
   | { type: 'networkError'; feedbackKey: string };
 
@@ -76,11 +77,6 @@ export class TimelogClockCardComponent {
   private readonly clockActionClickSubject = new Subject<'auto' | 'force-opposite'>();
 
   /**
-   * Internal state of the latest known time log.
-   */
-  private readonly latestTimeLogStateSubject = new ReplaySubject<TimeLog | undefined>(1);
-
-  /**
    * Reactive observable of the employee email.
    */
   private readonly employeeEmail$ = toObservable(this.employeeEmail).pipe(
@@ -99,12 +95,34 @@ export class TimelogClockCardComponent {
   );
 
   /**
+   * Employee's latest known time log.
+   *
+   * It is loaded:
+   * - when employeeEmail changes
+   * - when a clocking action completes successfully, reusing the API response directly
+   */
+  readonly latestTimeLog$: Observable<TimeLog | undefined> = this.employeeEmail$.pipe(
+    switchMap((employeeEmail) =>
+      merge(
+        this.searchLatestTimeLog(employeeEmail),
+        defer(() =>
+          this.successfulClockActionResult$.pipe(
+            filter((result) => result.employeeEmail === employeeEmail),
+            map((result) => result.timeLog),
+          ),
+        ),
+      ),
+    ),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  /**
    * Main execution flow for the clocking action.
    *
    * exhaustMap is used to ignore repeated clicks while an action is already in progress.
    */
-  readonly clockActionResult$ = this.clockActionClickSubject.pipe(
-    withLatestFrom(this.employeeEmail$, this.latestTimeLogStateSubject, this.canClockInOut$),
+  readonly clockActionResult$: Observable<ClockActionResult> = this.clockActionClickSubject.pipe(
+    withLatestFrom(this.employeeEmail$, this.latestTimeLog$, this.canClockInOut$),
     exhaustMap(([mode, employeeEmail, latestTimeLog, canClockInOut]) => {
       if (!canClockInOut) {
         return of<ClockActionResult>({
@@ -117,15 +135,15 @@ export class TimelogClockCardComponent {
 
       const shouldClockOut =
         mode === 'force-opposite'
-          ? !this.isOpenTimeLog(latestTimeLog) // invertido
-          : this.isOpenTimeLog(latestTimeLog); // normal
+          ? !this.isOpenTimeLog(latestTimeLog)
+          : this.isOpenTimeLog(latestTimeLog);
 
       const action$ = shouldClockOut
         ? this.timeLogService.clockOut(employeeEmail, worksiteCode)
         : this.timeLogService.clockIn(employeeEmail, worksiteCode);
 
       return action$.pipe(
-        map((timeLog) => ({ type: 'success', timeLog }) as ClockActionResult),
+        map((timeLog) => ({ type: 'success', employeeEmail, timeLog }) as ClockActionResult),
         catchError(() =>
           of<ClockActionResult>({
             type: 'networkError',
@@ -140,25 +158,18 @@ export class TimelogClockCardComponent {
   /**
    * Time log returned by a successful clocking action.
    */
-  readonly successfulClockActionTimeLog$ = this.clockActionResult$.pipe(
-    filter((result): result is Extract<ClockActionResult, { type: 'success' }> =>
-      result.type === 'success',
-    ),
-    map((result) => result.timeLog),
-  );
+  readonly successfulClockActionResult$: Observable<Extract<ClockActionResult, { type: 'success' }>> =
+    this.clockActionResult$.pipe(
+      filter((result): result is Extract<ClockActionResult, { type: 'success' }> =>
+        result.type === 'success',
+      ),
+    );
 
   /**
-   * Employee's latest known time log.
-   *
-   * It is loaded:
-   * - when employeeEmail changes
-   * - when a clocking action completes successfully, reusing the API response directly
+   * Time log returned by a successful clocking action.
    */
-  readonly latestTimeLog$ = this.employeeEmail$.pipe(
-    switchMap((employeeEmail) =>
-      merge(this.searchLatestTimeLog(employeeEmail), this.successfulClockActionTimeLog$),
-    ),
-    shareReplay({ bufferSize: 1, refCount: true }),
+  readonly successfulClockActionTimeLog$: Observable<TimeLog> = this.successfulClockActionResult$.pipe(
+    map((result) => result.timeLog),
   );
 
   /**
@@ -223,12 +234,6 @@ export class TimelogClockCardComponent {
   );
 
   constructor() {
-    this.latestTimeLog$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((timeLog) => {
-        this.latestTimeLogStateSubject.next(timeLog);
-      });
-
     this.clockActionResult$
       .pipe(
         filter((result) => result.type === 'success'),

--- a/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.ts
@@ -6,9 +6,9 @@ import { Component, DestroyRef, inject, input, output } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
 import {
+  ReplaySubject,
   Subject,
   catchError,
-  combineLatest,
   distinctUntilChanged,
   exhaustMap,
   filter,
@@ -76,9 +76,9 @@ export class TimelogClockCardComponent {
   private readonly clockActionClickSubject = new Subject<'auto' | 'force-opposite'>();
 
   /**
-   * Manual trigger to reload the latest time log.
+   * Internal state of the latest known time log.
    */
-  private readonly reloadLatestTimeLogSubject = new Subject<void>();
+  private readonly latestTimeLogStateSubject = new ReplaySubject<TimeLog | undefined>(1);
 
   /**
    * Reactive observable of the employee email.
@@ -98,20 +98,65 @@ export class TimelogClockCardComponent {
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  readonly latestTimeLogReloadTrigger$ = merge(of(undefined), this.reloadLatestTimeLogSubject);
+  /**
+   * Main execution flow for the clocking action.
+   *
+   * exhaustMap is used to ignore repeated clicks while an action is already in progress.
+   */
+  readonly clockActionResult$ = this.clockActionClickSubject.pipe(
+    withLatestFrom(this.employeeEmail$, this.latestTimeLogStateSubject, this.canClockInOut$),
+    exhaustMap(([mode, employeeEmail, latestTimeLog, canClockInOut]) => {
+      if (!canClockInOut) {
+        return of<ClockActionResult>({
+          type: 'permissionDenied',
+          feedbackKey: 'timelog.clockActionPermissionDenied',
+        });
+      }
+
+      const worksiteCode = latestTimeLog?.worksiteCode ?? this.defaultWorksiteCode;
+
+      const shouldClockOut =
+        mode === 'force-opposite'
+          ? !this.isOpenTimeLog(latestTimeLog) // invertido
+          : this.isOpenTimeLog(latestTimeLog); // normal
+
+      const action$ = shouldClockOut
+        ? this.timeLogService.clockOut(employeeEmail, worksiteCode)
+        : this.timeLogService.clockIn(employeeEmail, worksiteCode);
+
+      return action$.pipe(
+        map((timeLog) => ({ type: 'success', timeLog }) as ClockActionResult),
+        catchError(() =>
+          of<ClockActionResult>({
+            type: 'networkError',
+            feedbackKey: 'timelog.clockActionNetworkError',
+          }),
+        ),
+      );
+    }),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  /**
+   * Time log returned by a successful clocking action.
+   */
+  readonly successfulClockActionTimeLog$ = this.clockActionResult$.pipe(
+    filter((result): result is Extract<ClockActionResult, { type: 'success' }> =>
+      result.type === 'success',
+    ),
+    map((result) => result.timeLog),
+  );
 
   /**
    * Employee's latest known time log.
    *
-   * It is reloaded:
+   * It is loaded:
    * - when employeeEmail changes
-   * - when a clocking action completes successfully
+   * - when a clocking action completes successfully, reusing the API response directly
    */
   readonly latestTimeLog$ = this.employeeEmail$.pipe(
     switchMap((employeeEmail) =>
-      this.latestTimeLogReloadTrigger$.pipe(
-        switchMap(() => this.searchLatestTimeLog(employeeEmail)),
-      ),
+      merge(this.searchLatestTimeLog(employeeEmail), this.successfulClockActionTimeLog$),
     ),
     shareReplay({ bufferSize: 1, refCount: true }),
   );
@@ -124,8 +169,7 @@ export class TimelogClockCardComponent {
    * or undefined if the request fails or no timelog is found.
    */
   private searchLatestTimeLog(employeeEmail: string) {
-    return this.timeLogService.searchByEmployee(employeeEmail, 0, 5).pipe(
-      map((timeLogs) => this.getLatestTimeLog(timeLogs)),
+    return this.timeLogService.searchLatestByEmployee(employeeEmail).pipe(
       catchError(() => of(undefined)),
     );
   }
@@ -160,45 +204,6 @@ export class TimelogClockCardComponent {
   );
 
   /**
-   * Main execution flow for the clocking action.
-   *
-   * exhaustMap is used to ignore repeated clicks while an action is already in progress.
-   */
-  readonly clockActionResult$ = this.clockActionClickSubject.pipe(
-    withLatestFrom(this.employeeEmail$, this.latestTimeLog$, this.canClockInOut$),
-    exhaustMap(([mode, employeeEmail, latestTimeLog, canClockInOut]) => {
-      if (!canClockInOut) {
-        return of<ClockActionResult>({
-          type: 'permissionDenied',
-          feedbackKey: 'timelog.clockActionPermissionDenied',
-        });
-      }
-
-      const worksiteCode = latestTimeLog?.worksiteCode ?? this.defaultWorksiteCode;
-
-      const shouldClockOut =
-        mode === 'force-opposite'
-          ? !this.isOpenTimeLog(latestTimeLog) // invertido
-          : this.isOpenTimeLog(latestTimeLog); // normal
-
-      const action$ = shouldClockOut
-        ? this.timeLogService.clockOut(employeeEmail, worksiteCode)
-        : this.timeLogService.clockIn(employeeEmail, worksiteCode);
-
-      return action$.pipe(
-        map((timeLog) => ({ type: 'success', timeLog }) as ClockActionResult),
-        catchError(() =>
-          of<ClockActionResult>({
-            type: 'networkError',
-            feedbackKey: 'timelog.clockActionNetworkError',
-          }),
-        ),
-      );
-    }),
-    shareReplay({ bufferSize: 1, refCount: true }),
-  );
-
-  /**
    * Loading state of the button.
    */
   readonly isClockActionLoading$ = merge(
@@ -218,13 +223,18 @@ export class TimelogClockCardComponent {
   );
 
   constructor() {
+    this.latestTimeLog$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((timeLog) => {
+        this.latestTimeLogStateSubject.next(timeLog);
+      });
+
     this.clockActionResult$
       .pipe(
         filter((result) => result.type === 'success'),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => {
-        this.reloadLatestTimeLogSubject.next();
         this.clockActionDone.emit();
       });
   }
@@ -257,21 +267,4 @@ export class TimelogClockCardComponent {
     return !!timeLog && !timeLog.exitTime;
   }
 
-  /**
-   * Returns the most recent time log from a collection.
-   *
-   * @param timeLogs List of time logs.
-   * @returns The time log with the most recent entryTime, or undefined if the list is empty.
-   */
-  private getLatestTimeLog(timeLogs: TimeLog[]): TimeLog | undefined {
-    return timeLogs.reduce<TimeLog | undefined>((latest, current) => {
-      if (!latest) {
-        return current;
-      }
-
-      return new Date(current.entryTime).getTime() > new Date(latest.entryTime).getTime()
-        ? current
-        : latest;
-    }, undefined);
-  }
 }


### PR DESCRIPTION
### Motivation
- Evitar reconsultas HTTP innecesarias tras un `clockIn`/`clockOut` y simplificar la lógica de recarga del último `TimeLog` en la card.
- Hacer que la carga inicial del último timelog ocurra solo al montar el componente o cuando cambie `employeeEmail`.

### Description
- Reemplacé el trigger manual de recarga (`reloadLatestTimeLogSubject` / `latestTimeLogReloadTrigger$`) por un estado interno `latestTimeLogStateSubject` (un `ReplaySubject`) en `apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.ts`.
- Introduje `successfulClockActionTimeLog$` derivado de `clockActionResult$` que emite `result.timeLog` cuando `type === 'success'`, y combiné ese stream con la carga inicial para construir `latestTimeLog$` con `merge(this.searchLatestTimeLog(employeeEmail), this.successfulClockActionTimeLog$)`.
- Sustituí `searchLatestTimeLog(employeeEmail)` para usar el servicio `timeLogService.searchLatestByEmployee(employeeEmail)` en lugar de pedir 5 registros y reducir en cliente, y eliminé la función auxiliar de reducción `getLatestTimeLog` porque dejó de usarse.
- Ajusté `clockActionResult$` para obtener el `latestTimeLog` desde el `latestTimeLogStateSubject` (vía `withLatestFrom`) y mantuve `clockActionDone.emit()` en la suscripción a resultados exitosos para que el padre pueda seguir refrescando la tabla si lo necesita.
- Importes actualizados (`ReplaySubject`) y suscripción en el `constructor` para mantener sincronizado el `latestTimeLogStateSubject` a partir de `latestTimeLog$`.

### Testing
- Ejecuté la build del frontend con `npm run build` y la compilación fue exitosa.
- Verifiqué con búsquedas (`rg`) que las referencias antiguas `reloadLatestTimeLogSubject`, `latestTimeLogReloadTrigger$`, `getLatestTimeLog` y la llamada `searchByEmployee(..., 0, 5)` fueron eliminadas o reemplazadas en el componente, sin referencias residuales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd622ddc00832795662af8171dc38e)