### PR TITLE
feat(frontend): improve card ARIA semantics and TypeScript docs

### DIFF
--- a/apps/frontend/src/app/shared/ui/card/card.component.html
+++ b/apps/frontend/src/app/shared/ui/card/card.component.html
@@ -1,6 +1,6 @@
 <section
 	class="card {{ styleClass }}"
-	role="region"
+	[attr.role]="title || ariaLabel ? 'region' : null"
 	[attr.aria-labelledby]="title ? titleId : null"
 	[attr.aria-label]="title ? null : ariaLabel"
 >

--- a/apps/frontend/src/app/shared/ui/card/card.component.html
+++ b/apps/frontend/src/app/shared/ui/card/card.component.html
@@ -1,8 +1,13 @@
-<section class="card {{ styleClass }}">
+<section
+	class="card {{ styleClass }}"
+	role="region"
+	[attr.aria-labelledby]="title ? titleId : null"
+	[attr.aria-label]="title ? null : ariaLabel"
+>
 	@if (title || headerTpl) {
 	<header class="card-header {{ headerClass }}">
 		@if (title) {
-		<h2 class="card-title {{ titleClass }}">{{ title }}</h2>
+		<h2 [id]="titleId" class="card-title {{ titleClass }}">{{ title }}</h2>
 		} @if (headerTpl) {
 		<ng-container [ngTemplateOutlet]="headerTpl"></ng-container>
 		}

--- a/apps/frontend/src/app/shared/ui/card/card.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/card/card.component.spec.ts
@@ -263,5 +263,15 @@ describe('CardComponent', () => {
       expect(cardElement.getAttribute('aria-label')).toBe('Timesheet summary');
       expect(cardElement.hasAttribute('aria-labelledby')).toBeFalse();
     });
+
+    it('should not expose landmark role when card has no accessible name', () => {
+      fixture.detectChanges();
+
+      const cardElement = fixture.nativeElement.querySelector('section.card');
+
+      expect(cardElement.hasAttribute('role')).toBeFalse();
+      expect(cardElement.hasAttribute('aria-labelledby')).toBeFalse();
+      expect(cardElement.hasAttribute('aria-label')).toBeFalse();
+    });
   });
 });

--- a/apps/frontend/src/app/shared/ui/card/card.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/card/card.component.spec.ts
@@ -15,6 +15,7 @@ import { CardComponent } from './card.component';
   template: `
     <app-card
       [title]="title"
+      [ariaLabel]="ariaLabel"
       [styleClass]="styleClass"
       [titleClass]="titleClass"
       [headerClass]="headerClass"
@@ -34,6 +35,7 @@ import { CardComponent } from './card.component';
 })
 class TestHostComponent {
   title: string | null = null;
+  ariaLabel: string | null = null;
   styleClass = '';
   titleClass = '';
   headerClass = '';
@@ -46,6 +48,7 @@ class TestHostComponent {
   template: `
     <app-card
       [title]="title"
+      [ariaLabel]="ariaLabel"
       [styleClass]="styleClass"
       [titleClass]="titleClass"
       [headerClass]="headerClass"
@@ -57,6 +60,7 @@ class TestHostComponent {
 })
 class TestHostWithoutTemplatesComponent {
   title: string | null = null;
+  ariaLabel: string | null = null;
   styleClass = '';
   titleClass = '';
   headerClass = '';
@@ -169,6 +173,18 @@ describe('CardComponent', () => {
       expect(headerElement).toBeTruthy();
     });
 
+    it('should expose an aria-labelledby relationship when title exists', () => {
+      hostComponent.title = 'Accessible title';
+      fixture.detectChanges();
+
+      const cardElement = fixture.nativeElement.querySelector('section.card');
+      const titleElement = fixture.nativeElement.querySelector('.card-title');
+
+      expect(cardElement.getAttribute('role')).toBe('region');
+      expect(cardElement.getAttribute('aria-labelledby')).toBe(titleElement.id);
+      expect(cardElement.hasAttribute('aria-label')).toBeFalse();
+    });
+
     it('should render the footer element when a footer template exists', () => {
       fixture.detectChanges();
 
@@ -235,6 +251,17 @@ describe('CardComponent', () => {
 
       expect(bodyContent).toBeTruthy();
       expect(bodyContent.textContent.trim()).toBe('Projected body only');
+    });
+
+    it('should use aria-label when there is no title', () => {
+      hostComponent.ariaLabel = 'Timesheet summary';
+      fixture.detectChanges();
+
+      const cardElement = fixture.nativeElement.querySelector('section.card');
+
+      expect(cardElement.getAttribute('role')).toBe('region');
+      expect(cardElement.getAttribute('aria-label')).toBe('Timesheet summary');
+      expect(cardElement.hasAttribute('aria-labelledby')).toBeFalse();
     });
   });
 });

