### PR TITLE
feat(frontend): add yellow/black toggle button component

### DIFF
--- a/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.css
+++ b/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.css
@@ -1,0 +1,63 @@
+:host {
+  display: inline-flex;
+}
+
+.toggle-button {
+  width: 9rem;
+  height: 3.5rem;
+  border: 0;
+  border-radius: 999px;
+  background: #0a0a0a;
+  color: #f9d600;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggle-button:hover,
+.toggle-button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(249, 214, 0, 0.3);
+}
+
+.toggle-button__icon {
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1;
+  transform: translateX(1.85rem);
+  transition: transform 0.2s ease;
+}
+
+.toggle-button__knob {
+  width: 2.8rem;
+  height: 2.8rem;
+  border-radius: 50%;
+  background-color: #f9d600;
+  position: absolute;
+  top: 0.35rem;
+  left: 0.35rem;
+  box-shadow: 0 0.3rem 0.75rem rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease;
+}
+
+.toggle-button--checked {
+  background: linear-gradient(180deg, #ffe44d 0%, #f9d600 100%);
+  color: #0a0a0a;
+}
+
+.toggle-button--checked .toggle-button__icon {
+  transform: translateX(-1.85rem);
+}
+
+.toggle-button--checked .toggle-button__knob {
+  transform: translateX(5rem);
+  background-color: #111111;
+}
+
+.toggle-button--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.html
+++ b/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.html
@@ -1,0 +1,14 @@
+<button
+  type="button"
+  class="toggle-button"
+  [class.toggle-button--checked]="checked"
+  [class.toggle-button--disabled]="disabled"
+  role="switch"
+  [attr.aria-checked]="checked"
+  [attr.aria-label]="checked ? onLabel : offLabel"
+  [disabled]="disabled"
+  (click)="onToggle()"
+>
+  <span class="toggle-button__icon" aria-hidden="true">{{ checked ? '✓' : '✕' }}</span>
+  <span class="toggle-button__knob" aria-hidden="true"></span>
+</button>

--- a/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.spec.ts
@@ -22,21 +22,24 @@ describe('ToggleButtonComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should emit checkedChange with true when unchecked is toggled', () => {
+  it('should update checked and emit checkedChange when toggled', () => {
     const emitSpy = spyOn(component.checkedChange, 'emit');
 
     component.checked = false;
     component.onToggle();
 
+    expect(component.checked).toBeTrue();
     expect(emitSpy).toHaveBeenCalledWith(true);
   });
 
-  it('should not emit checkedChange when disabled', () => {
+  it('should not update checked or emit checkedChange when disabled', () => {
     const emitSpy = spyOn(component.checkedChange, 'emit');
 
+    component.checked = false;
     component.disabled = true;
     component.onToggle();
 
+    expect(component.checked).toBeFalse();
     expect(emitSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ToggleButtonComponent } from './toggle-button.component';
+
+describe('ToggleButtonComponent', () => {
+  let fixture: ComponentFixture<ToggleButtonComponent>;
+  let component: ToggleButtonComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ToggleButtonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ToggleButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit checkedChange with true when unchecked is toggled', () => {
+    const emitSpy = spyOn(component.checkedChange, 'emit');
+
+    component.checked = false;
+    component.onToggle();
+
+    expect(emitSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('should not emit checkedChange when disabled', () => {
+    const emitSpy = spyOn(component.checkedChange, 'emit');
+
+    component.disabled = true;
+    component.onToggle();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.ts
+++ b/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.ts
@@ -21,6 +21,7 @@ export class ToggleButtonComponent {
       return;
     }
 
-    this.checkedChange.emit(!this.checked);
+    this.checked = !this.checked;
+    this.checkedChange.emit(this.checked);
   }
 }

--- a/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.ts
+++ b/apps/frontend/src/app/shared/ui/toggle-button/toggle-button.component.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-toggle-button',
+  standalone: true,
+  templateUrl: './toggle-button.component.html',
+  styleUrl: './toggle-button.component.css',
+})
+export class ToggleButtonComponent {
+  @Input() checked = false;
+  @Input() disabled = false;
+  @Input() onLabel = 'Activado';
+  @Input() offLabel = 'Desactivado';
+  @Output() checkedChange = new EventEmitter<boolean>();
+
+  onToggle(): void {
+    if (this.disabled) {
+      return;
+    }
+
+    this.checkedChange.emit(!this.checked);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable toggle/switch UI element that follows the app yellow/black visual identity and can be used across frontend pages. 
- Ensure the control is accessible (`role=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c994c9675883279fa8c7faaa71438b)