### PR TITLE
Improve button accessibility and TypeScript JSDoc documentation

### DIFF
--- a/apps/frontend/src/app/shared/ui/button/button.component.html
+++ b/apps/frontend/src/app/shared/ui/button/button.component.html
@@ -1,6 +1,7 @@
 <button
     [class]="'app-button ' + variantClass + ' ' + styleClass"
     [attr.type]="type"
+    [attr.aria-label]="ariaLabel"
     [disabled]="disabled"
     (click)="clicked.emit($event)"
 >

--- a/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
@@ -68,6 +68,22 @@ describe('ButtonComponent', () => {
     expect(buttonEl.disabled).toBeTrue();
   });
 
+  it('should expose aria-label when provided', () => {
+    component.ariaLabel = 'Open menu';
+    fixture.detectChanges();
+
+    const buttonEl: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(buttonEl.getAttribute('aria-label')).toBe('Open menu');
+  });
+
+  it('should not render aria-label when not provided', () => {
+    component.ariaLabel = null;
+    fixture.detectChanges();
+
+    const buttonEl: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(buttonEl.hasAttribute('aria-label')).toBeFalse();
+  });
+
   it('should emit clicked when the button is pressed', () => {
     spyOn(component.clicked, 'emit');
 

--- a/apps/frontend/src/app/shared/ui/button/button.component.ts
+++ b/apps/frontend/src/app/shared/ui/button/button.component.ts
@@ -4,8 +4,19 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
+/**
+ * Visual intent styles that can be applied to the button.
+ */
 type ButtonVariant = 'default' | 'main' | 'secondary';
+
+/**
+ * Native button `type` values supported by this component.
+ */
 type ButtonType = 'button' | 'submit' | 'reset';
+
+/**
+ * Allowed positions for the optional decorative icon.
+ */
 type IconPosition = 'left' | 'right';
 
 @Component({
@@ -16,22 +27,72 @@ type IconPosition = 'left' | 'right';
   styleUrl: './button.component.css',
 })
 export class ButtonComponent {
+  /**
+   * Visual variant used to build the CSS modifier class.
+   */
   @Input() variant: ButtonVariant = 'default';
+
+  /**
+   * Native button type used for form interaction.
+   */
   @Input() type: ButtonType = 'button';
+
+  /**
+   * Optional decorative icon rendered as plain text.
+   */
   @Input() icon: string | null = null;
+
+  /**
+   * Side where the decorative icon is rendered.
+   */
   @Input() iconPosition: IconPosition = 'left';
+
+  /**
+   * Whether user interaction is disabled.
+   */
   @Input() disabled = false;
+
+  /**
+   * Extra CSS classes appended to the root button element.
+   */
   @Input() styleClass = '';
+
+  /**
+   * Accessible name for icon-only usage.
+   *
+   * If no projected text is provided, set this input so assistive
+   * technologies can announce a meaningful label.
+   */
+  @Input() ariaLabel: string | null = null;
+
+  /**
+   * Emits the native click event when the button is activated.
+   */
   @Output() clicked = new EventEmitter<MouseEvent>();
 
+  /**
+   * Builds the BEM modifier class for the selected variant.
+   *
+   * @returns CSS class suffix for the variant.
+   */
   get variantClass(): string {
     return `button--${this.variant}`;
   }
 
+  /**
+   * Indicates whether the icon must be rendered before the label.
+   *
+   * @returns `true` when an icon exists and the icon position is `left`.
+   */
   get hasIconOnLeft(): boolean {
     return !!this.icon && this.iconPosition === 'left';
   }
 
+  /**
+   * Indicates whether the icon must be rendered after the label.
+   *
+   * @returns `true` when an icon exists and the icon position is `right`.
+   */
   get hasIconOnRight(): boolean {
     return !!this.icon && this.iconPosition === 'right';
   }


### PR DESCRIPTION
### Motivation
- Ensure the `ButtonComponent` can be used in icon-only scenarios by providing an accessible name so assistive technologies can announce a meaningful label. 
- Improve maintainability by adding clear JSDoc-style TypeScript documentation for the component API and internal getters. 
- Align the component with ARIA best practices and make its intent explicit for consumers and reviewers.

### Description
- Added a new `@Input() ariaLabel: string | null` to `ButtonComponent` and bound it in the template with `[attr.aria-label]` so the button can expose an accessible name. 
- Added JSDoc-style documentation in English to the exported types, inputs, outputs and computed getters in `apps/frontend/src/app/shared/ui/button/button.component.ts`. 
- Added unit tests validating `aria-label` rendering behavior in `apps/frontend/src/app/shared/ui/button/button.component.spec.ts`. 
- Modified template `apps/frontend/src/app/shared/ui/button/button.component.html` to include the `aria-label` binding and preserved existing behavior for icons, labels and disabled state.

### Testing
- Attempted to run the button test suite with `npm test -- --watch=false --browsers=ChromeHeadless --include='src/app/shared/ui/button/button.component.spec.ts'`. 
- The test run failed during build with TypeScript errors `TS2307` due to a pre-existing missing dependency `@angular/cdk/overlay` referenced in unrelated autocomplete textbox files, preventing the test from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cbadf3b48327b5459412f28f5f2c)