### PR TITLE
Add WorksiteTable component and integrate into Worksites page with i18n

### DIFF
--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.css
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.css
@@ -1,0 +1,75 @@
+.worksite {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.worksite-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.worksite-title {
+	font-size: 1.25rem;
+	margin: 0;
+	text-transform: uppercase;
+	letter-spacing: 0.12em;
+	color: #f9d600;
+}
+
+.worksite-table {
+	width: 100%;
+	border-collapse: collapse;
+	background-color: #0f0f0f;
+	border-radius: 16px;
+	overflow: hidden;
+	box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.2);
+}
+
+.worksite-table th, .worksite-table td {
+	padding: 1rem 1.5rem;
+	text-align: left;
+}
+
+.worksite-table thead {
+	background-color: rgba(249, 214, 0, 0.12);
+	text-transform: uppercase;
+	letter-spacing: 0.12em;
+	font-size: 0.85rem;
+}
+
+.worksite-table tbody tr:nth-child(odd) {
+	background-color: rgba(255, 255, 255, 0.02);
+}
+
+.worksite-table tbody tr:nth-child(even) {
+	background-color: rgba(255, 255, 255, 0.08);
+}
+
+.worksite-table tbody tr:hover {
+	background-color: rgba(249, 214, 0, 0.18);
+}
+
+.worksite-message {
+	padding: 1rem 1.5rem;
+	border-radius: 16px;
+	background-color: rgba(255, 255, 255, 0.06);
+	color: #f9f9f9;
+}
+
+.worksite-message.error {
+	background-color: rgba(255, 87, 87, 0.12);
+}
+
+@media ( max-width : 640px) {
+	.worksite-header {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.worksite-table th, .worksite-table td {
+		padding: 0.75rem 1rem;
+	}
+}

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
@@ -1,0 +1,44 @@
+<section class="worksite" aria-labelledby="worksite-title">
+    <header class="worksite-header">
+        <h2 id="worksite-title" class="worksite-title">{{ 'worksite.worksites' | translate }}</h2>
+    </header>
+
+    @if (worksitesResource.error() !== undefined) {
+        <div class="worksite-message error" role="alert">
+            {{ 'worksite.loadError' | translate }}
+        </div>
+    }
+
+    @if (worksitesResource.isLoading()) {
+        <div class="worksite-message" aria-live="polite">
+            {{ 'worksite.loading' | translate }}
+        </div>
+    }
+
+    @if (!worksitesResource.isLoading() && worksites().length > 0) {
+        <table class="worksite-table" aria-labelledby="worksite-title">
+            <thead>
+                <tr>
+                    <th scope="col">{{ 'worksite.code' | translate }}</th>
+                    <th scope="col">{{ 'worksite.name' | translate }}</th>
+                    <th scope="col">{{ 'worksite.scope' | translate }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for (worksite of worksites(); track worksite.code) {
+                    <tr>
+                        <td>{{ worksite.code }}</td>
+                        <td>{{ worksite.name }}</td>
+                        <td>{{ worksite.scope }}</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+
+    @if (isEmpty()) {
+        <div class="worksite-message" aria-live="polite">
+            {{ 'worksite.empty' | translate }}
+        </div>
+    }
+</section>

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, computed, inject, resource } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { WorksiteApiService } from '../../services/worksite-api.service';
+import { Worksite } from '../../models/worksite';
+
+@Component({
+  selector: 'app-worksite-table',
+  standalone: true,
+  imports: [TranslatePipe],
+  templateUrl: './worksite-table.component.html',
+  styleUrl: './worksite-table.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WorksiteTableComponent {
+  private readonly worksiteApiService = inject(WorksiteApiService);
+
+  protected readonly worksitesResource = resource<Worksite[], void>({
+    loader: () => firstValueFrom(this.worksiteApiService.findAll()),
+    defaultValue: [],
+  });
+
+  protected readonly worksites = computed(() => this.worksitesResource.value());
+
+  protected readonly isEmpty = computed(
+    () =>
+      !this.worksitesResource.isLoading() &&
+      this.worksitesResource.error() === undefined &&
+      this.worksites().length === 0,
+  );
+}

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.css
@@ -5,7 +5,7 @@
     color: #f9f9f9;
 }
 
-.worksites-content app-card {
+.worksites-content app-worksite-table {
     display: block;
     flex: 1;
     min-height: 22rem;

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
@@ -1,6 +1,6 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.worksites">
     <section page-body class="worksites-content">
-        <app-card styleClass="worksites-card"></app-card>
+        <app-worksite-table />
     </section>
 
     <div page-footer></div>

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
-import { CardComponent } from '../../../shared/ui/card/card.component';
+import { WorksiteTableComponent } from '../components/worksite-table/worksite-table.component';
 
 @Component({
   selector: 'app-worksites-page',
   standalone: true,
-  imports: [CommonModule, CardComponent, PageTemplateComponent],
+  imports: [CommonModule, PageTemplateComponent, WorksiteTableComponent],
   templateUrl: './worksites-page.component.html',
   styleUrl: './worksites-page.component.css',
 })

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -104,5 +104,14 @@
       "update": "No s'han pogut actualitzar les preferències d'usuari.",
       "invalidTimezone": "La zona horaria no és vàlida."
     }
+  },
+  "worksite": {
+    "worksites": "Llocs de treball",
+    "code": "Codi",
+    "name": "Nom",
+    "scope": "Àmbit",
+    "loading": "S'estan carregant els llocs de treball...",
+    "empty": "Encara no hi ha llocs de treball disponibles.",
+    "loadError": "Ara mateix no es poden carregar els llocs de treball."
   }
 }

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -104,5 +104,14 @@
       "update": "Unable to update user preferences.",
       "invalidTimezone": "Invalid timezone."
     }
+  },
+  "worksite": {
+    "worksites": "Worksites",
+    "code": "Code",
+    "name": "Name",
+    "scope": "Scope",
+    "loading": "Loading worksites...",
+    "empty": "No worksites available yet.",
+    "loadError": "Unable to load worksites at this time."
   }
 }

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -104,5 +104,14 @@
       "update": "No se pudieron actualizar las preferencias de usuario.",
       "invalidTimezone": "La zona horaria no es válida."
     }
+  },
+  "worksite": {
+    "worksites": "Puestos de trabajo",
+    "code": "Código",
+    "name": "Nombre",
+    "scope": "Ámbito",
+    "loading": "Cargando puestos de trabajo...",
+    "empty": "Todavía no hay puestos de trabajo disponibles.",
+    "loadError": "No se pueden cargar los puestos de trabajo en este momento."
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a dedicated, accessible worksite listing UI with loading, error and empty states and localized labels.

### Description
- Added a standalone `WorksiteTableComponent` (`worksite-table.component.ts`, `.html`, `.css`) that uses Angular `resource` and `computed` to fetch worksites from `WorksiteApiService` and render a responsive table with accessibility attributes.
- Integrated the new component into the worksite page by replacing the placeholder card in `worksites-page.component.html`, updating the component import in `worksites-page.component.ts`, and adjusting the page CSS selector in `worksites-page.component.css`.
- Added translation entries for the `worksite` section to `en-EN.json`, `es-ES.json`, and `ca-ES.json` to support UI text for the table, loading, empty and error states.
- Implemented responsive and themed styles including row striping, hover state, header styling and message variants in `worksite-table.component.css`.

### Testing
- Ran a frontend type-check/build via `ng build` and executed the existing frontend unit tests via `ng test`, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf20ec800832788003dfc1bfb4d1d)