### PR TITLE
Add application settings REST API and frontend settings page

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/applicationsettings/ApplicationSettingsController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/applicationsettings/ApplicationSettingsController.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.applicationsettings;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import es.nivel36.janus.service.applicationsettings.ApplicationSettings;
+import es.nivel36.janus.service.applicationsettings.ApplicationSettingsService;
+import jakarta.validation.Valid;
+
+/**
+ * REST controller exposing read and update operations for global application settings.
+ */
+@RestController
+@RequestMapping("/api/v1/applicationsettings")
+public class ApplicationSettingsController {
+
+	private static final Logger logger = LoggerFactory.getLogger(ApplicationSettingsController.class);
+
+	private final ApplicationSettingsService applicationSettingsService;
+
+	public ApplicationSettingsController(final ApplicationSettingsService applicationSettingsService) {
+		this.applicationSettingsService = Objects.requireNonNull(applicationSettingsService,
+				"applicationSettingsService can't be null");
+	}
+
+	@PreAuthorize("hasAnyRole('JANUS_EMPLOYEE','JANUS_USER', 'JANUS_ADMIN')")
+	@GetMapping
+	public ResponseEntity<ApplicationSettingsResponse> findApplicationSettings() {
+		logger.debug("Find application settings ACTION performed");
+		final ApplicationSettings applicationSettings = this.applicationSettingsService.findApplicationSettings();
+		return ResponseEntity.ok(this.toResponse(applicationSettings));
+	}
+
+	@PreAuthorize("hasRole('JANUS_ADMIN')")
+	@PutMapping
+	public ResponseEntity<ApplicationSettingsResponse> updateApplicationSettings(
+			@Valid @RequestBody final UpdateApplicationSettingsRequest request) {
+		logger.debug("Update application settings ACTION performed");
+		final ApplicationSettings updatedSettings = this.applicationSettingsService.update(request.daysUntilLocked(),
+				request.employeeWorkplaceCreationAllowed(), request.worksiteChangeDuringShiftAllowed());
+		return ResponseEntity.ok(this.toResponse(updatedSettings));
+	}
+
+	private ApplicationSettingsResponse toResponse(final ApplicationSettings applicationSettings) {
+		return new ApplicationSettingsResponse(applicationSettings.getDaysUntilLocked(),
+				applicationSettings.isEmployeeWorkplaceCreationAllowed(),
+				applicationSettings.isWorksiteChangeDuringShiftAllowed());
+	}
+}

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/applicationsettings/ApplicationSettingsResponse.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/applicationsettings/ApplicationSettingsResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.applicationsettings;
+
+import es.nivel36.janus.service.applicationsettings.ApplicationSettings;
+
+/**
+ * Response payload that represents global {@link ApplicationSettings} values.
+ *
+ * @param daysUntilLocked                  number of days a time log remains editable
+ * @param employeeWorkplaceCreationAllowed whether employees can create personal worksites
+ * @param worksiteChangeDuringShiftAllowed whether changing worksite during a shift is allowed
+ */
+public record ApplicationSettingsResponse(int daysUntilLocked, boolean employeeWorkplaceCreationAllowed,
+		boolean worksiteChangeDuringShiftAllowed) {
+}

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/applicationsettings/UpdateApplicationSettingsRequest.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/applicationsettings/UpdateApplicationSettingsRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.applicationsettings;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+/**
+ * Request payload used to update global application settings.
+ *
+ * @param daysUntilLocked                  number of days a time log remains editable
+ * @param employeeWorkplaceCreationAllowed whether employees can create personal worksites
+ * @param worksiteChangeDuringShiftAllowed whether changing worksite during a shift is allowed
+ */
+public record UpdateApplicationSettingsRequest(
+		@PositiveOrZero(message = "daysUntilLocked must be greater than or equal to 0") int daysUntilLocked,
+		boolean employeeWorkplaceCreationAllowed, boolean worksiteChangeDuringShiftAllowed) {
+}

