### PR TITLE
Add query pattern validation to worksite search endpoint

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
@@ -90,7 +90,8 @@ public class WorksiteController {
 	 */
 	@GetMapping
 	@PreAuthorize("hasAnyRole('JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN')")
-	public ResponseEntity<Page<WorksiteResponse>> searchWorksites(final @RequestParam(required = false) String query,
+	public ResponseEntity<Page<WorksiteResponse>> searchWorksites(
+			final @RequestParam(required = false) @Pattern(regexp = "[A-Za-z0-9_-]{1,50}", message = "query must contain only letters, digits, underscores or hyphens (max 50)") String query,
 			final Pageable pageable) {
 		logger.debug("Search worksites ACTION performed");
 


### PR DESCRIPTION
### Motivation
- Ensure the optional `query` parameter for `WorksiteController#searchWorksites` accepts only letters, digits, underscores or hyphens and a maximum of 50 characters to match existing input constraints and prevent invalid input.

### Description
- Added `@Pattern(regexp = "[A-Za-z0-9_-]{1,50}", message = "query must contain only letters, digits, underscores or hyphens (max 50)")` to the `@RequestParam(required = false) String query` in `apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java`.

### Testing
- Ran backend compilation: `cd apps/backend && ./mvnw -q -DskipTests compile`, which completed successfully and no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14f2f0808832798dc596d9a88e8ed)