### PR TITLE
Add User Preferences page, menu entry and backend-backed PreferencesService

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -12,6 +12,17 @@ export const appRoutes: Routes = [
       import('./core/error-pages/forbidden/forbidden.component').then((m) => m.ForbiddenComponent),
   },
   {
+    path: 'user-preferences',
+    canActivate: [authGuard],
+    data: {
+      realmRole: ['JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN'],
+    },
+    loadComponent: () =>
+      import('./features/preferences/pages/user-preferences-page.component').then(
+        (m) => m.UserPreferencesPageComponent,
+      ),
+  },
+  {
     path: 'application-settings',
     canActivate: [authGuard],
     data: {

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
@@ -93,3 +93,8 @@
     outline: 2px solid #ffffff;
     outline-offset: -2px;
 }
+
+.main-menu__icon-button--user-preferences {
+    background-color: #050505;
+    color: #f9d600;
+}

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
@@ -8,11 +8,21 @@
             <button
                 type="button"
                 class="main-menu__icon-button main-menu__icon-button--settings"
-                aria-label="Configuración"
-                title="Configuración"
-                (click)="goToSettings()"
+                [attr.aria-label]="'navigation.applicationSettings' | translate"
+                [attr.title]="'navigation.applicationSettings' | translate"
+                (click)="goToApplicationSettings()"
             >
                 <span aria-hidden="true">⚙</span>
+            </button>
+
+            <button
+                type="button"
+                class="main-menu__icon-button main-menu__icon-button--user-preferences"
+                [attr.aria-label]="'navigation.userPreferences' | translate"
+                [attr.title]="'navigation.userPreferences' | translate"
+                (click)="goToUserPreferences()"
+            >
+                <span aria-hidden="true">👤</span>
             </button>
 
             <button

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.ts
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
+import { TranslatePipe } from '@ngx-translate/core';
 
 import { CurrentUserFacade } from '../../auth/current-user.facade';
 import { AuthService } from '../../auth/auth.service';
@@ -8,7 +9,7 @@ import { AuthService } from '../../auth/auth.service';
 @Component({
   selector: 'app-main-menu',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, TranslatePipe],
   templateUrl: './main-menu.component.html',
   styleUrls: ['./main-menu.component.css'],
 })
@@ -26,7 +27,11 @@ export class MainMenuComponent {
     this.router.navigate(['/login']);
   }
 
-  goToSettings(): void {
+  goToUserPreferences(): void {
+    this.router.navigate(['/user-preferences']);
+  }
+
+  goToApplicationSettings(): void {
     this.router.navigate(['/application-settings']);
   }
 }

--- a/apps/frontend/src/app/features/preferences/pages/user-preferences-page.component.css
+++ b/apps/frontend/src/app/features/preferences/pages/user-preferences-page.component.css
@@ -1,0 +1,45 @@
+.preferences-content {
+    width: min(1080px, 100%);
+    display: flex;
+    gap: 2.5rem;
+    color: #f9f9f9;
+}
+
+.preferences-content app-card {
+    display: block;
+    flex: 1;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    flex-grow: 1;
+}
+
+.field-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+}
+
+label {
+    color: #ffffff;
+    font-weight: 700;
+}
+
+select {
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 0.6rem;
+    padding: 0.65rem 0.75rem;
+    background: rgba(0, 0, 0, 0.2);
+    color: #ffffff;
+}
+
+.message {
+    margin: 0;
+}
+
+.error {
+    color: #ff8a8a;
+}

