### PR TITLE
Fix i18n locale resolution for language-region tags

### DIFF
--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -19,7 +19,7 @@ describe('AppComponent', () => {
         },
         {
           provide: TranslateService,
-          useValue: { currentLang: 'en', use: jasmine.createSpy('use') },
+          useValue: { currentLang: 'en-EN', use: jasmine.createSpy('use') },
         },
       ],
     }).compileComponents();
@@ -43,7 +43,7 @@ describe('AppComponent', () => {
         },
         {
           provide: TranslateService,
-          useValue: { currentLang: 'en', use: useSpy },
+          useValue: { currentLang: 'en-EN', use: useSpy },
         },
       ],
     }).compileComponents();
@@ -51,6 +51,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
 
-    expect(useSpy).toHaveBeenCalledWith('ca');
+    expect(useSpy).toHaveBeenCalledWith('ca-ES');
   });
 });

--- a/apps/frontend/src/app/app.config.spec.ts
+++ b/apps/frontend/src/app/app.config.spec.ts
@@ -5,25 +5,29 @@ import { resolveInitialLanguage, resolveSupportedLanguage } from './app.config';
 
 describe('resolveInitialLanguage', () => {
   it('returns ca when browser language is Catalan', () => {
-    expect(resolveInitialLanguage(['ca-ES'])).toBe('ca');
+    expect(resolveInitialLanguage(['ca-ES'])).toBe('ca-ES');
   });
 
   it('returns first supported language from browser preferences', () => {
-    expect(resolveInitialLanguage(['fr-FR', 'es-ES', 'en-GB'])).toBe('es');
+    expect(resolveInitialLanguage(['fr-FR', 'es-ES', 'en-GB'])).toBe('es-ES');
   });
 
   it('falls back to English when no supported languages are present', () => {
-    expect(resolveInitialLanguage(['fr-FR', 'de-DE'])).toBe('en');
+    expect(resolveInitialLanguage(['fr-FR', 'de-DE'])).toBe('en-EN');
   });
 });
 
 
 describe('resolveSupportedLanguage', () => {
   it('normalizes locale tags to a supported language', () => {
-    expect(resolveSupportedLanguage('es-ES')).toBe('es');
+    expect(resolveSupportedLanguage('es-ES')).toBe('es-ES');
+  });
+
+  it('maps language-only tags to a supported locale', () => {
+    expect(resolveSupportedLanguage('es')).toBe('es-ES');
   });
 
   it('falls back when locale is not supported', () => {
-    expect(resolveSupportedLanguage('fr-FR')).toBe('en');
+    expect(resolveSupportedLanguage('fr-FR', 'en-EN')).toBe('en-EN');
   });
 });

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -20,13 +20,22 @@ export function resolveSupportedLanguage(
   locale: string | undefined | null,
   fallbackLanguage: (typeof supportedLanguages)[number] = 'es-ES',
 ): (typeof supportedLanguages)[number] {
-  const normalizedLanguage = locale?.toLowerCase().split('-')[0];
+  const normalizedLocale = locale?.toLowerCase();
+  const exactMatch = supportedLanguages.find(
+    (supportedLanguage) => supportedLanguage.toLowerCase() === normalizedLocale,
+  );
 
-  if (
-    normalizedLanguage &&
-    supportedLanguages.includes(normalizedLanguage as (typeof supportedLanguages)[number])
-  ) {
-    return normalizedLanguage as (typeof supportedLanguages)[number];
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const languageOnly = normalizedLocale?.split('-')[0];
+  const languagePrefixMatch = supportedLanguages.find((supportedLanguage) =>
+    supportedLanguage.toLowerCase().startsWith(`${languageOnly}-`),
+  );
+
+  if (languagePrefixMatch) {
+    return languagePrefixMatch;
   }
 
   return fallbackLanguage;
@@ -64,7 +73,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(appRoutes),
     provideTranslateService({
       lang: initialLanguage,
-      fallbackLang: 'en',
+      fallbackLang: 'en-EN',
       loader: provideTranslateHttpLoader({
         prefix: 'assets/i18n/',
         suffix: '.json',


### PR DESCRIPTION
### Motivation
- The app attempted to load translation files using language-only tags (e.g. `es`) after switching to language-region locales, causing missing translation lookups like `es.json` instead of `es-ES.json`.
- The change aims to ensure the selected locale always matches available `assets/i18n` filenames (e.g. `en-EN.json`, `es-ES.json`, `ca-ES.json`) so ngx-translate loads the correct file.

### Description
- Changed `resolveSupportedLanguage` to first check for an exact `language-region` match, then map language-only tags to a supported `language-region` entry if present, otherwise return the fallback locale (file: `apps/frontend/src/app/app.config.ts`).
- Updated the ngx-translate `fallbackLang` to `en-EN` so fallbacks point to the actual translation asset filename (file: `apps/frontend/src/app/app.config.ts`).
- Updated unit tests to assert `language-region` formatted locales and added a test for mapping language-only tags to a supported locale (files: `apps/frontend/src/app/app.config.spec.ts` and `apps/frontend/src/app/app.component.spec.ts`).
- Committed changes that keep runtime behaviour and translation file lookup aligned with the `assets/i18n/*.json` filenames.

### Testing
- Ran frontend unit tests for the modified specs with `npm test` targeting `app.config.spec.ts` and `app.component.spec.ts`, but the test run failed before executing the specs due to a missing dependency error for `@angular/cdk/overlay` in the environment, so specs did not complete.
- No other automated tests were run in this rollout and the code changes are committed and ready for CI verification that includes the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b9c0ca788327ad28acc7b7bdad51)