### PR TITLE
feat(frontend): add reusable autocomplete textbox component

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
@@ -1,0 +1,71 @@
+:host {
+  display: block;
+}
+
+.autocomplete {
+  position: relative;
+  width: 100%;
+}
+
+.input-wrapper {
+  position: relative;
+}
+
+input {
+  width: 100%;
+  padding: 0.625rem 2.25rem 0.625rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #b8b8b8;
+  font-size: 0.95rem;
+}
+
+input[readonly] {
+  background-color: #f6f6f6;
+  cursor: default;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.35rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  color: #666;
+}
+
+.clear-button:hover {
+  color: #111;
+}
+
+.results {
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin: 0.25rem 0 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #d6d6d6;
+  border-radius: 0.5rem;
+  max-height: 14rem;
+  overflow-y: auto;
+  z-index: 20;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.results li button {
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+.results li button:hover {
+  background-color: #f4f4f4;
+}

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.html
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.html
@@ -1,0 +1,35 @@
+<div class="autocomplete">
+  <div class="input-wrapper">
+    <input
+      type="text"
+      [placeholder]="placeholder"
+      [formControl]="textControl"
+      [readonly]="hasSelection"
+      [attr.aria-readonly]="hasSelection"
+    />
+
+    @if (hasSelection) {
+      <button
+        type="button"
+        class="clear-button"
+        aria-label="Limpiar selección"
+        [disabled]="disabled"
+        (click)="clearSelection()"
+      >
+        ✕
+      </button>
+    }
+  </div>
+
+  @if (!hasSelection && results.length > 0) {
+    <ul class="results" role="listbox">
+      @for (result of results; track $index) {
+        <li>
+          <button type="button" (click)="onSelect(result)">
+            {{ displayWith(result) }}
+          </button>
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
+
+import { AutocompleteTextboxComponent } from './autocomplete-textbox.component';
+
+describe('AutocompleteTextboxComponent', () => {
+  let fixture: ComponentFixture<AutocompleteTextboxComponent<string>>;
+  let component: AutocompleteTextboxComponent<string>;
+  let searchMethodSpy: jasmine.Spy<(query: string) => ReturnType<typeof of>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AutocompleteTextboxComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AutocompleteTextboxComponent<string>);
+    component = fixture.componentInstance;
+    searchMethodSpy = jasmine.createSpy('searchMethod').and.callFake((query: string) =>
+      of([`${query}-1`, `${query}-2`]),
+    );
+    component.searchMethod = searchMethodSpy;
+    component.debounceMs = 300;
+
+    fixture.detectChanges();
+  });
+
+  function getInput(): HTMLInputElement {
+    return fixture.debugElement.query(By.css('input')).nativeElement;
+  }
+
+  it('should call search method after debounce when text has more than 3 chars', fakeAsync(() => {
+    const input = getInput();
+    input.value = 'madr';
+    input.dispatchEvent(new Event('input'));
+
+    tick(299);
+    expect(searchMethodSpy).not.toHaveBeenCalled();
+
+    tick(1);
+    fixture.detectChanges();
+
+    expect(searchMethodSpy).toHaveBeenCalledOnceWith('madr');
+    expect(component.results).toEqual(['madr-1', 'madr-2']);
+  }));
+
+  it('should not call search method when text has 3 chars or fewer', fakeAsync(() => {
+    const input = getInput();
+    input.value = 'mad';
+    input.dispatchEvent(new Event('input'));
+
+    tick(400);
+    fixture.detectChanges();
+
+    expect(searchMethodSpy).not.toHaveBeenCalled();
+    expect(component.results).toEqual([]);
+  }));
+
+  it('should lock input and show clear button after selecting a result', fakeAsync(() => {
+    component.textControl.setValue('madr');
+    tick(300);
+    fixture.detectChanges();
+
+    const firstResultButton: HTMLButtonElement = fixture.debugElement.query(By.css('.results li button')).nativeElement;
+    firstResultButton.click();
+    fixture.detectChanges();
+
+    const input = getInput();
+    expect(component.selectedValue).toBe('madr-1');
+    expect(input.readOnly).toBeTrue();
+    expect(fixture.debugElement.query(By.css('.clear-button'))).not.toBeNull();
+  }));
+
+  it('should clear selection, hide clear button and make input editable again', () => {
+    component.writeValue('valor fijo');
+    fixture.detectChanges();
+
+    const clearButton: HTMLButtonElement = fixture.debugElement.query(By.css('.clear-button')).nativeElement;
+    clearButton.click();
+    fixture.detectChanges();
+
+    const input = getInput();
+    expect(component.selectedValue).toBeNull();
+    expect(input.readOnly).toBeFalse();
+    expect(input.value).toBe('');
+    expect(fixture.debugElement.query(By.css('.clear-button'))).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
@@ -47,6 +47,25 @@ describe('AutocompleteTextboxComponent', () => {
     expect(component.results).toEqual(['madr-1', 'madr-2']);
   }));
 
+
+  it('should cancel queued search when user backspaces to 3 chars before debounce', fakeAsync(() => {
+    const input = getInput();
+
+    input.value = 'madr';
+    input.dispatchEvent(new Event('input'));
+
+    tick(150);
+
+    input.value = 'mad';
+    input.dispatchEvent(new Event('input'));
+
+    tick(300);
+    fixture.detectChanges();
+
+    expect(searchMethodSpy).not.toHaveBeenCalled();
+    expect(component.results).toEqual([]);
+  }));
+
   it('should not call search method when text has 3 chars or fewer', fakeAsync(() => {
     const input = getInput();
     input.value = 'mad';

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
@@ -93,6 +93,38 @@ describe('AutocompleteTextboxComponent', () => {
     expect(fixture.debugElement.query(By.css('.clear-button'))).not.toBeNull();
   }));
 
+
+  it('should not allow selecting results when disabled', fakeAsync(() => {
+    component.textControl.setValue('madr');
+    tick(300);
+    fixture.detectChanges();
+
+    component.setDisabledState(true);
+    fixture.detectChanges();
+
+    const firstResultButton: HTMLButtonElement = fixture.debugElement.query(By.css('.results li button')).nativeElement;
+    firstResultButton.click();
+    fixture.detectChanges();
+
+    expect(component.selectedValue).toBeNull();
+    expect(component.textControl.value).toBe('madr');
+  }));
+
+  it('should clear visible results when writeValue(null) is called', fakeAsync(() => {
+    component.textControl.setValue('madr');
+    tick(300);
+    fixture.detectChanges();
+
+    expect(component.results.length).toBeGreaterThan(0);
+
+    component.writeValue(null);
+    fixture.detectChanges();
+
+    expect(component.results).toEqual([]);
+    expect(component.textControl.value).toBe('');
+    expect(fixture.debugElement.query(By.css('.results'))).toBeNull();
+  }));
+
   it('should clear selection, hide clear button and make input editable again', () => {
     component.writeValue('valor fijo');
     fixture.detectChanges();

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
@@ -52,8 +52,8 @@ export class AutocompleteTextboxComponent<T = unknown> implements OnInit, Contro
             this.results = [];
           }
         }),
-        filter((value) => value.trim().length > this.minChars && !this.hasSelection),
         debounceTime(this.debounceMs),
+        filter((value) => value.trim().length > this.minChars && !this.hasSelection),
         switchMap((query) => {
           this.isLoading = true;
           return from(this.searchMethod(query.trim())).pipe(

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
@@ -1,0 +1,132 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { Observable, catchError, debounceTime, distinctUntilChanged, filter, finalize, from, of, switchMap, tap } from 'rxjs';
+
+@Component({
+  selector: 'app-autocomplete-textbox',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './autocomplete-textbox.component.html',
+  styleUrl: './autocomplete-textbox.component.css',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => AutocompleteTextboxComponent),
+      multi: true,
+    },
+  ],
+})
+export class AutocompleteTextboxComponent<T = unknown> implements OnInit, ControlValueAccessor {
+  @Input({ required: true })
+  searchMethod!: (query: string) => Observable<T[]> | Promise<T[]>;
+
+  @Input()
+  displayWith: (option: T) => string = (option: T) => String(option);
+
+  @Input() placeholder = '';
+  @Input() debounceMs = 350;
+
+  @Output() selectedChange = new EventEmitter<T | null>();
+
+  readonly minChars = 3;
+  textControl = new FormControl('', { nonNullable: true });
+
+  results: T[] = [];
+  selectedValue: T | null = null;
+  isLoading = false;
+  disabled = false;
+
+  private onChange: (value: T | null) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  ngOnInit(): void {
+    this.textControl.valueChanges
+      .pipe(
+        distinctUntilChanged(),
+        tap((value) => {
+          if (value.trim().length <= this.minChars || this.hasSelection) {
+            this.results = [];
+          }
+        }),
+        filter((value) => value.trim().length > this.minChars && !this.hasSelection),
+        debounceTime(this.debounceMs),
+        switchMap((query) => {
+          this.isLoading = true;
+          return from(this.searchMethod(query.trim())).pipe(
+            catchError(() => of([] as T[])),
+            finalize(() => {
+              this.isLoading = false;
+            }),
+          );
+        }),
+      )
+      .subscribe({
+        next: (results) => {
+          this.results = results;
+        },
+        error: () => {
+          this.results = [];
+        },
+      });
+  }
+
+  get hasSelection(): boolean {
+    return this.selectedValue !== null;
+  }
+
+  onSelect(option: T): void {
+    this.selectedValue = option;
+    this.textControl.setValue(this.displayWith(option), { emitEvent: false });
+    this.results = [];
+    this.selectedChange.emit(option);
+    this.onChange(option);
+    this.onTouched();
+  }
+
+  clearSelection(): void {
+    if (this.disabled) {
+      return;
+    }
+
+    this.selectedValue = null;
+    this.results = [];
+    this.textControl.setValue('', { emitEvent: false });
+    this.selectedChange.emit(null);
+    this.onChange(null);
+    this.onTouched();
+  }
+
+  writeValue(value: T | null): void {
+    this.selectedValue = value;
+
+    if (value === null) {
+      this.textControl.setValue('', { emitEvent: false });
+      return;
+    }
+
+    this.textControl.setValue(this.displayWith(value), { emitEvent: false });
+  }
+
+  registerOnChange(fn: (value: T | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+
+    if (isDisabled) {
+      this.textControl.disable({ emitEvent: false });
+      return;
+    }
+
+    this.textControl.enable({ emitEvent: false });
+  }
+}

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
@@ -79,6 +79,10 @@ export class AutocompleteTextboxComponent<T = unknown> implements OnInit, Contro
   }
 
   onSelect(option: T): void {
+    if (this.disabled) {
+      return;
+    }
+
     this.selectedValue = option;
     this.textControl.setValue(this.displayWith(option), { emitEvent: false });
     this.results = [];
@@ -102,6 +106,7 @@ export class AutocompleteTextboxComponent<T = unknown> implements OnInit, Contro
 
   writeValue(value: T | null): void {
     this.selectedValue = value;
+    this.results = [];
 
     if (value === null) {
       this.textControl.setValue('', { emitEvent: false });


### PR DESCRIPTION
### Motivation
- Provide a reusable standalone `app-autocomplete-textbox` Angular component to simplify text autocompletion across the frontend. 
- Integrate with Angular forms via `ControlValueAccessor` so the component can be used in reactive forms and form controls. 
- Implement the requested UX: lock input on selection with a visible clear `✕`, allow typing when editable, and perform debounced async queries when the typed text exceeds three characters.

### Description
- Added a new standalone component with files `autocomplete-textbox.component.ts`, `autocomplete-textbox.component.html`, `autocomplete-textbox.component.css`, and `autocomplete-textbox.component.spec.ts` under `apps/frontend/src/app/shared/ui/autocomplete-textbox/`.
- Component API: required input `searchMethod: (query: string) => Observable<T[]> | Promise<T[]>`, optional `displayWith`, `placeholder`, and `debounceMs`, plus `selectedChange` output and `ControlValueAccessor` support for forms.
- Behavior: debounces input (`debounceMs`, default 350ms), ignores queries of length ≤ 3, shows results in a dropdown, locks the input when an item is selected and shows a clear `✕` button that resets the selection to make the input editable again.
- Implementation includes error handling (`catchError`) to return an empty result set on search failures and unit tests that verify debounce, minimum-character gating, selection lock, and clear behavior.

### Testing
- Ran a full production build with `cd apps/frontend && npm run build`, which completed successfully.
- Attempted tests with `cd apps/frontend && npm test -- --watch=false --include src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts`, which failed due to a pre-existing unrelated TypeScript error in `src/app/shared/ui/button/button.component.spec.ts` (TS2322), so the new component spec was not executed end-to-end in the CI run.
- The new component includes unit tests added at `apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts` and was committed as `feat(frontend): add reusable autocomplete textbox component`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd33e894d48327b6377ed1ebd671d6)