### PR TITLE
refactor(frontend): centralize timezone option model and catalog helpers

### DIFF
--- a/apps/frontend/src/app/core/user/pages/user-preferences-page.component.ts
+++ b/apps/frontend/src/app/core/user/pages/user-preferences-page.component.ts
@@ -10,17 +10,17 @@ import { Observable, finalize, of, take } from 'rxjs';
 
 import { supportedLanguages } from '../../../app.config';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
+import { TimezoneOption } from '../../../shared/models/timezone-option.model';
+import {
+  createTimezoneCatalog,
+  resolveTimezoneByZoneId,
+} from '../../../shared/utils/timezone-catalog.util';
 import { AutocompleteTextboxComponent } from '../../../shared/ui/autocomplete-textbox/autocomplete-textbox.component';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { CardComponent } from '../../../shared/ui/card/card.component';
 import { UserPreferences } from '../models/user-preferences';
 import { CurrentUserFacade } from '../services/current-user.facade';
 import { TimeFormat } from '../services/user-profile-api.service';
-
-type TimezoneOption = {
-  zoneId: string;
-  literal: string;
-};
 
 /**
  * Page responsible for displaying and updating the preferences
@@ -90,7 +90,7 @@ export class UserPreferencesPageComponent implements OnInit {
   /**
    * Full timezone catalog used by the autocomplete search.
    */
-  readonly timezoneCatalog = this.createTimezoneCatalog();
+  readonly timezoneCatalog = createTimezoneCatalog();
 
   /**
    * Indicates whether the initial preference load is in progress.
@@ -233,7 +233,7 @@ export class UserPreferencesPageComponent implements OnInit {
    * @returns Matching timezone option or null when not found
    */
   readonly resolveTimezoneByValue = (zoneId: string): TimezoneOption | null =>
-    this.findTimezoneOption(zoneId);
+    resolveTimezoneByZoneId(this.timezoneCatalog, zoneId);
 
   /**
    * Search function used by the autocomplete component.
@@ -276,42 +276,4 @@ export class UserPreferencesPageComponent implements OnInit {
     this.form.markAsUntouched();
   }
 
-  /**
-   * Builds the full timezone catalog used by the autocomplete control.
-   *
-   * @returns List of timezone options with display literals
-   */
-  private createTimezoneCatalog(): TimezoneOption[] {
-    return Intl.supportedValuesOf('timeZone').map((zoneId) => ({
-      zoneId,
-      literal: `${zoneId} (${this.getUtcOffsetLiteral(zoneId)})`,
-    }));
-  }
-
-  /**
-   * Computes a human-readable UTC offset label for a timezone.
-   *
-   * @param zoneId IANA timezone identifier
-   * @returns UTC offset literal
-   */
-  private getUtcOffsetLiteral(zoneId: string): string {
-    const utcOffsetPart = new Intl.DateTimeFormat('en-US', {
-      timeZone: zoneId,
-      timeZoneName: 'shortOffset',
-    })
-      .formatToParts(new Date())
-      .find((part) => part.type === 'timeZoneName')?.value;
-
-    return utcOffsetPart?.replace('GMT', 'UTC') ?? 'UTC';
-  }
-
-  /**
-   * Finds the timezone option corresponding to a stored timezone id.
-   *
-   * @param zoneId IANA timezone identifier
-   * @returns Matching option or null
-   */
-  private findTimezoneOption(zoneId: string): TimezoneOption | null {
-    return this.timezoneCatalog.find((option) => option.zoneId === zoneId) ?? null;
-  }
 }

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -6,7 +6,12 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { Observable, of, finalize } from 'rxjs';
 
 import { CurrentUserFacade } from '../../../core/user/services/current-user.facade';
+import { TimezoneOption } from '../../../shared/models/timezone-option.model';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
+import {
+  createTimezoneCatalog,
+  resolveTimezoneByZoneId,
+} from '../../../shared/utils/timezone-catalog.util';
 import { AutocompleteTextboxComponent } from '../../../shared/ui/autocomplete-textbox/autocomplete-textbox.component';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { CardComponent } from '../../../shared/ui/card/card.component';
@@ -14,11 +19,6 @@ import { RangeSliderComponent } from '../../../shared/ui/range-slider/range-slid
 import { ToggleButtonComponent } from '../../../shared/ui/toggle-button/toggle-button.component';
 import { ApplicationSettings } from '../models/application-settings';
 import { ApplicationSettingsApiService } from '../services/application-settings-api.service';
