### PR TITLE
Fix WorksiteControllerIT assertions for paginated list payload

### DIFF
--- a/apps/backend/src/test/java/es/nivel36/janus/api/v1/worksite/WorksiteControllerIT.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/api/v1/worksite/WorksiteControllerIT.java
@@ -55,8 +55,8 @@ class WorksiteControllerIT {
 		this.mvc.perform(get(BASE).with(jwt()//
 				.authorities(createAuthorityList("ROLE_JANUS_ADMIN")))).andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
-				.andExpect(jsonPath("$[?(@.code=='BCN-HQ')]").exists())
-				.andExpect(jsonPath("$[?(@.code=='BCN-HQ' && @.scope=='GLOBAL')]").exists());
+				.andExpect(jsonPath("$.content[?(@.code=='BCN-HQ')]").exists())
+				.andExpect(jsonPath("$.content[?(@.code=='BCN-HQ' && @.scope=='GLOBAL')]").exists());
 	}
 
 	@Test
@@ -118,7 +118,7 @@ class WorksiteControllerIT {
 		this.mvc.perform(get(BASE).with(jwt()//
 				.authorities(createAuthorityList("ROLE_JANUS_ADMIN")))) //
 				.andExpect(status().isOk()) //
-				.andExpect(jsonPath("$[?(@.code=='%s')]".formatted(code)).exists());
+				.andExpect(jsonPath("$.content[?(@.code=='%s')]".formatted(code)).exists());
 	}
 
 	@Test
@@ -179,6 +179,6 @@ class WorksiteControllerIT {
 
 		this.mvc.perform(get(BASE).with(jwt()//
 				.authorities(createAuthorityList("ROLE_JANUS_ADMIN")))).andExpect(status().isOk())
-				.andExpect(jsonPath("$[?(@.code=='BCN-HQ')]").doesNotExist());
+				.andExpect(jsonPath("$.content[?(@.code=='BCN-HQ')]").doesNotExist());
 	}
 }


### PR DESCRIPTION
### Motivation
- The worksite list endpoint returns a paginated payload with `{ content, page }`, but tests were asserting an array at the JSON root causing integration failures.

### Description
- Updated `apps/backend/src/test/java/es/nivel36/janus/api/v1/worksite/WorksiteControllerIT.java` to use `$.content[...]` JSONPath checks instead of `$[...]` in `testListShouldReturnSeededWorksite`, the post-create list verification in `testCreateShouldReturn201AndBody`, and the post-delete verification in `testDeleteShouldReturn204AndRemoveFromList`.

### Testing
- Ran `cd apps/backend && ./mvnw -q -Dtest=WorksiteControllerIT test` and the test run succeeded (10 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14cfac7348327bbf409aadb78c0fc)