### PR TITLE
Add timezone catalog service and wire default timezone autocomplete

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/CatalogController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/CatalogController.java
@@ -71,7 +71,7 @@ public class CatalogController {
 	}
 
 	private TimeZoneCatalogItemResponse map(final TimeZoneCatalogItem timeZoneCatalogItem) {
-		return new TimeZoneCatalogItemResponse(timeZoneCatalogItem.literal(), timeZoneCatalogItem.level1(),
-				timeZoneCatalogItem.level2(), timeZoneCatalogItem.utc());
+		return new TimeZoneCatalogItemResponse(timeZoneCatalogItem.zoneId(), timeZoneCatalogItem.literal(),
+				timeZoneCatalogItem.level1(), timeZoneCatalogItem.level2(), timeZoneCatalogItem.utc());
 	}
 }

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/TimeZoneCatalogItemResponse.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/catalog/TimeZoneCatalogItemResponse.java
@@ -18,11 +18,12 @@ package es.nivel36.janus.api.v1.catalog;
 /**
  * Response payload for a single time zone catalog item.
  *
+ * @param zoneId  full Java zone id
  * @param literal full display value, for example {@code Europe/Madrid (UTC+2)}
  * @param level1  first segment of the zone id (before the first slash)
  * @param level2  remainder of the zone id after the first slash
  * @param utc     UTC offset string used in the literal
  */
-public record TimeZoneCatalogItemResponse(String literal, String level1, String level2, String utc) {
+public record TimeZoneCatalogItemResponse(String zoneId, String literal, String level1, String level2, String utc) {
 
 }

--- a/apps/backend/src/test/java/es/nivel36/janus/api/v1/catalog/CatalogControllerIT.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/api/v1/catalog/CatalogControllerIT.java
@@ -50,6 +50,7 @@ class CatalogControllerIT {
 				.authorities(createAuthorityList("ROLE_JANUS_ADMIN")))) //
 				.andExpect(status().isOk()) //
 				.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)) //
+				.andExpect(jsonPath("$.content[0].zoneId").value("Europe/Madrid")) //
 				.andExpect(jsonPath("$.content[0].literal").value(Matchers.containsString("Europe/Madrid"))) //
 				.andExpect(jsonPath("$.content[0].level1").value("Europe")) //
 				.andExpect(jsonPath("$.content[0].level2").value("Madrid")) //

--- a/apps/frontend/src/app/features/applicationsettings/models/application-settings.ts
+++ b/apps/frontend/src/app/features/applicationsettings/models/application-settings.ts
@@ -2,4 +2,5 @@ export interface ApplicationSettings {
   daysUntilLocked: number;
   employeeWorkplaceCreationAllowed: boolean;
   worksiteChangeDuringShiftAllowed: boolean;
+  defaultTimezone: string;
 }

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
@@ -38,3 +38,13 @@ label {
     margin-top: 0.5rem;
     color: #d8d8d8;
 }
+
+.timezone-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.timezone-control label {
+    cursor: default;
+}

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -34,6 +34,29 @@
                     }}
                 </label>
 