--- a/apps/frontend/src/app/features/preferences/pages/user-preferences-page.component.html
+++ b/apps/frontend/src/app/features/preferences/pages/user-preferences-page.component.html
@@ -1,0 +1,53 @@
+<app-page-template appNameKey="navigation.janus" pageNameKey="navigation.userPreferences">
+    <section page-body class="preferences-content">
+        <app-card styleClass="preferences-card">
+            <form [formGroup]="form" (ngSubmit)="save()">
+                <div class="field-control">
+                    <label for="preferences-locale">{{ 'userPreferences.fields.locale' | translate }}</label>
+                    <select id="preferences-locale" formControlName="locale">
+                        @for (locale of localeOptions; track locale) {
+                            <option [value]="locale">{{ locale }}</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="field-control">
+                    <label for="preferences-time-format">{{ 'userPreferences.fields.timeFormat' | translate }}</label>
+                    <select id="preferences-time-format" formControlName="timeFormat">
+                        @for (timeFormat of timeFormatOptions; track timeFormat) {
+                            <option [value]="timeFormat">
+                                {{ ('userPreferences.timeFormat.' + timeFormat) | translate }}
+                            </option>
+                        }
+                    </select>
+                </div>
+
+                <div class="field-control timezone-control">
+                    <label for="preferences-timezone">{{ 'userPreferences.fields.defaultTimezone' | translate }}</label>
+                    <app-autocomplete-textbox
+                        id="preferences-timezone"
+                        [formControl]="timezoneControl"
+                        [searchMethod]="searchMethod"
+                        [displayWith]="timezoneDisplayWith"
+                        [emptyHint]="'userPreferences.fields.defaultTimezoneHint' | translate"
+                        (selectedChange)="onTimezoneSelected($event)"
+                    />
+                </div>
+
+                <p class="message error" *ngIf="errorMessage">{{ errorMessage | translate }}</p>
+
+                <div class="buttons">
+                    <app-button type="button" variant="secondary" (clicked)="goBack()">
+                        {{ 'actions.cancel' | translate }}
+                    </app-button>
+
+                    <app-button type="submit" [disabled]="form.invalid || saving" variant="main">
+                        {{ 'actions.save' | translate }}
+                    </app-button>
+                </div>
+            </form>
+        </app-card>
+    </section>
+
+    <div page-footer></div>
+</app-page-template>

--- a/apps/frontend/src/app/features/preferences/pages/user-preferences-page.component.ts
+++ b/apps/frontend/src/app/features/preferences/pages/user-preferences-page.component.ts
@@ -1,0 +1,154 @@
+import { CommonModule, Location } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { TranslatePipe } from '@ngx-translate/core';
+import { Observable, finalize, of } from 'rxjs';
+
+import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
+import { AutocompleteTextboxComponent } from '../../../shared/ui/autocomplete-textbox/autocomplete-textbox.component';
+import { ButtonComponent } from '../../../shared/ui/button/button.component';
+import { CardComponent } from '../../../shared/ui/card/card.component';
+import { AppPreferences, PreferencesService, TimeFormat } from '../preferences.service';
+
+type TimezoneOption = {
+  zoneId: string;
+  literal: string;
+};
+
+@Component({
+  selector: 'app-user-preferences-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    TranslatePipe,
+    AutocompleteTextboxComponent,
+    ButtonComponent,
+    CardComponent,
+    PageTemplateComponent,
+  ],
+  templateUrl: './user-preferences-page.component.html',
+  styleUrl: './user-preferences-page.component.css',
+})
+export class UserPreferencesPageComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly preferencesService = inject(PreferencesService);
+  private readonly location = inject(Location);
+  private readonly router = inject(Router);
+
+  readonly form = this.fb.nonNullable.group({
+    locale: ['es-ES', [Validators.required, Validators.pattern(/^[a-z]{2,3}-[A-Z]{2}$/)]],
+    timeFormat: ['H24' as TimeFormat, Validators.required],
+    defaultTimezone: ['', Validators.required],
+  });
+  readonly timezoneControl = this.fb.control<TimezoneOption | null>(null);
+  readonly timezoneCatalog = this.createTimezoneCatalog();
+  readonly localeOptions = ['es-ES', 'en-US', 'ca-ES'];
+  readonly timeFormatOptions: TimeFormat[] = ['H24', 'H12'];
+
+  loading = true;
+  saving = false;
+  errorMessage = '';
+
+  ngOnInit(): void {
+    this.loadPreferences();
+  }
+
+  loadPreferences(): void {
+    this.loading = true;
+    this.errorMessage = '';
+
+    this.preferencesService
+      .load(true)
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: (preferences) => {
+          this.form.reset(preferences);
+          this.timezoneControl.setValue(this.findTimezoneOption(preferences.defaultTimezone), {
+            emitEvent: false,
+          });
+        },
+        error: () => {
+          this.errorMessage = 'userPreferences.errors.load';
+        },
+      });
+  }
+
+  save(): void {
+    if (this.saving || this.form.invalid) {
+      return;
+    }
+
+    this.saving = true;
+    this.errorMessage = '';
+
+    const payload: AppPreferences = this.form.getRawValue();
+
+    this.preferencesService
+      .update(payload)
+      .pipe(finalize(() => (this.saving = false)))
+      .subscribe({
+        next: () => this.goBack(),
+        error: () => {
+          this.errorMessage = 'userPreferences.errors.update';
+        },
+      });
+  }
+
+  goBack(): void {
+    if (window.history.length > 1) {
+      this.location.back();
+      return;
+    }
+
+    this.router.navigate(['/']);
+  }
+
+  onTimezoneSelected(option: TimezoneOption | null): void {
+    this.form.controls.defaultTimezone.setValue(option?.zoneId ?? '');
+  }
+
+  timezoneDisplayWith = (option: TimezoneOption): string => option.literal;
+
+  searchMethod = (query: string): Observable<TimezoneOption[]> => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (!normalizedQuery) {
+      return of([]);
+    }
+
+    return of(
+      this.timezoneCatalog
+        .filter(
+          (option) =>
+            option.zoneId.toLowerCase().includes(normalizedQuery) ||
+            option.literal.toLowerCase().includes(normalizedQuery),
+        )
+        .slice(0, 50),
+    );
+  };
+
+  private createTimezoneCatalog(): TimezoneOption[] {
+    return Intl.supportedValuesOf('timeZone').map((zoneId) => ({
+      zoneId,
+      literal: `${zoneId} (${this.getUtcOffsetLiteral(zoneId)})`,
+    }));
+  }
+
+  private getUtcOffsetLiteral(zoneId: string): string {
+    const utcOffsetPart = new Intl.DateTimeFormat('en-US', {
+      timeZone: zoneId,
+      timeZoneName: 'shortOffset',
+    })
+      .formatToParts(new Date())
+      .find((part) => part.type === 'timeZoneName')
+      ?.value;
+
+    return utcOffsetPart?.replace('GMT', 'UTC') ?? 'UTC';
+  }
+
+  private findTimezoneOption(zoneId: string): TimezoneOption | null {
+    return this.timezoneCatalog.find((option) => option.zoneId === zoneId) ?? null;
+  }
+}

