### PR TITLE
Improve ARIA compliance for shared range slider component

### DIFF
--- a/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.html
+++ b/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.html
@@ -1,11 +1,12 @@
 <div class="range-slider">
     <div class="range-slider__header">
-        <span class="range-slider__label">{{ label }}</span>
+        <label class="range-slider__label" [attr.for]="sliderId">{{ label }}</label>
         <span class="range-slider__value"> {{ value }}{{ unit ? ' ' + unit : '' }} </span>
     </div>
 
     <div class="range-slider__track-wrapper">
         <input
+            [id]="sliderId"
             type="range"
             class="range-slider__input"
             [min]="min"
@@ -13,6 +14,11 @@
             [step]="step"
             [value]="value"
             [disabled]="disabled"
+            [attr.aria-label]="label || null"
+            [attr.aria-valuemin]="min"
+            [attr.aria-valuemax]="max"
+            [attr.aria-valuenow]="value"
+            [attr.aria-valuetext]="valueText"
             [style.--progress]="progressPercent + '%'"
             [style.--progress-value]="progressPercent"
             (input)="onInput($event)"

--- a/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.ts
+++ b/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.ts
@@ -15,12 +15,15 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
   ],
 })
 export class RangeSliderComponent implements ControlValueAccessor {
+  private static nextId = 0;
+
   @Input() label = '';
   @Input() unit = '';
   @Input() min = 0;
   @Input() max = 100;
   @Input() step = 1;
 
+  readonly sliderId = `range-slider-${RangeSliderComponent.nextId++}`;
   value = 0;
   disabled = false;
 
@@ -61,5 +64,9 @@ export class RangeSliderComponent implements ControlValueAccessor {
     }
 
     return ((this.value - this.min) / range) * 100;
+  }
+
+  get valueText(): string {
+    return this.unit ? `${this.value} ${this.unit}` : `${this.value}`;
   }
 }


### PR DESCRIPTION
### Motivation
- Improve accessibility of the shared range slider so assistive technologies can announce the control and its current value reliably.
- Ensure the visible label is programmatically associated with the native `input[type="range"]` and that value semantics include the unit when present.

### Description
- Added a per-instance unique id via `private static nextId` and exposed it as `sliderId` to bind `id` on the input.
- Replaced the header label `span` with a `label` element and associated it with the input using `[attr.for]="sliderId"` and `[id]="sliderId"` on the input.
- Added ARIA attributes: `aria-label`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-valuetext` (the latter is computed by a new `valueText` getter that includes the unit when present).
- Files changed: `apps/frontend/src/app/shared/ui/range-slider/range-slider.component.ts` and `apps/frontend/src/app/shared/ui/range-slider/range-slider.component.html`.

### Testing
- Ran `npm run build` in `apps/frontend` to validate the change; the build failed due to a pre-existing missing dependency `@angular/cdk/overlay` in an unrelated component, so the failure is unrelated to the slider changes.
- No other automated tests were added or run for this small UI/ARIA change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c4c981248327874e07ac915562f1)