+                <div class="timezone-control">
+                    <label for="default-timezone">
+                        {{ 'applicationSettings.fields.defaultTimezone' | translate }}
+                    </label>
+                    @if (isAdmin) {
+                        <app-autocomplete-textbox
+                            id="default-timezone"
+                            [searchMethod]="searchTimeZones"
+                            [displayWith]="formatTimeZoneOption"
+                            [minChars]="1"
+                            [debounceMs]="250"
+                            [placeholder]="
+                                form.controls.defaultTimezone.value ||
+                                ('applicationSettings.fields.defaultTimezonePlaceholder'
+                                    | translate)
+                            "
+                            (selectedChange)="onDefaultTimezoneChange($event)"
+                        />
+                    } @else {
+                        <span>{{ form.controls.defaultTimezone.value }}</span>
+                    }
+                </div>
+
                 <p class="message error" *ngIf="errorMessage">
                     {{ errorMessage | translate }}
                 </p>

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -3,16 +3,18 @@ import { Component, OnInit, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
-import { finalize } from 'rxjs';
+import { finalize, map } from 'rxjs';
 
 import { CurrentUserFacade } from '../../../core/auth/current-user.facade';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
+import { AutocompleteTextboxComponent } from '../../../shared/ui/autocomplete-textbox/autocomplete-textbox.component';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { CardComponent } from '../../../shared/ui/card/card.component';
 import { RangeSliderComponent } from '../../../shared/ui/range-slider/range-slider.component';
 import { ToggleButtonComponent } from '../../../shared/ui/toggle-button/toggle-button.component';
 import { ApplicationSettings } from '../models/application-settings';
 import { ApplicationSettingsApiService } from '../services/application-settings-api.service';
+import { TimeZoneCatalogItem, TimezoneCatalogApiService } from '../services/timezone-catalog-api.service';
 
 @Component({
   selector: 'app-application-settings-page',
@@ -24,6 +26,7 @@ import { ApplicationSettingsApiService } from '../services/application-settings-
     RangeSliderComponent,
     ToggleButtonComponent,
     ButtonComponent,
+    AutocompleteTextboxComponent,
     CardComponent,
     PageTemplateComponent,
   ],
@@ -34,6 +37,7 @@ export class ApplicationSettingsPageComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly currentUser = inject(CurrentUserFacade);
   private readonly settingsApiService = inject(ApplicationSettingsApiService);
+  private readonly timezoneCatalogApiService = inject(TimezoneCatalogApiService);
   private readonly location = inject(Location);
   private readonly router = inject(Router);
 
@@ -41,6 +45,7 @@ export class ApplicationSettingsPageComponent implements OnInit {
     daysUntilLocked: [0, [Validators.required, Validators.min(0)]],
     employeeWorkplaceCreationAllowed: [false],
     worksiteChangeDuringShiftAllowed: [false],
+    defaultTimezone: ['', [Validators.required]],
   });
 
   loading = true;
@@ -53,6 +58,15 @@ export class ApplicationSettingsPageComponent implements OnInit {
 
   get daysUntilLockedSliderMax(): number {
     return Math.max(31, this.form.controls.daysUntilLocked.value);
+  }
+
+  readonly searchTimeZones = (query: string) =>
+    this.timezoneCatalogApiService.searchTimeZones(query).pipe(map((response) => response.content));
+
+  readonly formatTimeZoneOption = (option: TimeZoneCatalogItem): string => option.literal;
+
+  onDefaultTimezoneChange(option: TimeZoneCatalogItem | null): void {
+    this.form.controls.defaultTimezone.setValue(option?.zoneId ?? '');
   }
 
   ngOnInit(): void {

--- a/apps/frontend/src/app/features/applicationsettings/services/timezone-catalog-api.service.ts
+++ b/apps/frontend/src/app/features/applicationsettings/services/timezone-catalog-api.service.ts
@@ -1,0 +1,39 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+
+export interface TimeZoneCatalogItem {
+  zoneId: string;
+  literal: string;
+  level1: string;
+  level2: string;
+  utc: string;
+}
+
+export interface PagedResponse<T> {
+  content: T[];
+  page: {
+    size: number;
+    number: number;
+    totalElements: number;
+    totalPages: number;
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+export class TimezoneCatalogApiService {
+  private readonly baseUrl = `${environment.apiBaseUrl}/catalogs/time-zones`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  searchTimeZones(search: string, page = 0, size = 25): Observable<PagedResponse<TimeZoneCatalogItem>> {
+    const params = new HttpParams()
+      .set('search', search)
+      .set('page', page)
+      .set('size', size);
+
+    return this.http.get<PagedResponse<TimeZoneCatalogItem>>(this.baseUrl, { params });
+  }
+}

--- a/apps/frontend/src/assets/i18n/ca.json
+++ b/apps/frontend/src/assets/i18n/ca.json
@@ -49,7 +49,9 @@
     "fields": {
       "daysUntilLocked": "Dies fins al bloqueig dels fixatges",
       "employeeWorkplaceCreationAllowed": "Permetre que empleats creïn centres de treball",
-      "worksiteChangeDuringShiftAllowed": "Permetre canvi de centre durant el torn"
+      "worksiteChangeDuringShiftAllowed": "Permetre canvi de centre durant el torn",
+      "defaultTimezone": "Zona horària per defecte",
+      "defaultTimezonePlaceholder": "Cerca zona horària..."
     },
     "messages": {
       "loading": "S'està carregant la configuració...",

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -49,7 +49,9 @@
     "fields": {
       "daysUntilLocked": "Days until time logs are locked",
       "employeeWorkplaceCreationAllowed": "Allow employees to create worksites",
-      "worksiteChangeDuringShiftAllowed": "Allow worksite change during shift"
+      "worksiteChangeDuringShiftAllowed": "Allow worksite change during shift",
+      "defaultTimezone": "Default timezone",
+      "defaultTimezonePlaceholder": "Search timezone..."
     },
     "messages": {
       "loading": "Loading application settings...",

--- a/apps/frontend/src/assets/i18n/es.json
+++ b/apps/frontend/src/assets/i18n/es.json
@@ -49,7 +49,9 @@
     "fields": {
       "daysUntilLocked": "Días hasta el bloqueo de los fichajes",
       "employeeWorkplaceCreationAllowed": "Permitir que empleados creen centros de trabajo",
-      "worksiteChangeDuringShiftAllowed": "Permitir cambiar de centro durante el turno"
+      "worksiteChangeDuringShiftAllowed": "Permitir cambiar de centro durante el turno",
+      "defaultTimezone": "Zona horaria por defecto",
+      "defaultTimezonePlaceholder": "Buscar zona horaria..."
     },
     "messages": {
       "loading": "Cargando configuración...",


### PR DESCRIPTION
### Motivation
- Exponer un catálogo de zonas horarias con `zoneId` para poder seleccionar la zona por identificador en la configuración de la aplicación. 
- Consumir ese catálogo desde el frontend mediante un autocomplete para facilitar la selección administrable de la `defaultTimezone`.
- Mantener el contrato frontend/backend consistente (respuesta paginada y campos del ítem) para soportar búsqueda y paginación.

### Description
- Se añadió el servicio frontend `TimezoneCatalogApiService` en `apps/frontend/src/app/features/applicationsettings/services/timezone-catalog-api.service.ts` con `searchTimeZones(search, page = 0, size = 25)` que llama a `GET {apiBaseUrl}/catalogs/time-zones` y modelos tipados `TimeZoneCatalogItem` y `PagedResponse` con `zoneId`, `literal`, `level1`, `level2`, `utc`.
- Se integró el autocomplete en `ApplicationSettingsPageComponent`, añadiendo el control `defaultTimezone` al formulario, el `searchMethod` que consume el servicio y la lógica para almacenar el `zoneId` seleccionado.
- Se actualizó el modelo frontend `ApplicationSettings` para incluir `defaultTimezone` y se añadieron textos i18n (en/es/ca) y estilos CSS para el control de zona horaria.
- Se actualizó el backend para incluir `zoneId` en `TimeZoneCatalogItemResponse` y el mapeo en `CatalogController`, y se ajustó el test de integración `CatalogControllerIT` para validar `zoneId` en la respuesta.

### Testing
- Ejecutado `mvn -f apps/backend/pom.xml -Dtest=CatalogControllerIT test` y el test `CatalogControllerIT` pasó correctamente (BUILD SUCCESS).
- Ejecutado `npm --prefix apps/frontend run build` y la compilación del frontend completó con éxito (Angular build completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd459342a883278b0944d816ec78fc)