--- a/apps/frontend/src/app/shared/ui/card/card.component.ts
+++ b/apps/frontend/src/app/shared/ui/card/card.component.ts
@@ -6,12 +6,16 @@ import {
   AfterContentInit,
   Component,
   ContentChild,
-  ElementRef,
   Input,
   TemplateRef,
-  ViewChild,
 } from '@angular/core';
 
+/**
+ * Reusable card container with optional header and footer template slots.
+ *
+ * The component exposes ARIA metadata so the rendered `<section>` can be
+ * announced as a named region by assistive technologies.
+ */
 @Component({
   selector: 'app-card',
   standalone: true,
@@ -20,19 +24,47 @@ import {
   styleUrls: ['./card.component.css'],
 })
 export class CardComponent implements AfterContentInit {
+  private static nextTitleId = 0;
+  /**
+   * Plain text title rendered in the card header.
+   *
+   * When present, this title is also used to label the card region through
+   * `aria-labelledby`.
+   */
   @Input() title: string | null = null;
+  /** Extra CSS classes applied to the outer card container. */
   @Input() styleClass = '';
+  /** Extra CSS classes applied to the `<h2>` title element. */
   @Input() titleClass = '';
+  /** Extra CSS classes applied to the card header element. */
   @Input() headerClass = '';
+  /** Extra CSS classes applied to the card footer element. */
   @Input() footerClass = '';
+  /**
+   * Accessible name used when no title is rendered.
+   *
+   * Use this input to provide a meaningful label for screen readers when the
+   * card has no visible heading.
+   */
+  @Input() ariaLabel: string | null = null;
 
+  /** Stable id used by `aria-labelledby` when a title exists. */
+  readonly titleId = `card-title-${CardComponent.nextTitleId++}`;
+
+  /** Optional projected template rendered inside the header container. */
   @ContentChild('cardHeader', { read: TemplateRef }) headerTpl?: TemplateRef<unknown>;
+  /** Optional projected template rendered inside the footer container. */
   @ContentChild('cardFooter', { read: TemplateRef }) footerTpl?: TemplateRef<unknown>;
-  @ViewChild('content', { static: false, read: ElementRef }) ngContent?: ElementRef;
 
+  /** Indicates whether the card header should be rendered. */
   hasHeader = false;
+  /** Indicates whether the card footer should be rendered. */
   hasFooter = false;
 
+  /**
+   * Computes the visibility state of optional card regions after content
+   * projection resolves.
+   */
   ngAfterContentInit(): void {
     this.hasHeader = !!this.headerTpl || !!this.title;
     this.hasFooter = !!this.footerTpl;


### PR DESCRIPTION
### Motivation
- Make the `app-card` component accessible to screen readers by exposing it as a named region and providing predictable accessible naming. 
- Provide a fallback accessible name for cards that do not render a visible heading so assistive technology can still announce the region. 
- Improve developer experience by documenting the `CardComponent` API and behavior in English using Javadoc-style comments.

### Description
- Add ARIA semantics to the template: render the outer element with `role="region"`, set `aria-labelledby` to a stable `titleId` when `title` exists, and set `aria-label` to `ariaLabel` when no title is provided. 
- Add `@Input() ariaLabel: string | null` and a stable `titleId` using a static counter (`CardComponent.nextTitleId`) to support `aria-labelledby` when a title is present. 
- Document the component, its inputs and behavior with Javadoc-style TypeScript comments and remove unused `ElementRef`/`ViewChild` imports. 
- Extend `card.component.spec.ts` by wiring `ariaLabel` in the test hosts and adding tests that assert the `role`, `aria-labelledby` relationship when a title exists, and the `aria-label` fallback when no title is present.

### Testing
- Ran the focused unit test command `npm run test -- --watch=false --browsers=ChromeHeadless --include=src/app/shared/ui/card/card.component.spec.ts`, which failed during application bundle generation due to a missing dependency error (`TS2307: Cannot find module '@angular/cdk/overlay'`) in unrelated specs, so tests could not complete in this environment. 
- New unit assertions were added to `src/app/shared/ui/card/card.component.spec.ts` to verify `role="region"`, `aria-labelledby` when `title` is present, and `aria-label` when `title` is absent, and these are ready to run in a CI environment with the full test dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cc5d50988327b550e97db98a04f9)