### PR TITLE
Mapear roles de Keycloak (JWT) a authorities `ROLE_*` de Spring Security

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/config/SecurityConfig.java
@@ -104,21 +104,27 @@ public class SecurityConfig {
 
 	private Collection<GrantedAuthority> extractKeycloakRoles(final Jwt jwt) {
 		return Stream.concat(
-				extractRoles(jwt, "realm_access"),
-				extractRoles(jwt, "resource_access")).distinct().toList();
+				extractRealmRoles(jwt),
+				extractResourceRoles(jwt)).distinct().toList();
 	}
 
-	private Stream<GrantedAuthority> extractRoles(final Jwt jwt, final String claimName) {
-		final Map<String, Object> claim = jwt.getClaimAsMap(claimName);
-		if (claim == null) {
+	private Stream<GrantedAuthority> extractRealmRoles(final Jwt jwt) {
+		final Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+		if (realmAccess == null) {
 			return Stream.empty();
 		}
 
-		if ("realm_access".equals(claimName)) {
-			return getRolesFromMap(claim);
+		return getRolesFromMap(realmAccess);
+	}
+
+	private Stream<GrantedAuthority> extractResourceRoles(final Jwt jwt) {
+		final Map<String, Object> resourceAccess = jwt.getClaimAsMap("resource_access");
+		if (resourceAccess == null) {
+			return Stream.empty();
 		}
 
-		return claim.values().stream().filter(Map.class::isInstance).map(Map.class::cast).flatMap(this::getRolesFromMap);
+		return resourceAccess.values().stream().filter(Map.class::isInstance).map(Map.class::cast)
+				.flatMap(this::getRolesFromMap);
 	}
 
 	private Stream<GrantedAuthority> getRolesFromMap(final Map<String, Object> source) {

--- a/apps/backend/src/main/java/es/nivel36/janus/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/config/SecurityConfig.java
@@ -15,7 +15,10 @@
  */
 package es.nivel36.janus.config;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +30,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
@@ -55,7 +63,8 @@ public class SecurityConfig {
 					headers.cacheControl(Customizer.withDefaults()); //
 				}) //
 				.authorizeHttpRequests(this::getAuthorizations) //
-				.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults())) //
+				.oauth2ResourceServer(
+						oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))) //
 				.exceptionHandling(exception -> exception
 						.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))) //
 				.build();
@@ -80,5 +89,46 @@ public class SecurityConfig {
 		final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/api/**", config);
 		return source;
+	}
+
+	@Bean
+	JwtAuthenticationConverter jwtAuthenticationConverter() {
+		final JwtGrantedAuthoritiesConverter scopesConverter = new JwtGrantedAuthoritiesConverter();
+
+		final JwtAuthenticationConverter authenticationConverter = new JwtAuthenticationConverter();
+		authenticationConverter.setJwtGrantedAuthoritiesConverter(jwt -> Stream.concat(
+				scopesConverter.convert(jwt).stream(),
+				extractKeycloakRoles(jwt).stream()).distinct().toList());
+		return authenticationConverter;
+	}
+
+	private Collection<GrantedAuthority> extractKeycloakRoles(final Jwt jwt) {
+		return Stream.concat(
+				extractRoles(jwt, "realm_access"),
+				extractRoles(jwt, "resource_access")).distinct().toList();
+	}
+
+	private Stream<GrantedAuthority> extractRoles(final Jwt jwt, final String claimName) {
+		final Map<String, Object> claim = jwt.getClaimAsMap(claimName);
+		if (claim == null) {
+			return Stream.empty();
+		}
+
+		if ("realm_access".equals(claimName)) {
+			return getRolesFromMap(claim);
+		}
+
+		return claim.values().stream().filter(Map.class::isInstance).map(Map.class::cast).flatMap(this::getRolesFromMap);
+	}
+
+	private Stream<GrantedAuthority> getRolesFromMap(final Map<String, Object> source) {
+		final Object roles = source.get("roles");
+		if (!(roles instanceof Collection<?> roleValues)) {
+			return Stream.empty();
+		}
+
+		return roleValues.stream().filter(String.class::isInstance).map(String.class::cast).map(String::trim)
+				.filter(role -> !role.isBlank()).map(role -> role.toUpperCase())
+				.map(role -> new SimpleGrantedAuthority("ROLE_" + role));
 	}
 }

--- a/apps/backend/src/test/java/es/nivel36/janus/config/SecurityConfigTest.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/config/SecurityConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class SecurityConfigTest {
+
+	private final SecurityConfig securityConfig = new SecurityConfig();
+
+	@Test
+	void jwtAuthenticationConverterShouldMapRealmAndResourceRolesToAuthorities() {
+		final Jwt jwt = buildJwt(Map.of(
+				"realm_access", Map.of("roles", List.of("employee", "admin")),
+				"resource_access", Map.of("janus-api", Map.of("roles", List.of("user")))));
+
+		final AbstractAuthenticationToken authentication = securityConfig.jwtAuthenticationConverter().convert(jwt);
+
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getAuthorities()).extracting("authority")
+				.contains("ROLE_EMPLOYEE", "ROLE_ADMIN", "ROLE_USER");
+	}
+
+	@Test
+	void jwtAuthenticationConverterShouldKeepScopeAuthorities() {
+		final Jwt jwt = buildJwt(Map.of("scope", "openid profile"));
+
+		final AbstractAuthenticationToken authentication = securityConfig.jwtAuthenticationConverter().convert(jwt);
+
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getAuthorities()).extracting("authority")
+				.contains("SCOPE_openid", "SCOPE_profile");
+	}
+
+	private Jwt buildJwt(final Map<String, Object> claims) {
+		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(300),
+				Map.of("alg", "none"), claims);
+	}
+}


### PR DESCRIPTION
### Motivation
- La seguridad por métodos usa `@PreAuthorize("hasRole(...)")` pero el mapeo JWT por defecto solo aporta `SCOPE_*`, por lo que la autorización de métodos fallaba con `AuthorizationDeniedException`.
- Es necesario exponer los roles emitidos por Keycloak como authorities con prefijo `ROLE_` para que las comprobaciones `hasRole('EMPLOYEE'|'USER'|'ADMIN')` funcionen.

### Description
- Configura el resource server para usar un `JwtAuthenticationConverter` personalizado en lugar de `Customizer.withDefaults()` en `SecurityConfig`. 
- Implementa un convertidor que combina las authorities de scope (vía `JwtGrantedAuthoritiesConverter`) con roles extraídos de `realm_access.roles` y `resource_access.*.roles` del JWT.
- Convierte los roles extraídos a `ROLE_<ROL_EN_MAYÚSCULAS>` y los fusiona con las authorities de scope para que ambos tipos estén disponibles.
- Añade el test `SecurityConfigTest` que verifica el mapeo de roles Keycloak a `ROLE_*` y la preservación de authorities `SCOPE_*`.

### Testing
- Ejecutado `mvn -q -Dtest=SecurityConfigTest test` dentro de `apps/backend` y el test unitario `SecurityConfigTest` pasó correctamente. 
- Ejecutado `mvn -q -DskipTests compile` dentro de `apps/backend` para comprobar la compilación y fue exitoso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ba69efa083279fc9c815f20496b3)