### PR TITLE
Add time zone catalog service and REST endpoint

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/CatalogController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/CatalogController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.catalog;
+
+import java.util.Objects;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import es.nivel36.janus.service.catalog.TimeZoneCatalogItem;
+import es.nivel36.janus.service.catalog.TimeZoneCatalogService;
+import es.nivel36.janus.service.catalog.TimeZoneSortBy;
+
+/**
+ * REST controller exposing catalog endpoints.
+ */
+@RestController
+@RequestMapping("/api/v1/catalogs")
+public class CatalogController {
+
+	private final TimeZoneCatalogService timeZoneCatalogService;
+
+	/**
+	 * Builds a controller with the required catalog service dependency.
+	 *
+	 * @param timeZoneCatalogService service used to retrieve time zone catalog data
+	 */
+	public CatalogController(final TimeZoneCatalogService timeZoneCatalogService) {
+		this.timeZoneCatalogService = Objects.requireNonNull(timeZoneCatalogService,
+				"timeZoneCatalogService can't be null");
+	}
+
+	/**
+	 * Returns a paginated list of Java time zones with formatted literal and split
+	 * levels.
+	 *
+	 * @param search   optional search text over full zone id values
+	 * @param sortBy   sorting mode ({@code LEVEL1} or {@code UTC})
+	 * @param pageable Spring pagination information
+	 * @return a page with matching time zone catalog items
+	 */
+	@PreAuthorize("hasAnyRole('JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN')")
+	@GetMapping("/time-zones")
+	public ResponseEntity<Page<TimeZoneCatalogItemResponse>> searchTimeZones(
+			@RequestParam(value = "search", required = false) final String search,
+			@RequestParam(value = "sortBy", defaultValue = "LEVEL1") final TimeZoneSortBy sortBy,
+			final @PageableDefault(size = 25) Pageable pageable) {
+		final Page<TimeZoneCatalogItem> zones = this.timeZoneCatalogService.search(search, sortBy, pageable);
+		final Page<TimeZoneCatalogItemResponse> response = zones.map(this::map);
+		return ResponseEntity.ok(response);
+	}
+
+	private TimeZoneCatalogItemResponse map(final TimeZoneCatalogItem timeZoneCatalogItem) {
+		return new TimeZoneCatalogItemResponse(timeZoneCatalogItem.literal(), timeZoneCatalogItem.level1(),
+				timeZoneCatalogItem.level2(), timeZoneCatalogItem.utc());
+	}
+}

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/TimeZoneCatalogItemResponse.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/TimeZoneCatalogItemResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.catalog;
+
+/**
+ * Response payload for a single time zone catalog item.
+ *
+ * @param literal full display value, for example {@code Europe/Madrid (UTC+2)}
+ * @param level1  first segment of the zone id (before the first slash)
+ * @param level2  remainder of the zone id after the first slash
+ * @param utc     UTC offset string used in the literal
+ */
+public record TimeZoneCatalogItemResponse(String literal, String level1, String level2, String utc) {
+
+}

--- a/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogItem.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogItem.java
@@ -23,7 +23,9 @@ package es.nivel36.janus.service.catalog;
  * @param level1  first segment of the zone id (before the first slash)
  * @param level2  remainder of the zone id after the first slash
  * @param utc     UTC offset string used in the literal
+ * @param offsetSeconds numeric UTC offset in seconds, used for sorting
  */
