### PR TITLE
feat(frontend): add paginator to worksites table

### DIFF
--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
@@ -1,6 +1,18 @@
 <section class="worksite" aria-labelledby="worksite-title">
     <header class="worksite-header">
         <h2 id="worksite-title" class="worksite-title">{{ 'worksite.worksites' | translate }}</h2>
+        @if (totalItems() > 0) {
+            <app-paginator
+                [totalItems]="totalItems()"
+                [pageSize]="pageSize"
+                [currentPage]="currentPage()"
+                [betweenLabel]="'worksite.paginator.of' | translate"
+                [previousLabel]="'worksite.paginator.previousPage' | translate"
+                [nextLabel]="'worksite.paginator.nextPage' | translate"
+                [ariaLabel]="'worksite.paginator.ariaLabel' | translate"
+                (pageChange)="onPageChange($event)"
+            />
+        }
     </header>
 
     @if (worksitesResource.error() !== undefined) {
@@ -25,7 +37,7 @@
                 </tr>
             </thead>
             <tbody>
-                @for (worksite of worksites(); track worksite.code) {
+                @for (worksite of pagedWorksites(); track worksite.code) {
                     <tr>
                         <td>{{ worksite.code }}</td>
                         <td>{{ worksite.name }}</td>

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
@@ -1,20 +1,33 @@
-import { ChangeDetectionStrategy, Component, computed, inject, resource } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  resource,
+  signal,
+} from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { TranslatePipe } from '@ngx-translate/core';
 
 import { WorksiteApiService } from '../../services/worksite-api.service';
 import { Worksite } from '../../models/worksite';
+import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
 
 @Component({
   selector: 'app-worksite-table',
   standalone: true,
-  imports: [TranslatePipe],
+  imports: [TranslatePipe, PaginatorComponent],
   templateUrl: './worksite-table.component.html',
   styleUrl: './worksite-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorksiteTableComponent {
+  private static readonly PAGE_SIZE = 5;
+
   private readonly worksiteApiService = inject(WorksiteApiService);
+
+  protected readonly currentPage = signal(1);
 
   protected readonly worksitesResource = resource<Worksite[], void>({
     loader: () => firstValueFrom(this.worksiteApiService.findAll()),
@@ -23,10 +36,39 @@ export class WorksiteTableComponent {
 
   protected readonly worksites = computed(() => this.worksitesResource.value());
 
+  protected readonly totalItems = computed(() => this.worksites().length);
+
+  protected readonly pagedWorksites = computed(() => {
+    const start = (this.currentPage() - 1) * WorksiteTableComponent.PAGE_SIZE;
+    const end = start + WorksiteTableComponent.PAGE_SIZE;
+
+    return this.worksites().slice(start, end);
+  });
+
+  private readonly pageSyncEffect = effect(() => {
+    if (this.worksitesResource.isLoading()) {
+      return;
+    }
+
+    const maxPage = Math.max(1, Math.ceil(this.totalItems() / WorksiteTableComponent.PAGE_SIZE));
+
+    if (this.currentPage() > maxPage) {
+      this.currentPage.set(maxPage);
+    }
+  });
+
   protected readonly isEmpty = computed(
     () =>
       !this.worksitesResource.isLoading() &&
       this.worksitesResource.error() === undefined &&
       this.worksites().length === 0,
   );
+
+  protected onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
+
+  protected get pageSize(): number {
+    return WorksiteTableComponent.PAGE_SIZE;
+  }
 }

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -112,6 +112,12 @@
     "scope": "Àmbit",
     "loading": "S'estan carregant els llocs de treball...",
     "empty": "Encara no hi ha llocs de treball disponibles.",
-    "loadError": "Ara mateix no es poden carregar els llocs de treball."
+    "loadError": "Ara mateix no es poden carregar els llocs de treball.",
+    "paginator": {
+      "of": "de",
+      "previousPage": "Pàgina anterior",
+      "nextPage": "Pàgina següent",
+      "ariaLabel": "Paginació"
+    }
   }
 }

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -112,6 +112,12 @@
     "scope": "Scope",
     "loading": "Loading worksites...",
     "empty": "No worksites available yet.",
-    "loadError": "Unable to load worksites at this time."
+    "loadError": "Unable to load worksites at this time.",
+    "paginator": {
+      "of": "of",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "ariaLabel": "Pagination"
+    }
   }
 }

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -112,6 +112,12 @@
     "scope": "Ámbito",
     "loading": "Cargando puestos de trabajo...",
     "empty": "Todavía no hay puestos de trabajo disponibles.",
-    "loadError": "No se pueden cargar los puestos de trabajo en este momento."
+    "loadError": "No se pueden cargar los puestos de trabajo en este momento.",
+    "paginator": {
+      "of": "de",
+      "previousPage": "Página anterior",
+      "nextPage": "Página siguiente",
+      "ariaLabel": "Paginación"
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Unificar el comportamiento de la tabla de `worksites` con la de `timelogs` añadiendo paginación para mejorar la usabilidad con listas largas.

### Description
- Añadido el componente compartido `app-paginator` en `worksite-table.component.html` con las mismas bindings y accesibilidad que en `timelog-table`.
- Actualizado `WorksiteTableComponent` para paginación en cliente mediante `PAGE_SIZE`, `currentPage` (signal), `totalItems`, `pagedWorksites` (computed), efecto de sincronización de página (`effect`) y el handler `onPageChange` y `pageSize` getter.
- Modificada la renderización de filas para iterar `pagedWorksites()` en lugar de `worksites()` y añadida la importación de `PaginatorComponent` en el componente.
- Añadidas las claves de traducción `worksite.paginator` en `es-ES.json`, `en-EN.json` y `ca-ES.json` para proporcionar los textos del paginador.

### Testing
- Ejecutado `npm --prefix apps/frontend run build` que falló por un módulo no resuelto `@angular/cdk/overlay`, problema preexistente y no causado por estos cambios.
- No se ejecutaron tests unitarios adicionales en este cambio (no se modificó la suite de tests existente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd12d59fe483278af9c292660d9815)