### PR TITLE
Add default timezone support to application settings

### DIFF
--- a/apps/frontend/src/app/features/applicationsettings/models/application-settings.ts
+++ b/apps/frontend/src/app/features/applicationsettings/models/application-settings.ts
@@ -2,4 +2,5 @@ export interface ApplicationSettings {
   daysUntilLocked: number;
   employeeWorkplaceCreationAllowed: boolean;
   worksiteChangeDuringShiftAllowed: boolean;
+  defaultTimezone: string;
 }

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -34,6 +34,19 @@
                     }}
                 </label>
 
+                <div class="timezone-control">
+                    <label for="default-timezone">
+                        {{ 'applicationSettings.fields.defaultTimezone' | translate }}
+                    </label>
+                    <app-autocomplete-textbox
+                        id="default-timezone"
+                        [formControl]="timezoneControl"
+                        [searchMethod]="searchMethod"
+                        [displayWith]="timezoneDisplayWith"
+                        (selectedChange)="onTimezoneSelected($event)"
+                    />
+                </div>
+
                 <p class="message error" *ngIf="errorMessage">
                     {{ errorMessage | translate }}
                 </p>

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -3,16 +3,22 @@ import { Component, OnInit, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
-import { finalize } from 'rxjs';
+import { Observable, of, finalize } from 'rxjs';
 
 import { CurrentUserFacade } from '../../../core/auth/current-user.facade';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
+import { AutocompleteTextboxComponent } from '../../../shared/ui/autocomplete-textbox/autocomplete-textbox.component';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { CardComponent } from '../../../shared/ui/card/card.component';
 import { RangeSliderComponent } from '../../../shared/ui/range-slider/range-slider.component';
 import { ToggleButtonComponent } from '../../../shared/ui/toggle-button/toggle-button.component';
 import { ApplicationSettings } from '../models/application-settings';
 import { ApplicationSettingsApiService } from '../services/application-settings-api.service';
+
+type TimezoneOption = {
+  zoneId: string;
+  literal: string;
+};
 
 @Component({
   selector: 'app-application-settings-page',
@@ -21,6 +27,7 @@ import { ApplicationSettingsApiService } from '../services/application-settings-
     CommonModule,
     ReactiveFormsModule,
     TranslatePipe,
+    AutocompleteTextboxComponent,
     RangeSliderComponent,
     ToggleButtonComponent,
     ButtonComponent,
@@ -41,7 +48,10 @@ export class ApplicationSettingsPageComponent implements OnInit {
     daysUntilLocked: [0, [Validators.required, Validators.min(0)]],
     employeeWorkplaceCreationAllowed: [false],
     worksiteChangeDuringShiftAllowed: [false],
+    defaultTimezone: ['', Validators.required],
   });
+  readonly timezoneControl = this.fb.control<TimezoneOption | null>(null);
+  readonly timezoneCatalog = this.createTimezoneCatalog();
 
   loading = true;
   saving = false;
@@ -73,11 +83,16 @@ export class ApplicationSettingsPageComponent implements OnInit {
       .subscribe({
         next: (settings) => {
           this.form.reset(settings);
+          this.timezoneControl.setValue(this.findTimezoneOption(settings.defaultTimezone), {
+            emitEvent: false,
+          });
 
           if (!this.isAdmin) {
             this.form.disable();
+            this.timezoneControl.disable();
           } else {
             this.form.enable();
+            this.timezoneControl.enable();
           }
         },
         error: () => {
@@ -121,5 +136,52 @@ export class ApplicationSettingsPageComponent implements OnInit {
           this.errorMessage = 'applicationSettings.errors.update';
         },
       });
+  }
+
+  searchMethod = (query: string): Observable<TimezoneOption[]> => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (!normalizedQuery) {
+      return of([]);
+    }
+
+    return of(
+      this.timezoneCatalog
+        .filter(
+          (option) =>
+            option.zoneId.toLowerCase().includes(normalizedQuery) ||
+            option.literal.toLowerCase().includes(normalizedQuery),
+        )
+        .slice(0, 50),
+    );
+  };
+
+  onTimezoneSelected(option: TimezoneOption | null): void {
+    this.form.controls.defaultTimezone.setValue(option?.zoneId ?? '');
+  }
+
+  timezoneDisplayWith = (option: TimezoneOption): string => option.literal;
+
+  private createTimezoneCatalog(): TimezoneOption[] {
+    return Intl.supportedValuesOf('timeZone').map((zoneId) => ({
+      zoneId,
+      literal: `${zoneId} (${this.getUtcOffsetLiteral(zoneId)})`,
+    }));
+  }
+
+  private getUtcOffsetLiteral(zoneId: string): string {
+    const utcOffsetPart = new Intl.DateTimeFormat('en-US', {
+      timeZone: zoneId,
+      timeZoneName: 'shortOffset',
+    })
+      .formatToParts(new Date())
+      .find((part) => part.type === 'timeZoneName')
+      ?.value;
+
+    return utcOffsetPart?.replace('GMT', 'UTC') ?? 'UTC';
+  }
+
+  private findTimezoneOption(zoneId: string): TimezoneOption | null {
+    return this.timezoneCatalog.find((option) => option.zoneId === zoneId) ?? null;
   }
 }

--- a/apps/frontend/src/assets/i18n/ca.json
+++ b/apps/frontend/src/assets/i18n/ca.json
@@ -49,7 +49,8 @@
     "fields": {
       "daysUntilLocked": "Dies fins al bloqueig dels fixatges",
       "employeeWorkplaceCreationAllowed": "Permetre que empleats creïn centres de treball",
-      "worksiteChangeDuringShiftAllowed": "Permetre canvi de centre durant el torn"
+      "worksiteChangeDuringShiftAllowed": "Permetre canvi de centre durant el torn",
+      "defaultTimezone": "Zona horària predeterminada"
     },
     "messages": {
       "loading": "S'està carregant la configuració...",

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -49,7 +49,8 @@
     "fields": {
       "daysUntilLocked": "Days until time logs are locked",
       "employeeWorkplaceCreationAllowed": "Allow employees to create worksites",
-      "worksiteChangeDuringShiftAllowed": "Allow worksite change during shift"
+      "worksiteChangeDuringShiftAllowed": "Allow worksite change during shift",
+      "defaultTimezone": "Default timezone"
     },
     "messages": {
       "loading": "Loading application settings...",

--- a/apps/frontend/src/assets/i18n/es.json
+++ b/apps/frontend/src/assets/i18n/es.json
@@ -49,7 +49,8 @@
     "fields": {
       "daysUntilLocked": "Días hasta el bloqueo de los fichajes",
       "employeeWorkplaceCreationAllowed": "Permitir que empleados creen centros de trabajo",
-      "worksiteChangeDuringShiftAllowed": "Permitir cambiar de centro durante el turno"
+      "worksiteChangeDuringShiftAllowed": "Permitir cambiar de centro durante el turno",
+      "defaultTimezone": "Zona horaria predeterminada"
     },
     "messages": {
       "loading": "Cargando configuración...",


### PR DESCRIPTION
### Motivation

- Expose a configurable default timezone in application settings so administrators can set the app-wide timezone and select it via a friendly autocomplete UI.

### Description

- Added `defaultTimezone: string` to `ApplicationSettings` model to include the new setting in the typed contract.
- Extended `ApplicationSettingsPageComponent` to add a required `defaultTimezone` form control, a `timezoneControl` for the autocomplete, a `TimezoneOption` type, a `timezoneCatalog` generated from `Intl.supportedValuesOf('timeZone')`, and helpers `searchMethod`, `onTimezoneSelected`, `timezoneDisplayWith`, `getUtcOffsetLiteral` and `findTimezoneOption` to power selection and display.
- Imported and registered `AutocompleteTextboxComponent` in the component `imports` and wired the autocomplete in the template so the UI shows a translated label and a friendly display like `Europe/Madrid (UTC+2)` while persisting the `zoneId`.
- Added the translation key `applicationSettings.fields.defaultTimezone` to `apps/frontend/src/assets/i18n/en.json`, `es.json` and `ca.json`.

### Testing

- Ran the frontend build with `npm --prefix apps/frontend run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd45890d208327a2e0b46bec80e3dc)