### PR TITLE
feat(frontend): compact pagination for timelog table

### DIFF
--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.css
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.css
@@ -56,8 +56,46 @@
 	background-color: rgba(255, 87, 87, 0.12);
 }
 
+.timelog-pagination {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	align-self: flex-end;
+	padding: 0.375rem 0.625rem;
+	border-radius: 999px;
+	background-color: rgba(255, 255, 255, 0.06);
+}
+
+.pagination-button {
+	background: transparent;
+	border: none;
+	color: #f9d600;
+	font-size: 0.95rem;
+	font-weight: 700;
+	line-height: 1;
+	padding: 0;
+	width: 1.25rem;
+	height: 1.25rem;
+	cursor: pointer;
+}
+
+.pagination-button[disabled] {
+	color: rgba(249, 214, 0, 0.35);
+	cursor: default;
+}
+
+.pagination-summary {
+	font-size: 0.875rem;
+	color: #f9f9f9;
+	white-space: nowrap;
+}
+
 @media ( max-width : 640px) {
 	.timelog-table th, .timelog-table td {
 		padding: 0.75rem 1rem;
+	}
+
+	.timelog-pagination {
+		align-self: center;
 	}
 }

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -56,6 +56,31 @@
                 }
             </tbody>
         </table>
+
+        <nav class="timelog-pagination" aria-label="Pagination">
+            <button
+                type="button"
+                class="pagination-button"
+                (click)="goToPreviousPage()"
+                [disabled]="!canGoToPreviousPage()"
+                [attr.aria-label]="'timelog.pagination.previous' | translate"
+            >
+                &lt;
+            </button>
+            <span class="pagination-summary">
+                {{ paginationRangeText() }} {{ 'timelog.pagination.of' | translate }}
+                {{ totalElements() }}
+            </span>
+            <button
+                type="button"
+                class="pagination-button"
+                (click)="goToNextPage()"
+                [disabled]="!canGoToNextPage()"
+                [attr.aria-label]="'timelog.pagination.next' | translate"
+            >
+                &gt;
+            </button>
+        </nav>
     }
 
     @if (isEmpty()) {

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
@@ -9,6 +9,7 @@ import {
   inject,
   input,
   resource,
+  signal,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { firstValueFrom } from 'rxjs';
@@ -19,6 +20,7 @@ import { DurationPipe } from '../../../../shared/pipes/duration.pipe';
 import { TimeLog } from '../../models/timelog';
 import { TimeLogService } from '../../services/timelog-api.service';
 import { FALLBACK_LANGUAGE } from '../../../../core/i18n/language.util';
+import { Page } from '../../../../shared/models/page.model';
 
 /**
  * Displays the time logs of a specific employee in a table.
@@ -39,6 +41,7 @@ import { FALLBACK_LANGUAGE } from '../../../../core/i18n/language.util';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TimelogTableComponent {
+  private static readonly DEFAULT_PAGE_SIZE = 5;
   /**
    * Service used to retrieve time log data from the backend API.
    */
@@ -65,6 +68,8 @@ export class TimelogTableComponent {
    * </p>
    */
   readonly refreshToken = input(0);
+  readonly pageSize = input(TimelogTableComponent.DEFAULT_PAGE_SIZE);
+  protected readonly currentPage = signal(0);
 
   /**
    * Signal containing the current authenticated user state.
@@ -136,22 +141,52 @@ export class TimelogTableComponent {
    * </p>
    */
   protected readonly timelogsResource = resource<
-    TimeLog[],
-    { employeeEmail: string; refreshToken: number }
+    Page<TimeLog>,
+    { employeeEmail: string; refreshToken: number; page: number; size: number }
   >({
     params: () => ({
       employeeEmail: this.employeeEmail(),
       refreshToken: this.refreshToken(),
+      page: this.currentPage(),
+      size: this.pageSize(),
     }),
     loader: ({ params }) =>
-      firstValueFrom(this.timeLogService.searchByEmployee(params.employeeEmail)),
-    defaultValue: [],
+      firstValueFrom(
+        this.timeLogService.searchByEmployee(params.employeeEmail, params.page, params.size),
+      ),
+    defaultValue: {
+      content: [],
+      number: 0,
+      size: this.pageSize(),
+      totalElements: 0,
+      totalPages: 0,
+    },
   });
 
   /**
    * Computed signal containing the loaded list of time logs.
    */
-  protected readonly timelogs = computed(() => this.timelogsResource.value());
+  protected readonly timelogs = computed(() => this.timelogsResource.value().content ?? []);
+  protected readonly paginationRangeText = computed(() => {
+    const page = this.timelogsResource.value();
+    if (page.totalElements === 0 || page.content.length === 0) {
+      return '0-0';
+    }
+    const start = page.number * page.size + 1;
+    const end = start + page.content.length - 1;
+    return `${start}-${end}`;
+  });
+  protected readonly totalElements = computed(() => this.timelogsResource.value().totalElements ?? 0);
+  protected readonly canGoToPreviousPage = computed(
+    () => !this.timelogsResource.isLoading() && this.currentPage() > 0,
+  );
+  protected readonly canGoToNextPage = computed(() => {
+    if (this.timelogsResource.isLoading()) {
+      return false;
+    }
+    const page = this.timelogsResource.value();
+    return page.number + 1 < page.totalPages;
+  });
 
   /**
    * Indicates whether the component is in the empty state.
@@ -165,6 +200,20 @@ export class TimelogTableComponent {
     () =>
       !this.timelogsResource.isLoading() &&
       this.timelogsResource.error() === undefined &&
-      this.timelogs().length === 0,
+      this.totalElements() === 0,
   );
+
+  protected goToPreviousPage(): void {
+    if (!this.canGoToPreviousPage()) {
+      return;
+    }
+    this.currentPage.update((page) => Math.max(0, page - 1));
+  }
+
+  protected goToNextPage(): void {
+    if (!this.canGoToNextPage()) {
+      return;
+    }
+    this.currentPage.update((page) => page + 1);
+  }
 }

--- a/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
+++ b/apps/frontend/src/app/features/timelogs/services/timelog-api.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { map, Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { TimeLog } from '../models/timelog';
 import { environment } from '../../../../environments/environment';
+import { Page } from '../../../shared/models/page.model';
 
 @Injectable({ providedIn: 'root' })
 export class TimeLogService {
@@ -13,18 +14,15 @@ export class TimeLogService {
   /**
    * The `page` parameter follows Spring Data pagination (0-based index).
    */
-  searchByEmployee(email: string, page?: number, size?: number): Observable<TimeLog[]> {
+  searchByEmployee(email: string, page = 0, size = 5): Observable<Page<TimeLog>> {
     let params = new HttpParams().set('sort', 'entryTime,desc');
-    if (page != null) {
-      params = params.set('page', String(page));
-    }
-    if (size != null) {
-      params = params.set('size', String(size));
-    }
+    params = params.set('page', String(page));
+    params = params.set('size', String(size));
 
-    return this.http
-      .get<Page<TimeLog>>(`${this.baseUrl}/${encodeURIComponent(email)}/timelogs/`, { params })
-      .pipe(map((r) => r.content ?? []));
+    return this.http.get<Page<TimeLog>>(
+      `${this.baseUrl}/${encodeURIComponent(email)}/timelogs/`,
+      { params },
+    );
   }
 
   searchLatestByEmployee(email: string): Observable<TimeLog | undefined> {

--- a/apps/frontend/src/app/shared/models/page.model.ts
+++ b/apps/frontend/src/app/shared/models/page.model.ts
@@ -1,6 +1,10 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-interface Page<T> {
+export interface Page<T> {
   content: T[];
+  number: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
 }

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -35,7 +35,12 @@
     "loadError": "Ara mateix no es poden carregar els fitxatges.",
     "timelogs": "Fixatges",
     "clockActionPermissionDenied": "No tens permisos per fitxar.",
-    "clockActionNetworkError": "No s'ha pogut registrar el fitxatge en aquest moment. Torna-ho a provar."
+    "clockActionNetworkError": "No s'ha pogut registrar el fitxatge en aquest moment. Torna-ho a provar.",
+    "pagination": {
+      "of": "de",
+      "previous": "Pàgina anterior",
+      "next": "Pàgina següent"
+    }
   },
   "employee": {
     "employee": "Empleat",

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -35,7 +35,12 @@
     "loadError": "Unable to load time logs at this time.",
     "timelogs": "Time logs",
     "clockActionPermissionDenied": "You do not have permission to clock in or out.",
-    "clockActionNetworkError": "Unable to register your time action right now. Please try again."
+    "clockActionNetworkError": "Unable to register your time action right now. Please try again.",
+    "pagination": {
+      "of": "of",
+      "previous": "Previous page",
+      "next": "Next page"
+    }
   },
   "employee": {
     "employee": "Employee",

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -35,7 +35,12 @@
     "loadError": "No se pueden cargar los fichajes en este momento.",
     "timelogs": "Fichajes",
     "clockActionPermissionDenied": "No tienes permisos para fichar.",
-    "clockActionNetworkError": "No se pudo registrar el fichaje en este momento. Inténtalo de nuevo."
+    "clockActionNetworkError": "No se pudo registrar el fichaje en este momento. Inténtalo de nuevo.",
+    "pagination": {
+      "of": "de",
+      "previous": "Página anterior",
+      "next": "Página siguiente"
+    }
   },
   "employee": {
     "employee": "Empleado",


### PR DESCRIPTION
### Motivation
- Provide a compact pagination control for the timelogs table that shows only `<` and `>` plus a visible-range summary (e.g. `1-5 de 121`).
- Keep page size configurable by component input only and avoid adding an in-UI page-size selector.
- Consume the backend paginated response so the UI can display accurate totals and enable/disable navigation.

### Description
- Added and exported a `Page<T>` interface with pagination metadata (`number`, `size`, `totalElements`, `totalPages`) in `src/app/shared/models/page.model.ts`.
- Updated `TimeLogService.searchByEmployee` to accept `page` and `size` (defaults `0` and `5`) and return `Observable<Page<TimeLog>>` instead of flattening content.
- Extended `TimelogTableComponent` to accept a `pageSize` input, track `currentPage` as a signal, load `Page<TimeLog>` via the resource loader, and compute `paginationRangeText`, `totalElements`, `canGoToPreviousPage`, and `canGoToNextPage` signals; added `goToPreviousPage` and `goToNextPage` methods.
- Added a compact pagination UI block to `timelog-table.component.html` with only `<` and `>` buttons and a `start-end of total` summary, plus styling in `timelog-table.component.css` to render it as a small chip aligned to the table.
- Added i18n entries for pagination labels (`timelog.pagination.of`, `.previous`, `.next`) in Spanish, English and Catalan JSON files.

### Testing
- Ran `npm run build` in `apps/frontend` to validate changes, which failed due to a pre-existing missing dependency `@angular/cdk/overlay` unrelated to these modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db68a8d38083279e5784aefa530efa)