### PR TITLE
feat(frontend): add compact generic paginator to timelog table header

### DIFF
--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.css
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.css
@@ -4,6 +4,13 @@
 	gap: 1rem;
 }
 
+.timelog-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
 .timelog-title {
 	font-size: 1.25rem;
 	margin: 0;
@@ -57,6 +64,11 @@
 }
 
 @media ( max-width : 640px) {
+	.timelog-header {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
 	.timelog-table th, .timelog-table td {
 		padding: 0.75rem 1rem;
 	}

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -6,9 +6,10 @@
                 [totalItems]="totalItems()"
                 [pageSize]="pageSize"
                 [currentPage]="currentPage()"
-                betweenLabel="de"
-                previousLabel="Página anterior"
-                nextLabel="Página siguiente"
+                [betweenLabel]="'timelog.paginator.of' | translate"
+                [previousLabel]="'timelog.paginator.previousPage' | translate"
+                [nextLabel]="'timelog.paginator.nextPage' | translate"
+                [ariaLabel]="'timelog.paginator.ariaLabel' | translate"
                 (pageChange)="onPageChange($event)"
             />
         }

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -1,5 +1,18 @@
 <section class="timelog" aria-labelledby="timelog-title">
-    <h2 id="timelog-title" class="timelog-title">{{ 'timelog.timelogs' | translate }}</h2>
+    <header class="timelog-header">
+        <h2 id="timelog-title" class="timelog-title">{{ 'timelog.timelogs' | translate }}</h2>
+        @if (totalItems() > 0) {
+            <app-paginator
+                [totalItems]="totalItems()"
+                [pageSize]="pageSize"
+                [currentPage]="currentPage()"
+                betweenLabel="de"
+                previousLabel="Página anterior"
+                nextLabel="Página siguiente"
+                (pageChange)="onPageChange($event)"
+            />
+        }
+    </header>
 
     @if (timelogsResource.error() !== undefined) {
         <div class="timelog-message error" role="alert">
@@ -24,10 +37,7 @@
                 </tr>
             </thead>
             <tbody>
-                @for (
-                    timelog of timelogs();
-                    track timelog.entryTime + '-' + (timelog.exitTime ?? 'open')
-                ) {
+                @for (timelog of pagedTimelogs(); track timelog.entryTime + '-' + (timelog.exitTime ?? 'open')) {
                     <tr>
                         <td>
                             {{

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
@@ -6,8 +6,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   input,
+  signal,
   resource,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -19,6 +21,7 @@ import { DurationPipe } from '../../../../shared/pipes/duration.pipe';
 import { TimeLog } from '../../models/timelog';
 import { TimeLogService } from '../../services/timelog-api.service';
 import { FALLBACK_LANGUAGE } from '../../../../core/i18n/language.util';
+import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
 
 /**
  * Displays the time logs of a specific employee in a table.
@@ -33,12 +36,17 @@ import { FALLBACK_LANGUAGE } from '../../../../core/i18n/language.util';
 @Component({
   selector: 'app-timelog-table',
   standalone: true,
-  imports: [TranslatePipe, DatePipe, DurationPipe],
+  imports: [TranslatePipe, DatePipe, DurationPipe, PaginatorComponent],
   templateUrl: './timelog-table.component.html',
   styleUrl: './timelog-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TimelogTableComponent {
+  /**
+   * Number of rows displayed per page.
+   */
+  private static readonly PAGE_SIZE = 10;
+
   /**
    * Service used to retrieve time log data from the backend API.
    */
@@ -154,6 +162,36 @@ export class TimelogTableComponent {
   protected readonly timelogs = computed(() => this.timelogsResource.value());
 
   /**
+   * Current visible page in the table (1-based).
+   */
+  protected readonly currentPage = signal(1);
+
+  /**
+   * Total number of rows available in the full result.
+   */
+  protected readonly totalItems = computed(() => this.timelogs().length);
+
+  /**
+   * Subset of logs displayed in the currently selected page.
+   */
+  protected readonly pagedTimelogs = computed(() => {
+    const startIndex = (this.currentPage() - 1) * TimelogTableComponent.PAGE_SIZE;
+    const endIndex = startIndex + TimelogTableComponent.PAGE_SIZE;
+    return this.timelogs().slice(startIndex, endIndex);
+  });
+
+  /**
+   * Keeps the current page valid when the dataset changes.
+   */
+  private readonly pageSyncEffect = effect(() => {
+    const totalItems = this.totalItems();
+    const maxPage = Math.max(1, Math.ceil(totalItems / TimelogTableComponent.PAGE_SIZE));
+    if (this.currentPage() > maxPage) {
+      this.currentPage.set(maxPage);
+    }
+  });
+
+  /**
    * Indicates whether the component is in the empty state.
    *
    * <p>
@@ -167,4 +205,20 @@ export class TimelogTableComponent {
       this.timelogsResource.error() === undefined &&
       this.timelogs().length === 0,
   );
+
+  /**
+   * Handles page changes emitted by the paginator component.
+   *
+   * @param page New page number (1-based).
+   */
+  protected onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
+
+  /**
+   * Exposes the page size constant to the template.
+   */
+  protected get pageSize(): number {
+    return TimelogTableComponent.PAGE_SIZE;
+  }
 }

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
@@ -1,0 +1,39 @@
+:host {
+    display: inline-flex;
+}
+
+.paginator {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: #f9f9f9;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+}
+
+.paginator-button {
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 0.95rem;
+    line-height: 1;
+    font-weight: 700;
+    padding: 0.1rem 0.25rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.paginator-button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.paginator-button:not(:disabled):hover,
+.paginator-button:not(:disabled):focus-visible {
+    background: rgba(249, 214, 0, 0.2);
+    color: #f9d600;
+}

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.html
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.html
@@ -1,0 +1,25 @@
+<div class="paginator" role="group" aria-label="Paginación">
+    <button
+        type="button"
+        class="paginator-button"
+        [disabled]="!hasPreviousPage()"
+        [attr.aria-label]="previousLabel()"
+        (click)="goToPreviousPage()"
+    >
+        &lt;
+    </button>
+
+    <span class="paginator-text">
+        {{ startItem() }}-{{ endItem() }} {{ betweenLabel() }} {{ totalItems() }}
+    </span>
+
+    <button
+        type="button"
+        class="paginator-button"
+        [disabled]="!hasNextPage()"
+        [attr.aria-label]="nextLabel()"
+        (click)="goToNextPage()"
+    >
+        &gt;
+    </button>
+</div>

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.html
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.html
@@ -1,4 +1,4 @@
-<div class="paginator" role="group" aria-label="Paginación">
+<div class="paginator" role="group" [attr.aria-label]="ariaLabel()">
     <button
         type="button"
         class="paginator-button"

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.ts
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.ts
@@ -53,7 +53,7 @@ export class PaginatorComponent {
   /**
    * Accessible group label for the paginator region.
    */
-  readonly ariaLabel = input('Pagination');
+  readonly ariaLabel = input.required<string>();
 
   /**
    * Emits the next page (1-based) when navigation is requested.

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.ts
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.ts
@@ -1,0 +1,114 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+
+/**
+ * Compact, generic paginator for tabular data.
+ *
+ * <p>
+ * The paginator displays a compact summary in the form:
+ * {@code < 1-10 de 123 >}
+ * and emits page changes so parent components can decide how to load/slice data.
+ * </p>
+ */
+@Component({
+  selector: 'app-paginator',
+  standalone: true,
+  templateUrl: './paginator.component.html',
+  styleUrl: './paginator.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PaginatorComponent {
+  /**
+   * Total amount of available items.
+   */
+  readonly totalItems = input.required<number>();
+
+  /**
+   * Number of items shown per page.
+   */
+  readonly pageSize = input.required<number>();
+
+  /**
+   * Current page (1-based).
+   */
+  readonly currentPage = input.required<number>();
+
+  /**
+   * Text displayed between range and total count.
+   */
+  readonly betweenLabel = input('de');
+
+  /**
+   * Accessible label for the previous-page button.
+   */
+  readonly previousLabel = input('Página anterior');
+
+  /**
+   * Accessible label for the next-page button.
+   */
+  readonly nextLabel = input('Página siguiente');
+
+  /**
+   * Emits the next page (1-based) when navigation is requested.
+   */
+  readonly pageChange = output<number>();
+
+  /**
+   * Total number of available pages.
+   */
+  protected readonly totalPages = computed(() =>
+    Math.max(1, Math.ceil(this.totalItems() / this.pageSize())),
+  );
+
+  /**
+   * First visible item index in the current page (1-based).
+   */
+  protected readonly startItem = computed(() => {
+    if (this.totalItems() === 0) {
+      return 0;
+    }
+
+    return (this.currentPage() - 1) * this.pageSize() + 1;
+  });
+
+  /**
+   * Last visible item index in the current page (1-based).
+   */
+  protected readonly endItem = computed(() =>
+    Math.min(this.currentPage() * this.pageSize(), this.totalItems()),
+  );
+
+  /**
+   * Whether there is a previous page available.
+   */
+  protected readonly hasPreviousPage = computed(() => this.currentPage() > 1);
+
+  /**
+   * Whether there is a next page available.
+   */
+  protected readonly hasNextPage = computed(() => this.currentPage() < this.totalPages());
+
+  /**
+   * Requests navigation to the previous page if available.
+   */
+  protected goToPreviousPage(): void {
+    if (!this.hasPreviousPage()) {
+      return;
+    }
+
+    this.pageChange.emit(this.currentPage() - 1);
+  }
+
+  /**
+   * Requests navigation to the next page if available.
+   */
+  protected goToNextPage(): void {
+    if (!this.hasNextPage()) {
+      return;
+    }
+
+    this.pageChange.emit(this.currentPage() + 1);
+  }
+}

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.ts
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.ts
@@ -38,17 +38,22 @@ export class PaginatorComponent {
   /**
    * Text displayed between range and total count.
    */
-  readonly betweenLabel = input('de');
+  readonly betweenLabel = input('of');
 
   /**
    * Accessible label for the previous-page button.
    */
-  readonly previousLabel = input('Página anterior');
+  readonly previousLabel = input('Previous page');
 
   /**
    * Accessible label for the next-page button.
    */
-  readonly nextLabel = input('Página siguiente');
+  readonly nextLabel = input('Next page');
+
+  /**
+   * Accessible group label for the paginator region.
+   */
+  readonly ariaLabel = input('Pagination');
 
   /**
    * Emits the next page (1-based) when navigation is requested.

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -34,6 +34,12 @@
     "empty": "Encara no hi ha fitxatges disponibles.",
     "loadError": "Ara mateix no es poden carregar els fitxatges.",
     "timelogs": "Fixatges",
+    "paginator": {
+      "of": "de",
+      "previousPage": "Pàgina anterior",
+      "nextPage": "Pàgina següent",
+      "ariaLabel": "Paginació"
+    },
     "clockActionPermissionDenied": "No tens permisos per fitxar.",
     "clockActionNetworkError": "No s'ha pogut registrar el fitxatge en aquest moment. Torna-ho a provar."
   },

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -34,6 +34,12 @@
     "empty": "No time logs available yet.",
     "loadError": "Unable to load time logs at this time.",
     "timelogs": "Time logs",
+    "paginator": {
+      "of": "of",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "ariaLabel": "Pagination"
+    },
     "clockActionPermissionDenied": "You do not have permission to clock in or out.",
     "clockActionNetworkError": "Unable to register your time action right now. Please try again."
   },

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -34,6 +34,12 @@
     "empty": "Todavía no hay fichajes disponibles.",
     "loadError": "No se pueden cargar los fichajes en este momento.",
     "timelogs": "Fichajes",
+    "paginator": {
+      "of": "de",
+      "previousPage": "Página anterior",
+      "nextPage": "Página siguiente",
+      "ariaLabel": "Paginación"
+    },
     "clockActionPermissionDenied": "No tienes permisos para fichar.",
     "clockActionNetworkError": "No se pudo registrar el fichaje en este momento. Inténtalo de nuevo."
   },


### PR DESCRIPTION
### Motivation
- Añadir un paginador compacto y reutilizable para listas/tablas que muestre un resumen simple como `< 1-10 de 123 >` y exponga eventos de cambio de página. 
- Colocar ese paginador en la cabecera de la `timelog-table` con el título a la izquierda y el paginador a la derecha sin introducir una tabla genérica.

### Description
- Se añadió un nuevo componente standalone `app-paginator` en `shared/ui/paginator` con los archivos `paginator.component.ts`, `paginator.component.html` y `paginator.component.css` que implementan el formato compacto, controles anterior/siguiente y la salida `pageChange`.
- Se integró `app-paginator` en la cabecera de `TimelogTableComponent` y se añadió el layout CSS para alinear título a la izquierda y paginador a la derecha (`timelog-header`).
- Se implementó paginación en cliente dentro de `TimelogTableComponent`: constante de `PAGE_SIZE = 10`, `currentPage` (signal), `totalItems`, `pagedTimelogs` (slicing de la lista) y un efecto para ajustar la página actual cuando cambian los datos.
- Se actualizó la plantilla de la tabla para renderizar `pagedTimelogs()` en lugar de la lista completa y se conectó el evento `(pageChange)` al manejador `onPageChange`.

### Testing
- Ejecutado `npm run build` en `apps/frontend` para validar la compilación del frontend; la compilación falló por un problema preexistente de dependencia (`@angular/cdk/overlay` faltante usado por `autocomplete-textbox.component.ts`) y no por los cambios introducidos aquí.
- No se ejecutaron tests unitarios adicionales; no hay cambios en tests automatizados en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca266480483278e62d98787bef2dd)