--- a/apps/frontend/src/app/features/preferences/preferences.service.ts
+++ b/apps/frontend/src/app/features/preferences/preferences.service.ts
@@ -1,25 +1,34 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Injectable, signal } from '@angular/core';
+import { Injectable, signal, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, throwError } from 'rxjs';
-import { catchError, finalize, shareReplay, tap } from 'rxjs/operators';
+import { catchError, finalize, map, shareReplay, tap } from 'rxjs/operators';
+
+import { environment } from '../../../environments/environment';
+import { AuthService } from '../../core/auth/auth.service';
+
+export type TimeFormat = 'H12' | 'H24';
 
 export interface AppPreferences {
   locale: string;
-  timeFormat: '12h' | '24h';
-  dateFormat: string;
-  timezone: string;
-  theme?: 'light' | 'dark';
+  timeFormat: TimeFormat;
+  defaultTimezone: string;
+}
+
+interface AppUserPreferencesResponse extends AppPreferences {
+  username: string;
 }
 
 @Injectable({ providedIn: 'root' })
 export class PreferencesService {
+  private readonly http = inject(HttpClient);
+  private readonly authService = inject(AuthService);
+  private readonly baseUrl = `${environment.apiBaseUrl}/appusers`;
+
   readonly prefs = signal<AppPreferences | null>(null);
   private inflight?: Observable<AppPreferences>;
-
-  constructor(private http: HttpClient) {}
 
   load(force = false): Observable<AppPreferences> {
     const current = this.prefs();
@@ -30,20 +39,55 @@ export class PreferencesService {
       return this.inflight;
     }
 
-    this.inflight = this.http.get<AppPreferences>('/api/preferences').pipe(
-      tap((v) => this.prefs.set(v)),
-      catchError((err) => {
-        this.prefs.set(null);
-        return throwError(() => err);
-      }),
-      finalize(() => (this.inflight = undefined)),
-      shareReplay({ bufferSize: 1, refCount: false }),
-    );
+    const username = this.resolveUsername();
+    this.inflight = this.http
+      .get<AppUserPreferencesResponse>(`${this.baseUrl}/${encodeURIComponent(username)}`)
+      .pipe(
+        map((response) => this.toPreferences(response)),
+        tap((preferences) => this.prefs.set(preferences)),
+        catchError((err) => {
+          this.prefs.set(null);
+          return throwError(() => err);
+        }),
+        finalize(() => (this.inflight = undefined)),
+        shareReplay({ bufferSize: 1, refCount: false }),
+      );
+
     return this.inflight;
+  }
+
+  update(payload: AppPreferences): Observable<AppPreferences> {
+    const username = this.resolveUsername();
+
+    return this.http
+      .put<AppUserPreferencesResponse>(`${this.baseUrl}/${encodeURIComponent(username)}`, payload)
+      .pipe(
+        map((response) => this.toPreferences(response)),
+        tap((preferences) => this.prefs.set(preferences)),
+      );
   }
 
   clear(): void {
     this.prefs.set(null);
     this.inflight = undefined;
+  }
+
+  private resolveUsername(): string {
+    const claims = this.authService.getClaims();
+    const username = claims?.email ?? claims?.preferred_username;
+
+    if (!username) {
+      throw new Error('Cannot resolve username for preferences');
+    }
+
+    return username;
+  }
+
+  private toPreferences(response: AppUserPreferencesResponse): AppPreferences {
+    return {
+      locale: response.locale,
+      timeFormat: response.timeFormat,
+      defaultTimezone: response.defaultTimezone,
+    };
   }
 }