-public record TimeZoneCatalogItem(String zoneId, String literal, String level1, String level2, String utc) {
+public record TimeZoneCatalogItem(String zoneId, String literal, String level1, String level2, String utc,
+		int offsetSeconds) {
 
 }

--- a/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogItem.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogItem.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.catalog;
+
+/**
+ * Internal projection representing a single time zone catalog row.
+ *
+ * @param zoneId  full Java zone id
+ * @param literal full display value, for example {@code Europe/Madrid (UTC+2)}
+ * @param level1  first segment of the zone id (before the first slash)
+ * @param level2  remainder of the zone id after the first slash
+ * @param utc     UTC offset string used in the literal
+ */
+public record TimeZoneCatalogItem(String zoneId, String literal, String level1, String level2, String utc) {
+
+}

--- a/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogService.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogService.java
@@ -69,14 +69,15 @@ public class TimeZoneCatalogService {
 
 	private TimeZoneCatalogItem map(final String zoneId, final ZonedDateTime referenceDateTime) {
 		final ZoneId parsedZoneId = ZoneId.of(zoneId);
-		final String utc = formatUtcOffset(referenceDateTime.withZoneSameInstant(parsedZoneId).getOffset().getTotalSeconds());
+		final int offsetSeconds = referenceDateTime.withZoneSameInstant(parsedZoneId).getOffset().getTotalSeconds();
+		final String utc = formatUtcOffset(offsetSeconds);
 		final int splitIndex = zoneId.indexOf('/');
 		final String level1 = splitIndex >= 0 ? zoneId.substring(0, splitIndex) : zoneId;
 		// Keep everything after the first slash as the second level, including
 		// additional nested segments such as "Argentina/Buenos_Aires".
 		final String level2 = splitIndex >= 0 ? zoneId.substring(splitIndex + 1) : "";
 		final String literal = zoneId + " (" + utc + ")";
-		return new TimeZoneCatalogItem(zoneId, literal, level1, level2, utc);
+		return new TimeZoneCatalogItem(zoneId, literal, level1, level2, utc, offsetSeconds);
 	}
 
 	private String formatUtcOffset(final int totalSeconds) {
@@ -94,7 +95,7 @@ public class TimeZoneCatalogService {
 		return switch (sortBy) {
 		case LEVEL1 -> Comparator.comparing(TimeZoneCatalogItem::level1)
 				.thenComparing(TimeZoneCatalogItem::zoneId);
-		case UTC -> Comparator.comparing(TimeZoneCatalogItem::utc)
+		case UTC -> Comparator.comparingInt(TimeZoneCatalogItem::offsetSeconds)
 				.thenComparing(TimeZoneCatalogItem::zoneId);
 		};
 	}

--- a/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogService.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneCatalogService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.catalog;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Application service that exposes catalog data for Java time zones.
+ */
+@Service
+public class TimeZoneCatalogService {
+
+	/**
+	 * Searches available Java {@link ZoneId} values and returns a paginated catalog.
+	 * <p>
+	 * Search is a simple case-insensitive {@code contains} over the full zone id
+	 * string.
+	 * </p>
+	 *
+	 * @param search   optional search text applied to the full zone id
+	 * @param sortBy   sort strategy for the resulting catalog page
+	 * @param pageable Spring pagination information (page and size)
+	 * @return a page of catalog items matching the input filters
+	 */
+	public Page<TimeZoneCatalogItem> search(final String search, final TimeZoneSortBy sortBy, final Pageable pageable) {
+		Objects.requireNonNull(sortBy, "sortBy can't be null");
+		Objects.requireNonNull(pageable, "pageable can't be null");
+
+		final String normalizedSearch = search == null ? null : search.trim().toLowerCase(Locale.ROOT);
+		final ZonedDateTime now = ZonedDateTime.now();
+
+		final List<TimeZoneCatalogItem> filtered = ZoneId.getAvailableZoneIds().stream().sorted().map(zoneId -> map(zoneId, now))
+				.filter(item -> normalizedSearch == null || normalizedSearch.isBlank()
+						|| item.zoneId().toLowerCase(Locale.ROOT).contains(normalizedSearch))
+				.sorted(resolveSort(sortBy))
+				.toList();
+
+		final int start = Math.toIntExact(pageable.getOffset());
+		if (start >= filtered.size()) {
+			return new PageImpl<>(List.of(), pageable, filtered.size());
+		}
+
+		final int end = Math.min(start + pageable.getPageSize(), filtered.size());
+		return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
+	}
+
+	private TimeZoneCatalogItem map(final String zoneId, final ZonedDateTime referenceDateTime) {
+		final ZoneId parsedZoneId = ZoneId.of(zoneId);
+		final String utc = formatUtcOffset(referenceDateTime.withZoneSameInstant(parsedZoneId).getOffset().getTotalSeconds());
+		final int splitIndex = zoneId.indexOf('/');
+		final String level1 = splitIndex >= 0 ? zoneId.substring(0, splitIndex) : zoneId;
+		// Keep everything after the first slash as the second level, including
+		// additional nested segments such as "Argentina/Buenos_Aires".
+		final String level2 = splitIndex >= 0 ? zoneId.substring(splitIndex + 1) : "";
+		final String literal = zoneId + " (" + utc + ")";
+		return new TimeZoneCatalogItem(zoneId, literal, level1, level2, utc);
+	}
+
+	private String formatUtcOffset(final int totalSeconds) {
+		final int absTotalSeconds = Math.abs(totalSeconds);
+		final int hours = absTotalSeconds / 3600;
+		final int minutes = (absTotalSeconds % 3600) / 60;
+		final String sign = totalSeconds >= 0 ? "+" : "-";
+		if (minutes == 0) {
+			return "UTC" + sign + hours;
+		}
+		return "UTC" + sign + hours + ":" + String.format("%02d", minutes);
+	}
+
+	private Comparator<TimeZoneCatalogItem> resolveSort(final TimeZoneSortBy sortBy) {
+		return switch (sortBy) {
+		case LEVEL1 -> Comparator.comparing(TimeZoneCatalogItem::level1)
+				.thenComparing(TimeZoneCatalogItem::zoneId);
+		case UTC -> Comparator.comparing(TimeZoneCatalogItem::utc)
+				.thenComparing(TimeZoneCatalogItem::zoneId);
+		};
+	}
+}

--- a/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneSortBy.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/catalog/TimeZoneSortBy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.service.catalog;
+
+/**
+ * Sorting strategies available for the time zone catalog endpoint.
+ */
+public enum TimeZoneSortBy {
+	/**
+	 * Sort by first zone id segment ({@code level1}), then by full zone id.
+	 */
+	LEVEL1,
+	/**
+	 * Sort by UTC offset string, then by full zone id.
+	 */
+	UTC
+}

--- a/apps/backend/src/test/java/es/nivel36/janus/api/v1/catalog/CatalogControllerIT.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/api/v1/catalog/CatalogControllerIT.java
@@ -70,7 +70,7 @@ class CatalogControllerIT {
 		this.mvc.perform(get(BASE).queryParam("sortBy", "UTC").queryParam("page", "0").queryParam("size", "20")
 				.with(jwt().authorities(createAuthorityList("ROLE_JANUS_ADMIN")))) //
 				.andExpect(status().isOk()) //
-				.andExpect(jsonPath("$.content[0].utc").isNotEmpty());
+				.andExpect(jsonPath("$.content[0].utc").value(Matchers.startsWith("UTC-")));
 	}
 
 	@Test

--- a/apps/backend/src/test/java/es/nivel36/janus/api/v1/catalog/CatalogControllerIT.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/api/v1/catalog/CatalogControllerIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Abel Ferrer Jiménez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package es.nivel36.janus.api.v1.catalog;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import es.nivel36.janus.api.v1.SecurityTestConfiguration;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Import(SecurityTestConfiguration.class)
+@Transactional
+class CatalogControllerIT {
+
+	private static final String BASE = "/api/v1/catalogs/time-zones";
+
+	private @Autowired MockMvc mvc;
+
+	@Test
+	void testSearchTimeZonesShouldReturn200AndPageData() throws Exception {
+		this.mvc.perform(get(BASE).queryParam("search", "Europe/Madrid").with(jwt()//
+				.authorities(createAuthorityList("ROLE_JANUS_ADMIN")))) //
+				.andExpect(status().isOk()) //
+				.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)) //
+				.andExpect(jsonPath("$.content[0].literal").value(Matchers.containsString("Europe/Madrid"))) //
+				.andExpect(jsonPath("$.content[0].level1").value("Europe")) //
+				.andExpect(jsonPath("$.content[0].level2").value("Madrid")) //
+				.andExpect(jsonPath("$.content[0].utc").value(Matchers.matchesPattern("UTC[+-]\\d{1,2}(:\\d{2})?")));
+	}
+
+	@Test
+	void testSearchTimeZonesShouldBePaginated() throws Exception {
+		this.mvc.perform(get(BASE).queryParam("page", "0").queryParam("size", "5").with(jwt()//
+				.authorities(createAuthorityList("ROLE_JANUS_ADMIN")))) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.content.length()").value(5)) //
+				.andExpect(jsonPath("$.page.size").value(5));
+	}
+
+	@Test
+	void testSearchTimeZonesShouldSortByUtcWhenRequested() throws Exception {
+		this.mvc.perform(get(BASE).queryParam("sortBy", "UTC").queryParam("page", "0").queryParam("size", "20")
+				.with(jwt().authorities(createAuthorityList("ROLE_JANUS_ADMIN")))) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.content[0].utc").isNotEmpty());
+	}
+
+	@Test
+	void testSearchTimeZonesShouldKeepRemainingSegmentsInSecondLevel() throws Exception {
+		this.mvc.perform(get(BASE).queryParam("search", "America/Argentina/Buenos_Aires").with(jwt()//
+				.authorities(createAuthorityList("ROLE_JANUS_ADMIN")))) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.content[0].level1").value("America")) //
+				.andExpect(jsonPath("$.content[0].level2").value("Argentina/Buenos_Aires"));
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide a paginated, searchable and sortable catalog of Java time zones exposed via REST to support client selection and display of time zone literals with UTC offsets and split id levels.

### Description

- Add `TimeZoneCatalogService` that enumerates `ZoneId` values, builds `TimeZoneCatalogItem` records with `literal`, `level1`, `level2` and formatted `utc` offset, supports case-insensitive `search`, pagination and sorting by `LEVEL1` or `UTC` via `TimeZoneSortBy`.
- Add `CatalogController` exposing `GET /api/v1/catalogs/time-zones` with `search`, `sortBy` and pageable parameters and secured with `@PreAuthorize` roles, mapping service items to `TimeZoneCatalogItemResponse` records.
- Add data records `TimeZoneCatalogItem` and response payload `TimeZoneCatalogItemResponse` to represent internal and API models respectively.
- Add `TimeZoneSortBy` enum and comprehensive integration tests in `CatalogControllerIT` covering search, pagination, sorting and multi-segment level2 behavior.

### Testing

- Ran the new integration tests in `CatalogControllerIT` which exercise `GET /api/v1/catalogs/time-zones` search, pagination, `sortBy=UTC`, and multi-segment zone ids, and all assertions passed.
- Executed the test run via `./mvnw test` which completed successfully for the modified code base.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccff2ec3548327b15b42cd7a1c9b39)