-
-type TimezoneOption = {
-  zoneId: string;
-  literal: string;
-};
 
 @Component({
   selector: 'app-application-settings-page',
@@ -60,7 +60,7 @@ export class ApplicationSettingsPageComponent implements OnInit {
   /**
    * Full timezone catalog used by the autocomplete search.
    */
-  readonly timezoneCatalog = this.createTimezoneCatalog();
+  readonly timezoneCatalog = createTimezoneCatalog();
 
   /**
    * Indicates whether the initial preference load is in progress.
@@ -231,44 +231,5 @@ export class ApplicationSettingsPageComponent implements OnInit {
    * @returns Matching timezone option or null when not found
    */
   readonly resolveTimezoneByValue = (zoneId: string): TimezoneOption | null =>
-    this.findTimezoneOption(zoneId);
-
-  /**
-   * Builds the full timezone catalog used by the autocomplete control.
-   *
-   * @returns List of timezone options with display literals
-   */
-  private createTimezoneCatalog(): TimezoneOption[] {
-    return Intl.supportedValuesOf('timeZone').map((zoneId) => ({
-      zoneId,
-      literal: `${zoneId} (${this.getUtcOffsetLiteral(zoneId)})`,
-    }));
-  }
-
-  /**
-   * Computes a human-readable UTC offset label for a timezone.
-   *
-   * @param zoneId IANA timezone identifier
-   * @returns UTC offset literal
-   */
-  private getUtcOffsetLiteral(zoneId: string): string {
-    const utcOffsetPart = new Intl.DateTimeFormat('en-US', {
-      timeZone: zoneId,
-      timeZoneName: 'shortOffset',
-    })
-      .formatToParts(new Date())
-      .find((part) => part.type === 'timeZoneName')?.value;
-
-    return utcOffsetPart?.replace('GMT', 'UTC') ?? 'UTC';
-  }
-
-  /**
-   * Finds the timezone option corresponding to a stored timezone id.
-   *
-   * @param zoneId IANA timezone identifier
-   * @returns Matching option or null
-   */
-  private findTimezoneOption(zoneId: string): TimezoneOption | null {
-    return this.timezoneCatalog.find((option) => option.zoneId === zoneId) ?? null;
-  }
+    resolveTimezoneByZoneId(this.timezoneCatalog, zoneId);
 }

--- a/apps/frontend/src/app/shared/models/timezone-option.model.ts
+++ b/apps/frontend/src/app/shared/models/timezone-option.model.ts
@@ -1,0 +1,7 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export type TimezoneOption = {
+  zoneId: string;
+  literal: string;
+};

--- a/apps/frontend/src/app/shared/utils/timezone-catalog.util.ts
+++ b/apps/frontend/src/app/shared/utils/timezone-catalog.util.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { TimezoneOption } from '../models/timezone-option.model';
+
+/**
+ * Builds the full timezone catalog used by autocomplete controls.
+ */
+export function createTimezoneCatalog(): TimezoneOption[] {
+  return Intl.supportedValuesOf('timeZone').map((zoneId) => ({
+    zoneId,
+    literal: `${zoneId} (${getUtcOffsetLiteral(zoneId)})`,
+  }));
+}
+
+/**
+ * Computes a human-readable UTC offset label for a timezone.
+ */
+export function getUtcOffsetLiteral(zoneId: string): string {
+  const utcOffsetPart = new Intl.DateTimeFormat('en-US', {
+    timeZone: zoneId,
+    timeZoneName: 'shortOffset',
+  })
+    .formatToParts(new Date())
+    .find((part) => part.type === 'timeZoneName')?.value;
+
+  return utcOffsetPart?.replace('GMT', 'UTC') ?? 'UTC';
+}
+
+/**
+ * Finds the timezone option corresponding to a stored timezone id.
+ */
+export function resolveTimezoneByZoneId(
+  timezoneCatalog: TimezoneOption[],
+  zoneId: string,
+): TimezoneOption | null {
+  return timezoneCatalog.find((option) => option.zoneId === zoneId) ?? null;
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated timezone option type and helper logic from multiple components and centralize them for reuse and consistency.
- Provide a single source for building the timezone catalog and computing UTC offset literals to reduce maintenance and potential bugs.
- Keep components focused on UI/form logic while avoiding cross-module circular references by placing shared code under `shared/`.

### Description
- Added a shared model `TimezoneOption` at `apps/frontend/src/app/shared/models/timezone-option.model.ts` with `zoneId` and `literal` properties.
- Added shared utilities in `apps/frontend/src/app/shared/utils/timezone-catalog.util.ts` exposing `createTimezoneCatalog()`, `getUtcOffsetLiteral()` and `resolveTimezoneByZoneId()` which use `Intl.supportedValuesOf('timeZone')` and `Intl.DateTimeFormat`.
- Updated `ApplicationSettingsPageComponent` and `UserPreferencesPageComponent` to import `TimezoneOption` and the shared utilities from `shared/` and removed their duplicated private timezone helpers (`createTimezoneCatalog`, `getUtcOffsetLiteral`, `findTimezoneOption`).
- Preserved component-specific UI/form logic (for example `searchMethod`) and ensured imports/typing reference only `shared/` to avoid cross-layer circular dependencies.

### Testing
- Ran `npm run build` in `apps/frontend`; the build failed due to a missing environment dependency `@angular/cdk/overlay` referenced by `autocomplete-textbox.component.ts`, which is unrelated to this refactor and blocks a full verification in this environment.
- No unit tests were added or modified; TypeScript/IDE references within the changed files were validated locally by the build attempt which surfaced only the unrelated `@angular/cdk/overlay` resolution error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d090075083278571cbbabba737c8)