### PR TITLE
feat(frontend): add footer main menu with large icon actions

### DIFF
--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
@@ -1,0 +1,61 @@
+.main-menu {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.9rem 1.1rem;
+    border: 2px solid #f9d600;
+    border-radius: 0.9rem;
+    background: linear-gradient(180deg, #151515 0%, #090909 100%);
+    color: #f9d600;
+    box-sizing: border-box;
+}
+
+.main-menu__identity {
+    min-width: 0;
+}
+
+.main-menu__user-name {
+    display: block;
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.main-menu__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.main-menu__icon-button {
+    width: 3.1rem;
+    height: 3.1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid #f9d600;
+    border-radius: 0.7rem;
+    background-color: #050505;
+    color: #f9d600;
+    font-size: 1.85rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: transform 120ms ease, background-color 120ms ease, color 120ms ease;
+}
+
+.main-menu__icon-button:hover,
+.main-menu__icon-button:focus-visible {
+    background-color: #f9d600;
+    color: #050505;
+    transform: translateY(-1px);
+}
+
+.main-menu__icon-button:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+}

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
@@ -1,14 +1,29 @@
 @if (currentUser$ | async; as user) {
-    <nav class="main-menu">
-        <div class="left">
-            <!-- navegación general -->
+    <nav class="main-menu" aria-label="Menú principal">
+        <div class="main-menu__identity">
+            <span class="main-menu__user-name">{{ user.fullName }}</span>
         </div>
 
-        <div class="right">
-            <span class="user-name">{{ user.fullName }}</span>
+        <div class="main-menu__actions">
+            <button
+                type="button"
+                class="main-menu__icon-button"
+                aria-label="Configuración"
+                title="Configuración"
+                (click)="goToSettings()"
+            >
+                <span aria-hidden="true">⚙</span>
+            </button>
 
-            <button (click)="goToSettings()">Configuración</button>
-            <button (click)="logout()">Salir</button>
+            <button
+                type="button"
+                class="main-menu__icon-button"
+                aria-label="Salir"
+                title="Salir"
+                (click)="logout()"
+            >
+                <span aria-hidden="true">⏻</span>
+            </button>
         </div>
     </nav>
 }

--- a/apps/frontend/src/app/shared/layout/page-template/page-template.component.css
+++ b/apps/frontend/src/app/shared/layout/page-template/page-template.component.css
@@ -48,5 +48,8 @@
 }
 
 .page-footer {
-    min-height: 1px;
+    width: min(1080px, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 }

--- a/apps/frontend/src/app/shared/layout/page-template/page-template.component.html
+++ b/apps/frontend/src/app/shared/layout/page-template/page-template.component.html
@@ -16,6 +16,7 @@
         </section>
 
         <footer class="page-footer">
+            <app-main-menu></app-main-menu>
             <ng-content select="[page-footer]"></ng-content>
         </footer>
     </section>

--- a/apps/frontend/src/app/shared/layout/page-template/page-template.component.ts
+++ b/apps/frontend/src/app/shared/layout/page-template/page-template.component.ts
@@ -1,10 +1,12 @@
 import { Component, Input } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 
+import { MainMenuComponent } from '../../../core/layout/main-menu/main-menu.component';
+
 @Component({
   selector: 'app-page-template',
   standalone: true,
-  imports: [TranslatePipe],
+  imports: [TranslatePipe, MainMenuComponent],
   templateUrl: './page-template.component.html',
   styleUrl: './page-template.component.css',
 })


### PR DESCRIPTION
### Motivation
- Hacer que el menú principal existente aparezca en el footer de todas las páginas que usan el layout compartido para facilitar acceso rápido a ajustes y logout.
- Alinear la presentación del menú con la identidad visual de la app (amarillo/negro) y reemplazar botones de texto por iconos grandes para mejorar la ergonomía en el footer.

### Description
- Inserté `<app-main-menu>` en el footer de `app-page-template` y actualicé `PageTemplateComponent` para importar `MainMenuComponent` como dependencia standalone. 
- Reescribí la plantilla de `main-menu` para mostrar el nombre de usuario y dos botones de acción icono-grandes (⚙ para configuración y ⏻ para salir) manteniendo `aria-label` y `title` para accesibilidad. 
- Añadí estilos amarillos/negros en `main-menu.component.css` para bordes, fondo y estados hover/focus y definí dimensiones grandes para los botones de icono. 
- Ajusté el CSS de `page-template` (`.page-footer`) para acomodar el menú en el footer con layout en columna y un pequeño gap.

### Testing
- Ejecuté la compilación de la aplicación frontal con `cd apps/frontend && npm run build` y la build completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3dc9f3b48327a976b6202aacabc7)