### PR TITLE
Use user preference locale as app language

### DIFF
--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -2,21 +2,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
 import { AppComponent } from './app.component';
+import { CurrentUserFacade } from './core/user/services/current-user.facade';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
+  it('should create the app', async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        {
+          provide: CurrentUserFacade,
+          useValue: { preferences$: of(null) },
+        },
+        {
+          provide: TranslateService,
+          useValue: { currentLang: 'en', use: jasmine.createSpy('use') },
+        },
+      ],
     }).compileComponents();
-  });
 
-  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('should apply app language from user locale preferences', async () => {
+    const useSpy = jasmine.createSpy('use');
+
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [
+        {
+          provide: CurrentUserFacade,
+          useValue: {
+            preferences$: of({ locale: 'ca-ES', timeFormat: 'H24', defaultTimezone: 'Europe/Madrid' }),
+          },
+        },
+        {
+          provide: TranslateService,
+          useValue: { currentLang: 'en', use: useSpy },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    expect(useSpy).toHaveBeenCalledWith('ca');
   });
 });

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -1,8 +1,14 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Component } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterOutlet } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
+
+import { resolveSupportedLanguage } from './app.config';
+import { CurrentUserFacade } from './core/user/services/current-user.facade';
 
 @Component({
   selector: 'app-root',
@@ -11,4 +17,24 @@ import { RouterOutlet } from '@angular/router';
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  private readonly currentUserFacade = inject(CurrentUserFacade);
+  private readonly translateService = inject(TranslateService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  ngOnInit(): void {
+    this.currentUserFacade.preferences$
+      .pipe(
+        map((preferences) => preferences?.locale),
+        filter((locale): locale is string => !!locale),
+        map((locale) =>
+          resolveSupportedLanguage(locale, resolveSupportedLanguage(this.translateService.currentLang)),
+        ),
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((language) => {
+        this.translateService.use(language);
+      });
+  }
+}

--- a/apps/frontend/src/app/app.config.spec.ts
+++ b/apps/frontend/src/app/app.config.spec.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import { resolveInitialLanguage } from './app.config';
+import { resolveInitialLanguage, resolveSupportedLanguage } from './app.config';
 
 describe('resolveInitialLanguage', () => {
   it('returns ca when browser language is Catalan', () => {
@@ -14,5 +14,16 @@ describe('resolveInitialLanguage', () => {
 
   it('falls back to English when no supported languages are present', () => {
     expect(resolveInitialLanguage(['fr-FR', 'de-DE'])).toBe('en');
+  });
+});
+
+
+describe('resolveSupportedLanguage', () => {
+  it('normalizes locale tags to a supported language', () => {
+    expect(resolveSupportedLanguage('es-ES')).toBe('es');
+  });
+
+  it('falls back when locale is not supported', () => {
+    expect(resolveSupportedLanguage('fr-FR')).toBe('en');
   });
 });

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -16,17 +16,32 @@ import { appRoutes } from './app.routes';
 
 export const supportedLanguages = ['en', 'es', 'ca'] as const;
 
+export function resolveSupportedLanguage(
+  locale: string | undefined | null,
+  fallbackLanguage: (typeof supportedLanguages)[number] = 'en',
+): (typeof supportedLanguages)[number] {
+  const normalizedLanguage = locale?.toLowerCase().split('-')[0];
+
+  if (normalizedLanguage && supportedLanguages.includes(normalizedLanguage as (typeof supportedLanguages)[number])) {
+    return normalizedLanguage as (typeof supportedLanguages)[number];
+  }
+
+  return fallbackLanguage;
+}
+
 export function resolveInitialLanguage(
   browserLanguages: readonly string[] | undefined,
   fallbackLanguage: (typeof supportedLanguages)[number] = 'en',
 ): (typeof supportedLanguages)[number] {
-  const normalizedLanguages = (browserLanguages ?? [])
-    .map((language) => language.toLowerCase().split('-')[0])
-    .filter((language): language is (typeof supportedLanguages)[number] =>
-      supportedLanguages.includes(language as (typeof supportedLanguages)[number]),
-    );
+  for (const browserLanguage of browserLanguages ?? []) {
+    const resolvedLanguage = resolveSupportedLanguage(browserLanguage, fallbackLanguage);
 
-  return normalizedLanguages[0] ?? fallbackLanguage;
+    if (resolvedLanguage !== fallbackLanguage || browserLanguage?.toLowerCase().startsWith(fallbackLanguage)) {
+      return resolvedLanguage;
+    }
+  }
+
+  return fallbackLanguage;
 }
 
 const initialLanguage = resolveInitialLanguage(


### PR DESCRIPTION
### Motivation
- The app language must be driven by the authenticated user preferences `locale` so the UI matches the user-selected locale.
- Ensure locale normalization (e.g. `ca-ES` → `ca`) and consistent resolution across initial browser detection and user preferences.

### Description
- Subscribe the root `AppComponent` to `CurrentUserFacade.preferences$` and call `TranslateService.use(...)` when a persisted `locale` is available. (file: `apps/frontend/src/app/app.component.ts`)
- Add `resolveSupportedLanguage(...)` to `app.config.ts` to normalize BCP47 tags to supported languages and reuse it from `resolveInitialLanguage(...)`. (file: `apps/frontend/src/app/app.config.ts`)
- Update and add unit tests: extend `app.config.spec.ts` with tests for `resolveSupportedLanguage` and add an `AppComponent` test that asserts a saved preference (`ca-ES`) results in `translateService.use('ca')`. (files: `apps/frontend/src/app/app.config.spec.ts`, `apps/frontend/src/app/app.component.spec.ts`)

### Testing
- Ran the frontend unit tests with `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/app.component.spec.ts --include=src/app/app.config.spec.ts`; the build failed due to a missing dependency error for `@angular/cdk/overlay`, unrelated to these changes, so tests could not complete. 
- Verified the TypeScript type error from initial changes was resolved by normalizing the `translateService.currentLang` value via `resolveSupportedLanguage`. 
- New and updated specs were added and exercise the language resolution logic and `AppComponent` behavior, but the full test run is blocked by the environment dependency issue described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec68321f88327829b1a3704e57825)