### PR TITLE
Make Janus brand in header link to home page

### DIFF
--- a/apps/frontend/src/app/core/layout/page-template/page-template.component.css
+++ b/apps/frontend/src/app/core/layout/page-template/page-template.component.css
@@ -29,6 +29,16 @@
     color: #f9d600;
 }
 
+.brand-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+.brand-link:hover,
+.brand-link:focus-visible {
+    text-decoration: underline;
+}
+
 .section-label {
     font-size: 1rem;
     color: rgba(249, 249, 249, 0.72);

--- a/apps/frontend/src/app/core/layout/page-template/page-template.component.html
+++ b/apps/frontend/src/app/core/layout/page-template/page-template.component.html
@@ -2,7 +2,9 @@
     <section class="page-template">
         <header class="page-header">
             <h1 class="brand">
-                {{ appNameKey | translate }}
+                <a class="brand-link" routerLink="/">
+                    {{ appNameKey | translate }}
+                </a>
             </h1>
             <div class="header-actions">
                 <span class="section-label">

--- a/apps/frontend/src/app/core/layout/page-template/page-template.component.ts
+++ b/apps/frontend/src/app/core/layout/page-template/page-template.component.ts
@@ -1,12 +1,13 @@
 import { Component, Input } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
+import { RouterLink } from '@angular/router';
 
 import { MainMenuComponent } from '../../../core/layout/main-menu/main-menu.component';
 
 @Component({
   selector: 'app-page-template',
   standalone: true,
-  imports: [TranslatePipe, MainMenuComponent],
+  imports: [TranslatePipe, RouterLink, MainMenuComponent],
   templateUrl: './page-template.component.html',
   styleUrl: './page-template.component.css',
 })


### PR DESCRIPTION
### Motivation
- Users expect the app name in the header to navigate back to the application's root for quick access to the home/dashboard.
- Keep header behavior consistent with common web app navigation patterns and improve keyboard/visual affordance for returning to the main page.

### Description
- Added `RouterLink` to the standalone `PageTemplateComponent` imports to enable router-aware links in the template by updating `apps/frontend/src/app/core/layout/page-template/page-template.component.ts`.
- Changed the header template to render the app name as a link with `routerLink="/"` by modifying `apps/frontend/src/app/core/layout/page-template/page-template.component.html`.
- Added `.brand-link` CSS to preserve the existing visual style and show an underline on `:hover`/`:focus-visible` in `apps/frontend/src/app/core/layout/page-template/page-template.component.css`.

### Testing
- Ran `cd apps/frontend && npm run build` and the build failed due to a pre-existing missing dependency `@angular/cdk/overlay`, which is unrelated to this change and blocks a full build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec40d60e48327aff2a7a7634b42b7)