### PR TITLE
Add SearchBar component and integrate into Worksites page with i18n

### DIFF
--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
@@ -27,7 +27,7 @@
         </div>
     }
 
-    @if (!worksitesResource.isLoading() && worksites().length > 0) {
+    @if (!worksitesResource.isLoading() && filteredWorksites().length > 0) {
         <table class="worksite-table" aria-labelledby="worksite-title">
             <thead>
                 <tr>
@@ -50,7 +50,7 @@
 
     @if (isEmpty()) {
         <div class="worksite-message" aria-live="polite">
-            {{ 'worksite.empty' | translate }}
+            {{ (hasActiveQuery() ? 'worksite.searchEmpty' : 'worksite.empty') | translate }}
         </div>
     }
 </section>

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
@@ -4,6 +4,7 @@ import {
   computed,
   effect,
   inject,
+  input,
   resource,
   signal,
 } from '@angular/core';
@@ -27,6 +28,8 @@ export class WorksiteTableComponent {
 
   private readonly worksiteApiService = inject(WorksiteApiService);
 
+  readonly query = input('');
+
   protected readonly currentPage = signal(1);
 
   protected readonly worksitesResource = resource<Worksite[], void>({
@@ -36,13 +39,35 @@ export class WorksiteTableComponent {
 
   protected readonly worksites = computed(() => this.worksitesResource.value());
 
-  protected readonly totalItems = computed(() => this.worksites().length);
+  protected readonly normalizedQuery = computed(() => this.query().trim().toLowerCase());
+
+  protected readonly filteredWorksites = computed(() => {
+    const normalizedQuery = this.normalizedQuery();
+
+    if (normalizedQuery === '') {
+      return this.worksites();
+    }
+
+    return this.worksites().filter((worksite) => {
+      const code = worksite.code.toLowerCase();
+      const name = worksite.name.toLowerCase();
+      const scope = worksite.scope.toLowerCase();
+
+      return (
+        code.includes(normalizedQuery) ||
+        name.includes(normalizedQuery) ||
+        scope.includes(normalizedQuery)
+      );
+    });
+  });
+
+  protected readonly totalItems = computed(() => this.filteredWorksites().length);
 
   protected readonly pagedWorksites = computed(() => {
     const start = (this.currentPage() - 1) * WorksiteTableComponent.PAGE_SIZE;
     const end = start + WorksiteTableComponent.PAGE_SIZE;
 
-    return this.worksites().slice(start, end);
+    return this.filteredWorksites().slice(start, end);
   });
 
   private readonly pageSyncEffect = effect(() => {
@@ -61,8 +86,10 @@ export class WorksiteTableComponent {
     () =>
       !this.worksitesResource.isLoading() &&
       this.worksitesResource.error() === undefined &&
-      this.worksites().length === 0,
+      this.filteredWorksites().length === 0,
   );
+
+  protected readonly hasActiveQuery = computed(() => this.normalizedQuery() !== '');
 
   protected onPageChange(page: number): void {
     this.currentPage.set(page);

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.css
@@ -1,8 +1,14 @@
 .worksites-content {
     width: min(1080px, 100%);
     display: flex;
-    gap: 2.5rem;
+    flex-direction: column;
+    gap: 1rem;
     color: #f9f9f9;
+}
+
+.worksites-content app-search-bar {
+    display: block;
+    width: min(420px, 100%);
 }
 
 .worksites-content app-worksite-table {

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
@@ -1,7 +1,7 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.worksites">
     <section page-body class="worksites-content">
-        <app-search-bar />
-        <app-worksite-table />
+        <app-search-bar (queryChange)="onQueryChange($event)" />
+        <app-worksite-table [query]="searchQuery()" />
     </section>
 
     <div page-footer></div>

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
@@ -1,5 +1,6 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.worksites">
     <section page-body class="worksites-content">
+        <app-search-bar />
         <app-worksite-table />
     </section>
 

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
@@ -5,11 +5,12 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
 import { WorksiteTableComponent } from '../components/worksite-table/worksite-table.component';
+import { SearchBarComponent } from '../../../shared/ui/search-bar/search-bar.component';
 
 @Component({
   selector: 'app-worksites-page',
   standalone: true,
-  imports: [CommonModule, PageTemplateComponent, WorksiteTableComponent],
+  imports: [CommonModule, PageTemplateComponent, WorksiteTableComponent, SearchBarComponent],
   templateUrl: './worksites-page.component.html',
   styleUrl: './worksites-page.component.css',
 })

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
 import { WorksiteTableComponent } from '../components/worksite-table/worksite-table.component';
 import { SearchBarComponent } from '../../../shared/ui/search-bar/search-bar.component';
@@ -14,4 +14,10 @@ import { SearchBarComponent } from '../../../shared/ui/search-bar/search-bar.com
   templateUrl: './worksites-page.component.html',
   styleUrl: './worksites-page.component.css',
 })
-export class WorksitesPageComponent {}
+export class WorksitesPageComponent {
+  protected readonly searchQuery = signal('');
+
+  protected onQueryChange(query: string): void {
+    this.searchQuery.set(query);
+  }
+}

--- a/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.css
+++ b/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.css
@@ -1,0 +1,66 @@
+.search-bar {
+    width: 100%;
+    display: flex;
+    align-items: stretch;
+    border: 1px solid #fece0b;
+    border-radius: 0.5rem;
+    background: #050505;
+    overflow: hidden;
+}
+
+.search-bar:focus-within {
+    box-shadow: 0 0 0 2px rgba(249, 214, 0, 0.3);
+}
+
+.search-bar input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: #050505;
+    color: #f9f9f9;
+    padding: 0.625rem 0.75rem;
+    font-size: 0.95rem;
+}
+
+.search-bar input::placeholder {
+    color: #b3b3b3;
+}
+
+.search-icon {
+    border: none;
+    border-left: 1px solid #2f2f2f;
+    background: transparent;
+    color: #f9f9f9;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.9rem;
+    cursor: pointer;
+}
+
+.search-icon:hover,
+.search-icon:focus-visible {
+    color: #fece0b;
+}
+
+.search-icon svg {
+    width: 1rem;
+    height: 1rem;
+    stroke: currentColor;
+    stroke-width: 2;
+    fill: none;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
+}

--- a/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.html
+++ b/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.html
@@ -1,0 +1,20 @@
+<form class="search-bar" role="search" (submit)="$event.preventDefault(); submitCurrentQuery()">
+    <label class="sr-only" [for]="inputId">{{ 'searchBar.inputLabel' | translate }}</label>
+    <input
+        [id]="inputId"
+        type="search"
+        [formControl]="queryControl"
+        [attr.placeholder]="'searchBar.placeholder' | translate"
+        [attr.aria-label]="'searchBar.inputLabel' | translate"
+        [attr.aria-describedby]="helpTextId"
+    />
+
+    <span class="sr-only" [id]="helpTextId">{{ 'searchBar.helpText' | translate }}</span>
+
+    <button type="submit" class="search-icon" [attr.aria-label]="'searchBar.buttonAriaLabel' | translate">
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="16.65" y1="16.65" x2="21" y2="21"></line>
+        </svg>
+    </button>
+</form>

--- a/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.ts
+++ b/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.ts
@@ -1,0 +1,41 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component, DestroyRef, EventEmitter, Output, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TranslatePipe } from '@ngx-translate/core';
+import { debounceTime, distinctUntilChanged, map } from 'rxjs';
+
+@Component({
+  selector: 'app-search-bar',
+  standalone: true,
+  imports: [ReactiveFormsModule, TranslatePipe],
+  templateUrl: './search-bar.component.html',
+  styleUrl: './search-bar.component.css',
+})
+export class SearchBarComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly inputId = 'search-bar-input';
+  protected readonly helpTextId = 'search-bar-help';
+
+  protected readonly queryControl = new FormControl('', { nonNullable: true });
+
+  @Output() readonly queryChange = new EventEmitter<string>();
+
+  constructor() {
+    this.queryControl.valueChanges
+      .pipe(
+        map((value) => value.trim()),
+        debounceTime(250),
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((query) => this.queryChange.emit(query));
+  }
+
+  protected submitCurrentQuery(): void {
+    this.queryChange.emit(this.queryControl.value.trim());
+  }
+}

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -16,6 +16,12 @@
     "cancel": "Cancel·la",
     "cleanSelection": "Neteja la sel·lecció"
   },
+  "searchBar": {
+    "placeholder": "Cerca llocs de treball...",
+    "inputLabel": "Cerca",
+    "buttonAriaLabel": "Executa la cerca",
+    "helpText": "Escriu per filtrar la llista de llocs de treball"
+  },
   "autocomplete": {
     "noResultsFound": "No s'ha trobat cap resultat",
     "loadingResults": "Carregant resultats",

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -118,6 +118,7 @@
     "scope": "Àmbit",
     "loading": "S'estan carregant els llocs de treball...",
     "empty": "Encara no hi ha llocs de treball disponibles.",
+    "searchEmpty": "No hi ha llocs de treball que coincideixin amb la cerca.",
     "loadError": "Ara mateix no es poden carregar els llocs de treball.",
     "paginator": {
       "of": "de",

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -118,6 +118,7 @@
     "scope": "Scope",
     "loading": "Loading worksites...",
     "empty": "No worksites available yet.",
+    "searchEmpty": "No worksites match your search.",
     "loadError": "Unable to load worksites at this time.",
     "paginator": {
       "of": "of",

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -16,6 +16,12 @@
     "cancel": "Cancel",
     "cleanSelection": "Clean selection"
   },
+  "searchBar": {
+    "placeholder": "Search worksites...",
+    "inputLabel": "Search",
+    "buttonAriaLabel": "Run search",
+    "helpText": "Type to filter the worksites list"
+  },
   "autocomplete": {
     "noResultsFound": "No results found",
     "loadingResults": "Loading results",

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -16,6 +16,12 @@
     "cancel": "Cancela",
     "cleanSelection": "Limpia la selección"
   },
+  "searchBar": {
+    "placeholder": "Buscar puestos de trabajo...",
+    "inputLabel": "Buscar",
+    "buttonAriaLabel": "Ejecutar búsqueda",
+    "helpText": "Escribe para filtrar la lista de puestos de trabajo"
+  },
   "autocomplete": {
     "noResultsFound": "No se ha encontrado ningún resultado",
     "loadingResults": "Cargando resultados",

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -118,6 +118,7 @@
     "scope": "Ámbito",
     "loading": "Cargando puestos de trabajo...",
     "empty": "Todavía no hay puestos de trabajo disponibles.",
+    "searchEmpty": "No hay puestos de trabajo que coincidan con la búsqueda.",
     "loadError": "No se pueden cargar los puestos de trabajo en este momento.",
     "paginator": {
       "of": "de",


### PR DESCRIPTION
### Motivation
- Provide a reusable, accessible search control for filtering worksites and wire it into the worksites page UI.
- Ensure the search UI is translatable and visually consistent with existing frontend styles.

### Description
- Introduced a new standalone `SearchBarComponent` with `search-bar.component.ts`, `search-bar.component.html`, and `search-bar.component.css` that emits debounced `queryChange` events and supports form submission via `submitCurrentQuery()`.
- Integrated the search bar into the worksites page by adding the `<app-search-bar />` element to `worksites-page.component.html` and importing `SearchBarComponent` in `worksites-page.component.ts`.
- Adjusted worksites page layout in `worksites-page.component.css` to stack the search bar above the worksite table and tuned spacing (`flex-direction: column; gap: 1rem;`) and width constraints for the search bar.
- Added translation entries for `searchBar` (`placeholder`, `inputLabel`, `buttonAriaLabel`, `helpText`) to `en-EN.json`, `es-ES.json`, and `ca-ES.json`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1f6b41b883279e5ab9474e18ab03)