### PR TITLE
Add worksites feature scaffold with page route and API client

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -33,6 +33,18 @@ export const appRoutes: Routes = [
         (m) => m.ApplicationSettingsPageComponent,
       ),
   },
+
+  {
+    path: 'worksites',
+    canActivate: [authGuard],
+    data: {
+      realmRole: ['JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN'],
+    },
+    loadComponent: () =>
+      import('./features/worksites/pages/worksites-page.component').then(
+        (m) => m.WorksitesPageComponent,
+      ),
+  },
   {
     path: '',
     canActivate: [authGuard],

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
@@ -15,6 +15,16 @@
         <div class="main-menu__actions">
             <button
                 type="button"
+                class="main-menu__icon-button"
+                [attr.aria-label]="'navigation.worksites' | translate"
+                [attr.title]="'navigation.worksites' | translate"
+                (click)="goToWorksites()"
+            >
+                <span aria-hidden="true">🏢</span>
+            </button>
+
+            <button
+                type="button"
                 class="main-menu__icon-button main-menu__icon-button--settings"
                 [attr.aria-label]="'navigation.applicationSettings' | translate"
                 [attr.title]="'navigation.applicationSettings' | translate"

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.ts
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.ts
@@ -34,4 +34,9 @@ export class MainMenuComponent {
   goToApplicationSettings(): void {
     this.router.navigate(['/application-settings']);
   }
+
+  goToWorksites(): void {
+    this.router.navigate(['/worksites']);
+  }
 }
+

--- a/apps/frontend/src/app/features/worksites/models/worksite.ts
+++ b/apps/frontend/src/app/features/worksites/models/worksite.ts
@@ -1,0 +1,24 @@
+export type WorksiteScope = 'GLOBAL' | 'PERSONAL';
+
+export interface Worksite {
+  code: string;
+  name: string;
+  timeZone: string;
+  scope: WorksiteScope;
+  ownerEmployeeEmail: string | null;
+}
+
+export interface CreateWorksitePayload {
+  code: string;
+  name: string;
+  timeZone: string;
+  scope: WorksiteScope;
+  ownerEmployeeEmail: string | null;
+}
+
+export interface UpdateWorksitePayload {
+  name: string;
+  timeZone: string;
+  scope: WorksiteScope;
+  ownerEmployeeEmail: string | null;
+}

--- a/apps/frontend/src/app/features/worksites/models/worksite.ts
+++ b/apps/frontend/src/app/features/worksites/models/worksite.ts
@@ -1,4 +1,4 @@
-export type WorksiteScope = 'GLOBAL' | 'PERSONAL';
+export type WorksiteScope = 'GLOBAL' | 'PERSONAL' | 'ASSIGNED';
 
 export interface Worksite {
   code: string;

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.css
@@ -1,0 +1,12 @@
+.worksites-content {
+    width: min(1080px, 100%);
+    display: flex;
+    gap: 2.5rem;
+    color: #f9f9f9;
+}
+
+.worksites-content app-card {
+    display: block;
+    flex: 1;
+    min-height: 22rem;
+}

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
@@ -1,0 +1,7 @@
+<app-page-template appNameKey="navigation.janus" pageNameKey="navigation.worksites">
+    <section page-body class="worksites-content">
+        <app-card styleClass="worksites-card"></app-card>
+    </section>
+
+    <div page-footer></div>
+</app-page-template>

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
@@ -1,0 +1,13 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
+import { CardComponent } from '../../../shared/ui/card/card.component';
+
+@Component({
+  selector: 'app-worksites-page',
+  standalone: true,
+  imports: [CommonModule, CardComponent, PageTemplateComponent],
+  templateUrl: './worksites-page.component.html',
+  styleUrl: './worksites-page.component.css',
+})
+export class WorksitesPageComponent {}

--- a/apps/frontend/src/app/features/worksites/services/worksite-api.service.ts
+++ b/apps/frontend/src/app/features/worksites/services/worksite-api.service.ts
@@ -1,0 +1,69 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import { CreateWorksitePayload, UpdateWorksitePayload, Worksite } from '../models/worksite';
+
+/**
+ * Provides CRUD operations for worksite resources using the backend REST API.
+ *
+ * All methods are thin wrappers around HTTP calls and return cold observables
+ * that execute when subscribed.
+ */
+@Injectable({ providedIn: 'root' })
+export class WorksiteApiService {
+  private readonly baseUrl = `${environment.apiBaseUrl}/worksites`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /**
+   * Retrieves all worksites visible to the authenticated user.
+   *
+   * @returns Observable emitting the complete list of worksites.
+   */
+  findAll(): Observable<Worksite[]> {
+    return this.http.get<Worksite[]>(this.baseUrl);
+  }
+
+  /**
+   * Retrieves a single worksite by its unique code.
+   *
+   * @param worksiteCode Unique worksite business identifier.
+   * @returns Observable emitting the requested worksite.
+   */
+  findByCode(worksiteCode: string): Observable<Worksite> {
+    return this.http.get<Worksite>(`${this.baseUrl}/${encodeURIComponent(worksiteCode)}`);
+  }
+
+  /**
+   * Creates a new worksite.
+   *
+   * @param payload Worksite data required by the create endpoint.
+   * @returns Observable emitting the created worksite.
+   */
+  create(payload: CreateWorksitePayload): Observable<Worksite> {
+    return this.http.post<Worksite>(this.baseUrl, payload);
+  }
+
+  /**
+   * Updates an existing worksite identified by its code.
+   *
+   * @param worksiteCode Unique worksite business identifier.
+   * @param payload Updated worksite data.
+   * @returns Observable emitting the updated worksite.
+   */
+  update(worksiteCode: string, payload: UpdateWorksitePayload): Observable<Worksite> {
+    return this.http.put<Worksite>(`${this.baseUrl}/${encodeURIComponent(worksiteCode)}`, payload);
+  }
+
+  /**
+   * Deletes an existing worksite by its code.
+   *
+   * @param worksiteCode Unique worksite business identifier.
+   * @returns Observable completing when deletion succeeds.
+   */
+  delete(worksiteCode: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${encodeURIComponent(worksiteCode)}`);
+  }
+}

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -3,7 +3,8 @@
     "janus": "Janus",
     "dashboard": "Panell de control",
     "applicationSettings": "Configuració",
-    "userPreferences": "Preferències d'usuari"
+    "userPreferences": "Preferències d'usuari",
+    "worksites": "Llocs de treball"
   },
   "locale": {
     "ca-ES": "Català",

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -3,7 +3,8 @@
     "janus": "Janus",
     "dashboard": "Dashboard",
     "applicationSettings": "Application settings",
-    "userPreferences": "User preferences"
+    "userPreferences": "User preferences",
+    "worksites": "Worksites"
   },
   "locale": {
     "ca-ES": "Catalan",

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -3,7 +3,8 @@
     "janus": "Janus",
     "dashboard": "Panel de control",
     "applicationSettings": "Configuración",
-    "userPreferences": "Preferencias de usuario"
+    "userPreferences": "Preferencias de usuario",
+    "worksites": "Puestos de trabajo"
   },
   "locale": {
     "ca-ES": "Catalán",


### PR DESCRIPTION
### Motivation
- Provide an initial management screen for worksites mirroring the layout of `application-settings` so the feature can be progressively implemented.
- Add a frontend feature structure for worksites including typed models and an API client so the UI can interact with the existing backend worksite endpoints.
- Make the page reachable from the application routes and main menu and add locale keys so the navigation is available in the UI.

### Description
- Add typed models under `apps/frontend/src/app/features/worksites/models/worksite.ts` (`Worksite`, `WorksiteScope`, `CreateWorksitePayload`, `UpdateWorksitePayload`).
- Add a standalone `WorksitesPageComponent` under `apps/frontend/src/app/features/worksites/pages/` that renders an empty `app-card` and includes minimal CSS to match the applicationsettings page structure.
- Implement `WorksiteApiService` in `apps/frontend/src/app/features/worksites/services/worksite-api.service.ts` with full CRUD methods (`findAll`, `findByCode`, `create`, `update`, `delete`) and English JSDoc-style documentation in the `services` folder.
- Register the new `/worksites` route in `apps/frontend/src/app/app.routes.ts`, add a main-menu button and navigation method in `apps/frontend/src/app/core/layout/main-menu/`, and add `navigation.worksites` keys to the EN/ES/CA i18n files.
- Changes were committed and a PR was created with these changes.

### Testing
- Ran the frontend build via `npm run build`; the build failed due to an unresolved dependency error: `Cannot find module '@angular/cdk/overlay'` referenced from `autocomplete-textbox.component.ts`, so the failure is due to an existing dependency issue and not the new `worksites` files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcce0b84c88327aae4eb1061bcc0e9)