--- a/apps/frontend/src/assets/i18n/ca.json
+++ b/apps/frontend/src/assets/i18n/ca.json
@@ -2,7 +2,8 @@
   "navigation": {
     "janus": "Janus",
     "dashboard": "Panell de control",
-    "applicationSettings": "Configuració"
+    "applicationSettings": "Configuració",
+    "userPreferences": "Preferències d'usuari"
   },
   "actions": {
     "save": "Desa",
@@ -61,6 +62,23 @@
     "errors": {
       "load": "No s'ha pogut carregar la configuració.",
       "update": "No s'ha pogut actualitzar la configuració."
+    }
+  },
+  "userPreferences": {
+    "title": "Preferències d'usuari",
+    "fields": {
+      "locale": "Idioma",
+      "timeFormat": "Format d'hora",
+      "defaultTimezone": "Zona horària predeterminada",
+      "defaultTimezoneHint": "Busca la teva zona horària. Per exemple, Europe/Madrid."
+    },
+    "timeFormat": {
+      "H24": "24 hores",
+      "H12": "12 hores"
+    },
+    "errors": {
+      "load": "No s'han pogut carregar les preferències d'usuari.",
+      "update": "No s'han pogut actualitzar les preferències d'usuari."
     }
   }
 }

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -2,7 +2,8 @@
   "navigation": {
     "janus": "Janus",
     "dashboard": "Dashboard",
-    "applicationSettings": "Application settings"
+    "applicationSettings": "Application settings",
+    "userPreferences": "User preferences"
   },
   "actions": {
     "save": "Save",
@@ -61,6 +62,23 @@
     "errors": {
       "load": "Unable to load application settings.",
       "update": "Unable to update application settings."
+    }
+  },
+  "userPreferences": {
+    "title": "User preferences",
+    "fields": {
+      "locale": "Language",
+      "timeFormat": "Time format",
+      "defaultTimezone": "Default timezone",
+      "defaultTimezoneHint": "Find your timezone. For example, Europe/Madrid."
+    },
+    "timeFormat": {
+      "H24": "24-hour",
+      "H12": "12-hour"
+    },
+    "errors": {
+      "load": "Unable to load user preferences.",
+      "update": "Unable to update user preferences."
     }
   }
 }

--- a/apps/frontend/src/assets/i18n/es.json
+++ b/apps/frontend/src/assets/i18n/es.json
@@ -2,7 +2,8 @@
   "navigation": {
     "janus": "Janus",
     "dashboard": "Panel de control",
-    "applicationSettings": "Configuración"
+    "applicationSettings": "Configuración",
+    "userPreferences": "Preferencias de usuario"
   },
   "actions": {
     "save": "Guarda",
@@ -61,6 +62,23 @@
     "errors": {
       "load": "No se pudo cargar la configuración.",
       "update": "No se pudo actualizar la configuración."
+    }
+  },
+  "userPreferences": {
+    "title": "Preferencias de usuario",
+    "fields": {
+      "locale": "Idioma",
+      "timeFormat": "Formato de hora",
+      "defaultTimezone": "Zona horaria predeterminada",
+      "defaultTimezoneHint": "Busca tu zona horaria. Por ejemplo, Europe/Madrid."
+    },
+    "timeFormat": {
+      "H24": "24 horas",
+      "H12": "12 horas"
+    },
+    "errors": {
+      "load": "No se pudieron cargar las preferencias de usuario.",
+      "update": "No se pudieron actualizar las preferencias de usuario."
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Provide a UI for users to configure per-user settings (locale, time format and default timezone). 
- Surface a quick access entry in the main menu to manage user preferences.
- Persist and load preferences from the backend using the authenticated user's identity.

### Description

- Add a guarded route `'/user-preferences'` to `appRoutes` that lazy-loads `UserPreferencesPageComponent`.
- Add a user preferences button to the main menu and adjust menu handlers by introducing `goToUserPreferences()` and renaming `goToSettings()` to `goToApplicationSettings()` in `MainMenuComponent` and update related templates and styles.
- Implement the standalone `UserPreferencesPageComponent` with template and styles (`.ts`, `.html`, `.css`) including a reactive form for `locale`, `timeFormat` and `defaultTimezone`, an autocomplete timezone search, and navigation/save logic (`save()`, `loadPreferences()`, `goBack()`).
- Extend `PreferencesService` to call backend endpoints at `${environment.apiBaseUrl}/appusers/{username}`, add `update()` and `load()` behavior that maps server response to `AppPreferences`, and resolve the username from `AuthService` claims.
- Add translation keys for `userPreferences` to `en.json`, `es.json` and `ca.json` and add a CSS rule for the new menu icon style.

### Testing

- Performed a frontend build and smoke test of the UI, including navigating to the new `'/user-preferences'` page and exercising the save/load flows; build and smoke checks succeeded.
- Ran the project's unit test suite and linter; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd917695008327960fa2bdd81d7cfc)