### PR TITLE
test(frontend): align autocomplete spec to minChars=3 behavior

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
@@ -50,9 +50,9 @@ describe('AutocompleteTextboxComponent', () => {
     ) as HTMLButtonElement[];
   }
 
-  it('should call search method after debounce when text has more than 3 chars', fakeAsync(() => {
+  it('should call search method after debounce when text has at least 3 chars', fakeAsync(() => {
     const input = getInput();
-    input.value = 'madr';
+    input.value = 'mad';
     input.dispatchEvent(new Event('input'));
 
     tick(299);
@@ -61,12 +61,12 @@ describe('AutocompleteTextboxComponent', () => {
     tick(1);
     fixture.detectChanges();
 
-    expect(searchMethodSpy).toHaveBeenCalledOnceWith('madr');
-    expect(component.results).toEqual(['madr-1', 'madr-2']);
+    expect(searchMethodSpy).toHaveBeenCalledOnceWith('mad');
+    expect(component.results).toEqual(['mad-1', 'mad-2']);
     expect(getOverlayResultButtons().length).toBe(2);
   }));
 
-  it('should cancel queued search when user backspaces to 3 chars before debounce', fakeAsync(() => {
+  it('should cancel queued search when user backspaces to fewer than 3 chars before debounce', fakeAsync(() => {
     const input = getInput();
 
     input.value = 'madr';
@@ -74,7 +74,7 @@ describe('AutocompleteTextboxComponent', () => {
 
     tick(150);
 
-    input.value = 'mad';
+    input.value = 'ma';
     input.dispatchEvent(new Event('input'));
 
     tick(300);
@@ -85,9 +85,9 @@ describe('AutocompleteTextboxComponent', () => {
     expect(getOverlayResultButtons().length).toBe(0);
   }));
 
-  it('should not call search method when text has 3 chars or fewer', fakeAsync(() => {
+  it('should not call search method when text has fewer than 3 chars', fakeAsync(() => {
     const input = getInput();
-    input.value = 'mad';
+    input.value = 'ma';
     input.dispatchEvent(new Event('input'));
 
     tick(400);


### PR DESCRIPTION
### Motivation

- The autocomplete component triggers searches when the input length is at least `minChars` (default `3`), but the tests assumed a different threshold and occasionally used inconsistent input lengths, causing flaky/failing specs.

### Description

- Updated the debounce test to use a 3-character query and adjusted expected search/result values to assert calls with `'mad'` and results `['mad-1','mad-2']`.
- Modified the cancellation test to backspace to fewer-than-3 characters (`'ma'`) so it validates cancelling the queued search correctly.
- Adjusted the no-search test to use a 2-character query (`'ma'`) and renamed test descriptions to reflect the "fewer than 3 chars" semantics; only `apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts` was changed.

### Testing

- Ran `npm test -- --watch=false --browsers=ChromeHeadless --include='src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts'` which initially failed during build due to a missing `@angular/cdk` dependency. 
- Installed `@angular/cdk@^20` with `npm i --no-save @angular/cdk@^20` and reran the targeted test command; the build completed successfully but the test run could not start because the `ChromeHeadless` binary is not available in this environment.
- The targeted spec file compiles and the build output contains the test bundle, indicating the spec changes are valid, but full automated execution could not be completed here due to the browser binary limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd88a7bec48327a9df38af7a46349d)