--- a/apps/backend/src/test/java/es/nivel36/janus/api/v1/applicationsettings/ApplicationSettingsControllerIT.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/api/v1/applicationsettings/ApplicationSettingsControllerIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.applicationsettings;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import es.nivel36.janus.api.v1.SecurityTestConfiguration;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Import(SecurityTestConfiguration.class)
+@Transactional
+class ApplicationSettingsControllerIT {
+
+	private static final String BASE = "/api/v1/applicationsettings";
+
+	private @Autowired MockMvc mvc;
+
+	@Test
+	@Sql(statements = "INSERT INTO application_settings(id, days_until_locked, employee_workplace_creation_allowed, worksite_change_during_shift_allowed) VALUES (1, 7, true, false)")
+	void testFindShouldReturnCurrentSettingsForEmployeeRole() throws Exception {
+		this.mvc.perform(get(BASE).with(jwt().authorities(createAuthorityList("ROLE_JANUS_EMPLOYEE"))))
+				.andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+				.andExpect(jsonPath("$.daysUntilLocked").isNumber())
+				.andExpect(jsonPath("$.employeeWorkplaceCreationAllowed").isBoolean())
+				.andExpect(jsonPath("$.worksiteChangeDuringShiftAllowed").isBoolean());
+	}
+
+	@Test
+	@Sql(statements = "INSERT INTO application_settings(id, days_until_locked, employee_workplace_creation_allowed, worksite_change_during_shift_allowed) VALUES (1, 7, true, false)")
+	void testUpdateShouldReturnForbiddenForNonAdmin() throws Exception {
+		final String body = """
+				{"daysUntilLocked":5,"employeeWorkplaceCreationAllowed":true,"worksiteChangeDuringShiftAllowed":false}
+				""";
+
+		this.mvc.perform(put(BASE).contentType(APPLICATION_JSON).content(body)
+				.with(jwt().authorities(createAuthorityList("ROLE_JANUS_USER")))).andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@Sql(statements = "INSERT INTO application_settings(id, days_until_locked, employee_workplace_creation_allowed, worksite_change_during_shift_allowed) VALUES (1, 7, true, false)")
+	void testUpdateShouldReturnUpdatedSettingsForAdmin() throws Exception {
+		final String body = """
+				{"daysUntilLocked":3,"employeeWorkplaceCreationAllowed":false,"worksiteChangeDuringShiftAllowed":true}
+				""";
+
+		this.mvc.perform(put(BASE).contentType(APPLICATION_JSON).content(body)
+				.with(jwt().authorities(createAuthorityList("ROLE_JANUS_ADMIN"))))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.daysUntilLocked").value(3))
+				.andExpect(jsonPath("$.employeeWorkplaceCreationAllowed").value(false))
+				.andExpect(jsonPath("$.worksiteChangeDuringShiftAllowed").value(true));
+	}
+}

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -12,6 +12,17 @@ export const appRoutes: Routes = [
       import('./core/error-pages/forbidden/forbidden.component').then((m) => m.ForbiddenComponent),
   },
   {
+    path: 'application-settings',
+    canActivate: [authGuard],
+    data: {
+      realmRole: ['JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN'],
+    },
+    loadComponent: () =>
+      import('./features/applicationsettings/pages/application-settings-page.component').then(
+        (m) => m.ApplicationSettingsPageComponent,
+      ),
+  },
+  {
     path: '',
     canActivate: [authGuard],
     data: {

--- a/apps/frontend/src/app/features/applicationsettings/models/application-settings.ts
+++ b/apps/frontend/src/app/features/applicationsettings/models/application-settings.ts
@@ -1,0 +1,5 @@
+export interface ApplicationSettings {
+  daysUntilLocked: number;
+  employeeWorkplaceCreationAllowed: boolean;
+  worksiteChangeDuringShiftAllowed: boolean;
+}

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
@@ -1,0 +1,71 @@
+.settings-page {
+  max-width: 920px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 1rem;
+}
+
+.settings-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid #d8dde4;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+input[type='number'] {
+  width: 120px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+button {
+  border: 0;
+  border-radius: 8px;
+  background: #2f73ff;
+  color: #fff;
+  padding: 0.6rem 1.1rem;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.message {
+  margin: 0;
+}
+
+.error {
+  color: #ba1a1a;
+}
+
+.success {
+  color: #1b873f;
+}
+
+.read-only {
+  margin-top: 0.5rem;
+  color: #6b7280;
+}

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -1,0 +1,42 @@
+<main class="app-shell">
+  <section class="settings-page">
+    <header class="settings-header">
+      <h1>{{ 'navigation.janus' | translate }}</h1>
+      <span>{{ 'applicationSettings.title' | translate }}</span>
+    </header>
+
+    <section class="settings-card" *ngIf="!loading; else loadingState">
+      <form [formGroup]="form" (ngSubmit)="save()">
+        <label>
+          {{ 'applicationSettings.fields.daysUntilLocked' | translate }}
+          <input type="number" min="0" formControlName="daysUntilLocked" />
+        </label>
+
+        <label>
+          <input type="checkbox" formControlName="employeeWorkplaceCreationAllowed" />
+          {{ 'applicationSettings.fields.employeeWorkplaceCreationAllowed' | translate }}
+        </label>
+
+        <label>
+          <input type="checkbox" formControlName="worksiteChangeDuringShiftAllowed" />
+          {{ 'applicationSettings.fields.worksiteChangeDuringShiftAllowed' | translate }}
+        </label>
+
+        <p class="message error" *ngIf="errorMessage">{{ errorMessage | translate }}</p>
+        <p class="message success" *ngIf="successMessage">{{ successMessage | translate }}</p>
+
+        <div class="actions" *ngIf="isAdmin">
+          <button type="submit" [disabled]="form.invalid || saving">
+            {{ 'applicationSettings.actions.save' | translate }}
+          </button>
+        </div>
+      </form>
+
+      <p *ngIf="!isAdmin" class="read-only">{{ 'applicationSettings.messages.readOnly' | translate }}</p>
+    </section>
+  </section>
+</main>
+
+<ng-template #loadingState>
+  <p class="message">{{ 'applicationSettings.messages.loading' | translate }}</p>
+</ng-template>

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -21,8 +21,8 @@ export class ApplicationSettingsPageComponent implements OnInit {
 
   readonly form = this.fb.nonNullable.group({
     daysUntilLocked: [0, [Validators.required, Validators.min(0)]],
-    employeeWorkplaceCreationAllowed: [false, [Validators.required]],
-    worksiteChangeDuringShiftAllowed: [false, [Validators.required]],
+    employeeWorkplaceCreationAllowed: [false],
+    worksiteChangeDuringShiftAllowed: [false],
   });
 
   loading = true;

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -1,0 +1,85 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { AuthService } from '../../../core/auth/auth.service';
+import { ApplicationSettingsApiService } from '../services/application-settings-api.service';
+import { ApplicationSettings } from '../models/application-settings';
+
+@Component({
+  selector: 'app-application-settings-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  templateUrl: './application-settings-page.component.html',
+  styleUrl: './application-settings-page.component.css',
+})
+export class ApplicationSettingsPageComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly settingsApiService = inject(ApplicationSettingsApiService);
+
+  readonly form = this.fb.nonNullable.group({
+    daysUntilLocked: [0, [Validators.required, Validators.min(0)]],
+    employeeWorkplaceCreationAllowed: [false, [Validators.required]],
+    worksiteChangeDuringShiftAllowed: [false, [Validators.required]],
+  });
+
+  loading = true;
+  saving = false;
+  errorMessage = '';
+  successMessage = '';
+
+  get isAdmin(): boolean {
+    return this.authService.hasRealmRole('JANUS_ADMIN');
+  }
+
+  ngOnInit(): void {
+    this.loadSettings();
+  }
+
+  loadSettings(): void {
+    this.loading = true;
+    this.errorMessage = '';
+    this.successMessage = '';
+
+    this.settingsApiService.find().subscribe({
+      next: (settings) => {
+        this.form.reset(settings);
+        if (!this.isAdmin) {
+          this.form.disable();
+        } else {
+          this.form.enable();
+        }
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.errorMessage = 'applicationSettings.errors.load';
+      },
+    });
+  }
+
+  save(): void {
+    if (!this.isAdmin || this.form.invalid || this.saving) {
+      return;
+    }
+
+    this.saving = true;
+    this.errorMessage = '';
+    this.successMessage = '';
+    const payload: ApplicationSettings = this.form.getRawValue();
+
+    this.settingsApiService.update(payload).subscribe({
+      next: (updatedSettings) => {
+        this.form.reset(updatedSettings);
+        this.saving = false;
+        this.successMessage = 'applicationSettings.messages.updated';
+      },
+      error: () => {
+        this.saving = false;
+        this.errorMessage = 'applicationSettings.errors.update';
+      },
+    });
+  }
+}

--- a/apps/frontend/src/app/features/applicationsettings/services/application-settings-api.service.ts
+++ b/apps/frontend/src/app/features/applicationsettings/services/application-settings-api.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { ApplicationSettings } from '../models/application-settings';
+
+@Injectable({ providedIn: 'root' })
+export class ApplicationSettingsApiService {
+  private readonly baseUrl = `${environment.apiBaseUrl}/applicationsettings`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  find(): Observable<ApplicationSettings> {
+    return this.http.get<ApplicationSettings>(this.baseUrl);
+  }
+
+  update(payload: ApplicationSettings): Observable<ApplicationSettings> {
+    return this.http.put<ApplicationSettings>(this.baseUrl, payload);
+  }
+}

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.css
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.css
@@ -67,3 +67,15 @@
     font-size: 0.875rem;
     font-weight: 500;
 }
+
+.header-actions {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.header-actions a {
+  color: #2f73ff;
+  text-decoration: none;
+  font-weight: 500;
+}

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
@@ -4,9 +4,12 @@
             <h1 class="brand">
                 {{ 'navigation.janus' | translate }}
             </h1>
-            <span class="section-label">
-                {{ 'navigation.dashboard' | translate }}
-            </span>
+            <div class="header-actions">
+                <a routerLink="/application-settings">{{ 'navigation.applicationSettings' | translate }}</a>
+                <span class="section-label">
+                    {{ 'navigation.dashboard' | translate }}
+                </span>
+            </div>
         </header>
 
         <section class="dashboard-content">

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.ts
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { AsyncPipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -18,6 +19,7 @@ import { TimelogClockCardComponent } from '../../timelogs/components/timelog-clo
   standalone: true,
   imports: [
     AsyncPipe,
+    RouterLink,
     FormsModule,
     TranslatePipe,
     UserCardComponent,

--- a/apps/frontend/src/assets/i18n/ca.json
+++ b/apps/frontend/src/assets/i18n/ca.json
@@ -1,7 +1,8 @@
 {
   "navigation": {
     "janus": "Janus",
-    "dashboard": "Panell de control"
+    "dashboard": "Panell de control",
+    "applicationSettings": "Configuració"
   },
   "timelog": {
     "activeWorkday": "Jornada en curs",
@@ -38,5 +39,25 @@
     "title": "Accés denegat",
     "message": "No tens permisos per accedir a aquesta pàgina.",
     "backToHome": "Torna a l'inici"
+  },
+  "applicationSettings": {
+    "title": "Configuració de l'aplicació",
+    "fields": {
+      "daysUntilLocked": "Dies fins al bloqueig",
+      "employeeWorkplaceCreationAllowed": "Permetre que empleats creïn centres de treball",
+      "worksiteChangeDuringShiftAllowed": "Permetre canvi de centre durant el torn"
+    },
+    "actions": {
+      "save": "Desa la configuració"
+    },
+    "messages": {
+      "loading": "S'està carregant la configuració...",
+      "updated": "Configuració actualitzada correctament.",
+      "readOnly": "Mode només lectura. Només JANUS_ADMIN pot actualitzar ajustos."
+    },
+    "errors": {
+      "load": "No s'ha pogut carregar la configuració.",
+      "update": "No s'ha pogut actualitzar la configuració."
+    }
   }
 }

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -1,7 +1,8 @@
 {
   "navigation": {
     "janus": "Janus",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "applicationSettings": "Application settings"
   },
   "timelog": {
     "activeWorkday": "Active Workday",
@@ -38,5 +39,25 @@
     "title": "Access denied",
     "message": "You do not have permission to access this page.",
     "backToHome": "Back to home"
+  },
+  "applicationSettings": {
+    "title": "Application settings",
+    "fields": {
+      "daysUntilLocked": "Days until lock",
+      "employeeWorkplaceCreationAllowed": "Allow employees to create worksites",
+      "worksiteChangeDuringShiftAllowed": "Allow worksite change during shift"
+    },
+    "actions": {
+      "save": "Save settings"
+    },
+    "messages": {
+      "loading": "Loading application settings...",
+      "updated": "Settings updated successfully.",
+      "readOnly": "Read-only mode. Only JANUS_ADMIN can update settings."
+    },
+    "errors": {
+      "load": "Unable to load application settings.",
+      "update": "Unable to update application settings."
+    }
   }
 }

--- a/apps/frontend/src/assets/i18n/es.json
+++ b/apps/frontend/src/assets/i18n/es.json
@@ -1,7 +1,8 @@
 {
   "navigation": {
     "janus": "Janus",
-    "dashboard": "Panel de control"
+    "dashboard": "Panel de control",
+    "applicationSettings": "Configuración"
   },
   "timelog": {
     "activeWorkday": "Jornada en curso",
@@ -38,5 +39,25 @@
     "title": "Acceso denegado",
     "message": "No tienes permisos para acceder a esta página.",
     "backToHome": "Volver al inicio"
+  },
+  "applicationSettings": {
+    "title": "Configuración de la aplicación",
+    "fields": {
+      "daysUntilLocked": "Días hasta bloqueo",
+      "employeeWorkplaceCreationAllowed": "Permitir que empleados creen centros de trabajo",
+      "worksiteChangeDuringShiftAllowed": "Permitir cambiar de centro durante el turno"
+    },
+    "actions": {
+      "save": "Guardar configuración"
+    },
+    "messages": {
+      "loading": "Cargando configuración...",
+      "updated": "Configuración actualizada correctamente.",
+      "readOnly": "Modo solo lectura. Solo JANUS_ADMIN puede actualizar ajustes."
+    },
+    "errors": {
+      "load": "No se pudo cargar la configuración.",
+      "update": "No se pudo actualizar la configuración."
+    }
   }
 }


### PR DESCRIPTION
### Motivation

- Exponer y permitir la gestión centralizada de los valores globales de la aplicación (`daysUntilLocked`, `employeeWorkplaceCreationAllowed`, `worksiteChangeDuringShiftAllowed`) mediante una API segura y un frontal para administración cuando el usuario tenga el rol `JANUS_ADMIN`.

### Description

- Añade el controlador REST `ApplicationSettingsController` con `GET /api/v1/applicationsettings` (lectura para `JANUS_EMPLOYEE|JANUS_USER|JANUS_ADMIN`) y `PUT /api/v1/applicationsettings` (actualización solo para `JANUS_ADMIN`).
- Crea los DTOs `ApplicationSettingsResponse` y `UpdateApplicationSettingsRequest` y mapea la entidad `ApplicationSettings` a la respuesta.
- Añade pruebas de integración `ApplicationSettingsControllerIT` que validan lectura, actualización y control de acceso por rol.
- Implementa el frontal Angular: modelo `ApplicationSettings`, servicio API `ApplicationSettingsApiService`, página standalone `ApplicationSettingsPageComponent`, ruta `/application-settings`, enlace desde el dashboard y textos i18n en `en`, `es` y `ca`.

### Testing

- Ejecuté la prueba de integración específica con `./mvnw -Dtest=ApplicationSettingsControllerIT test`, inicialmente falló por ausencia de la fila global en la tabla, se ajustó el fixture de test y la prueba se volvió a ejecutar con éxito.
- Compilé el frontend con `npm run build` y la build finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c977fe51f48327a42ff9aa133fd481)