### PR TITLE
feat(frontend): add yellow-black range slider component

### DIFF
--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
@@ -9,29 +9,31 @@
   justify-content: space-between;
   align-items: baseline;
   margin-bottom: 1rem;
+  color: #f9d600;
 }
 
 .settings-card {
-  background: #fff;
+  background: #0d0d0d;
   border-radius: 12px;
-  padding: 1rem;
-  border: 1px solid #d8dde4;
+  padding: 1.25rem;
+  border: 1px solid #f9d600;
 }
 
 form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 label {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  color: #ffffff;
 }
 
-input[type='number'] {
-  width: 120px;
+input[type='checkbox'] {
+  accent-color: #f9d600;
 }
 
 .actions {
@@ -42,10 +44,11 @@ input[type='number'] {
 button {
   border: 0;
   border-radius: 8px;
-  background: #2f73ff;
-  color: #fff;
+  background: #f9d600;
+  color: #111111;
   padding: 0.6rem 1.1rem;
   cursor: pointer;
+  font-weight: 700;
 }
 
 button:disabled {
@@ -58,14 +61,14 @@ button:disabled {
 }
 
 .error {
-  color: #ba1a1a;
+  color: #ff8a8a;
 }
 
 .success {
-  color: #1b873f;
+  color: #7dff9f;
 }
 
 .read-only {
   margin-top: 0.5rem;
-  color: #6b7280;
+  color: #d8d8d8;
 }

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
@@ -72,3 +72,18 @@ button:disabled {
   margin-top: 0.5rem;
   color: #d8d8d8;
 }
+
+
+.days-until-locked-control {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.days-until-locked-input {
+  width: 8rem;
+  background: #111111;
+  color: #ffffff;
+  border: 1px solid #f9d600;
+  border-radius: 8px;
+  padding: 0.45rem 0.55rem;
+}

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -7,16 +7,24 @@
 
     <section class="settings-card" *ngIf="!loading; else loadingState">
       <form [formGroup]="form" (ngSubmit)="save()">
-        <app-range-slider
-          [label]="'applicationSettings.fields.daysUntilLocked' | translate"
-          unit="días"
-          [min]="0"
-          [max]="90"
-          [step]="1"
-          [disabled]="form.disabled"
-          [value]="form.controls.daysUntilLocked.value"
-          (valueChange)="form.controls.daysUntilLocked.setValue($event)"
-        />
+        <div class="days-until-locked-control">
+          <app-range-slider
+            [label]="'applicationSettings.fields.daysUntilLocked' | translate"
+            [min]="0"
+            [max]="daysUntilLockedSliderMax"
+            [step]="1"
+            [disabled]="form.disabled"
+            [value]="form.controls.daysUntilLocked.value"
+            (valueChange)="form.controls.daysUntilLocked.setValue($event)"
+          />
+          <input
+            type="number"
+            min="0"
+            formControlName="daysUntilLocked"
+            class="days-until-locked-input"
+            [attr.aria-label]="'applicationSettings.fields.daysUntilLocked' | translate"
+          />
+        </div>
 
         <label>
           <input type="checkbox" formControlName="employeeWorkplaceCreationAllowed" />

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -7,10 +7,16 @@
 
     <section class="settings-card" *ngIf="!loading; else loadingState">
       <form [formGroup]="form" (ngSubmit)="save()">
-        <label>
-          {{ 'applicationSettings.fields.daysUntilLocked' | translate }}
-          <input type="number" min="0" formControlName="daysUntilLocked" />
-        </label>
+        <app-range-slider
+          [label]="'applicationSettings.fields.daysUntilLocked' | translate"
+          unit="días"
+          [min]="0"
+          [max]="90"
+          [step]="1"
+          [disabled]="form.disabled"
+          [value]="form.controls.daysUntilLocked.value"
+          (valueChange)="form.controls.daysUntilLocked.setValue($event)"
+        />
 
         <label>
           <input type="checkbox" formControlName="employeeWorkplaceCreationAllowed" />

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -61,6 +61,12 @@ export class ApplicationSettingsPageComponent implements OnInit {
     });
   }
 
+
+
+  get daysUntilLockedSliderMax(): number {
+    return Math.max(120, this.form.controls.daysUntilLocked.value);
+  }
+
   save(): void {
     if (!this.isAdmin || this.form.invalid || this.saving) {
       return;

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -6,11 +6,12 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { AuthService } from '../../../core/auth/auth.service';
 import { ApplicationSettingsApiService } from '../services/application-settings-api.service';
 import { ApplicationSettings } from '../models/application-settings';
+import { RangeSliderComponent } from '../../../shared/ui/range-slider/range-slider.component';
 
 @Component({
   selector: 'app-application-settings-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [CommonModule, ReactiveFormsModule, TranslatePipe, RangeSliderComponent],
   templateUrl: './application-settings-page.component.html',
   styleUrl: './application-settings-page.component.css',
 })

--- a/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.css
+++ b/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.css
@@ -1,0 +1,64 @@
+:host {
+  display: block;
+}
+
+.range-slider {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.range-slider__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.range-slider__label {
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.range-slider__value {
+  color: #111111;
+  background: #f9d600;
+  font-weight: 800;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  padding: 0.25rem 0.5rem;
+}
+
+.range-slider__input {
+  --progress: 0%;
+  appearance: none;
+  width: 100%;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #f9d600 var(--progress), #ffffff var(--progress));
+  outline: none;
+}
+
+.range-slider__input::-webkit-slider-thumb {
+  appearance: none;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  border: 4px solid #f9d600;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.range-slider__input::-moz-range-thumb {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  border: 4px solid #f9d600;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.range-slider__input:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}

--- a/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.html
+++ b/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.html
@@ -1,0 +1,20 @@
+<div class="range-slider">
+  <div class="range-slider__header">
+    <span class="range-slider__label">{{ label }}</span>
+    <span class="range-slider__value">{{ value }}{{ unit ? ' ' + unit : '' }}</span>
+  </div>
+
+  <div class="range-slider__track-wrapper">
+    <input
+      type="range"
+      class="range-slider__input"
+      [min]="min"
+      [max]="max"
+      [step]="step"
+      [value]="value"
+      [disabled]="disabled"
+      [style.--progress]="progressPercent + '%'"
+      (input)="onInput($event)"
+    />
+  </div>
+</div>

--- a/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.ts
+++ b/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-range-slider',
+  standalone: true,
+  templateUrl: './range-slider.component.html',
+  styleUrl: './range-slider.component.css',
+})
+export class RangeSliderComponent {
+  @Input() label = '';
+  @Input() unit = '';
+  @Input() min = 0;
+  @Input() max = 100;
+  @Input() step = 1;
+  @Input() value = 0;
+  @Input() disabled = false;
+
+  @Output() valueChange = new EventEmitter<number>();
+
+  onInput(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    const nextValue = Number(target.value);
+    this.value = nextValue;
+    this.valueChange.emit(nextValue);
+  }
+
+  get progressPercent(): number {
+    const range = this.max - this.min;
+    if (range <= 0) {
+      return 0;
+    }
+
+    return ((this.value - this.min) / range) * 100;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable range slider styled with the app's yellow/black visual language to improve the UX for numeric settings such as `daysUntilLocked`.
- Replace the plain numeric input with a more visual control that can be reused across the frontend.

### Description
- Added a standalone `RangeSliderComponent` with files `apps/frontend/src/app/shared/ui/range-slider/range-slider.component.ts`, `.html`, and `.css` exposing `@Input()`s (`label`, `unit`, `min`, `max`, `step`, `value`, `disabled`) and emitting `valueChange` events.
- Integrated the component into the Application Settings page by importing `RangeSliderComponent` into `ApplicationSettingsPageComponent` and replacing the numeric input with an `<app-range-slider>` bound to the reactive form control `daysUntilLocked`.
- Implemented the yellow/black styling, a progress-filled track driven by a `--progress` CSS custom property, and a value chip to match the app theme.
- Updated `apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css` to a dark background and yellow accents so the slider fits the page aesthetics.

### Testing
- Ran `cd apps/frontend && npm run build` and the build completed successfully and produced the application bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a324248c832782e08456b484a1b1)