### PR TITLE
Improve clock ARIA semantics and TypeScript documentation

### DIFF
--- a/apps/frontend/src/app/shared/ui/clock/clock.component.html
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.html
@@ -1,3 +1,12 @@
 <div class="clock-container {{styleClass}}">
-	<span class="clock-time {{timeClass}}">{{ time }}</span>
+	<time
+		class="clock-time {{timeClass}}"
+		role="timer"
+		aria-live="off"
+		aria-atomic="true"
+		[attr.aria-label]="ariaLabel"
+		[attr.datetime]="isoDateTime"
+	>
+		{{ time }}
+	</time>
 </div>

--- a/apps/frontend/src/app/shared/ui/clock/clock.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.spec.ts
@@ -86,4 +86,23 @@ describe('ClockComponent', () => {
     component.ngOnDestroy();
     expect(clearSpy).toHaveBeenCalled();
   }));
+
+  it('should expose semantic and ARIA attributes for assistive technologies', fakeAsync(() => {
+    spyOn(Date.prototype, 'toLocaleTimeString').and.returnValue('10:15:30');
+    component.ariaLabel = 'Live clock';
+    fixture.detectChanges();
+    tick(0);
+    fixture.detectChanges();
+
+    const timeEl = fixture.nativeElement.querySelector('time.clock-time') as HTMLElement | null;
+
+    expect(timeEl).not.toBeNull();
+    expect(timeEl?.getAttribute('role')).toBe('timer');
+    expect(timeEl?.getAttribute('aria-live')).toBe('off');
+    expect(timeEl?.getAttribute('aria-atomic')).toBe('true');
+    expect(timeEl?.getAttribute('aria-label')).toBe('Live clock');
+    expect(timeEl?.getAttribute('datetime')).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+  }));
 });

--- a/apps/frontend/src/app/shared/ui/clock/clock.component.ts
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.ts
@@ -3,6 +3,13 @@
  */
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 
+/**
+ * Displays the current local time and refreshes it every second.
+ *
+ * The component renders semantic `<time>` markup and includes ARIA metadata
+ * so assistive technologies can identify the element as a timer without being
+ * interrupted each second.
+ */
 @Component({
   selector: 'app-clock',
   standalone: true,
@@ -10,26 +17,69 @@ import { Component, OnInit, OnDestroy, Input } from '@angular/core';
   styleUrls: ['./clock.component.css'],
 })
 export class ClockComponent implements OnInit, OnDestroy {
+  /**
+   * Preferred BCP 47 locale used to format the visual time string.
+   * If not provided, the component falls back to `navigator.language`.
+   */
   @Input() locale?: string;
+
+  /**
+   * Whether the rendered time should use a 12-hour clock format.
+   */
   @Input() use12Hour: boolean = false;
+
+  /**
+   * Optional CSS classes added to the clock container.
+   */
   @Input() styleClass = '';
+
+  /**
+   * Optional CSS classes added to the rendered time element.
+   */
   @Input() timeClass = '';
 
+  /**
+   * Accessible name announced for the timer element.
+   */
+  @Input() ariaLabel = 'Current time';
+
+  /**
+   * Human-readable time shown in the UI (for example, `10:15:30`).
+   */
   time: string = '';
+
+  /**
+   * ISO-8601 datetime value bound to the `<time datetime>` attribute.
+   */
+  isoDateTime: string = '';
+
+  /**
+   * Internal interval handle used to stop periodic updates on destroy.
+   */
   private timerId?: number;
 
+  /**
+   * Initializes the clock and starts a one-second refresh interval.
+   */
   ngOnInit(): void {
     this.updateTime();
     this.timerId = window.setInterval(() => this.updateTime(), 1000);
   }
 
+  /**
+   * Stops the internal timer when the component is destroyed.
+   */
   ngOnDestroy(): void {
     if (this.timerId) clearInterval(this.timerId);
   }
 
+  /**
+   * Recomputes the formatted and machine-readable current time values.
+   */
   private updateTime(): void {
     const currentLocale = this.locale ?? navigator.language;
     const now = new Date();
     this.time = now.toLocaleTimeString(currentLocale, { hour12: this.use12Hour });
+    this.isoDateTime = now.toISOString();
   }
 }


### PR DESCRIPTION
### Motivation
- Make the shared `ClockComponent` accessible by using semantic markup and ARIA attributes so assistive technologies can recognize it as a timer without noisy live updates.
- Provide clear English TSDoc/Javadoc-style documentation for the component's inputs, properties and lifecycle to improve maintainability and discoverability.

### Description
- Replace the visual `<span>` with a semantic `<time>` element and add `role="timer"`, `aria-live="off"`, `aria-atomic="true"`, a configurable `ariaLabel` input, and a machine-readable `datetime` bound to `isoDateTime` in the template (`apps/frontend/src/app/shared/ui/clock/clock.component.html`).
- Add new inputs and properties: `ariaLabel` and `isoDateTime`, populate `isoDateTime` with `now.toISOString()` in `updateTime()`, and document all inputs/properties/methods using English Javadoc/TSDoc-style comments (`apps/frontend/src/app/shared/ui/clock/clock.component.ts`).
- Extend unit tests to assert the presence and values of the semantic element and ARIA attributes (new spec in `apps/frontend/src/app/shared/ui/clock/clock.component.spec.ts`).

### Testing
- Ran the component spec with `npm test -- --watch=false --include='src/app/shared/ui/clock/clock.component.spec.ts' --browsers=ChromeHeadless` which failed during build due to an unrelated missing dependency `@angular/cdk/overlay` referenced by another spec in the project, so the clock spec could not execute to completion. Failed.
- Added a unit test `should expose semantic and ARIA attributes for assistive technologies` to validate the new `<time>` element and attributes, but its execution was blocked by the build error described above. Failed to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c8fd257483279b5c546eeebb72cb)