### PR TITLE
Fix autocomplete textbox tests by completing TranslateService mock

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
@@ -14,6 +14,15 @@ class MockTranslateService {
   readonly onLangChange = new Subject<any>();
   readonly onTranslationChange = new Subject<any>();
   readonly onDefaultLangChange = new Subject<any>();
+  readonly onFallbackLangChange = new Subject<any>();
+
+  getCurrentLang(): string {
+    return 'es-ES';
+  }
+
+  getFallbackLang(): string {
+    return 'en-EN';
+  }
 
   instant(key: string, params?: Record<string, unknown>): string {
     if (key === 'autocomplete.manyResultsAvailable' && params?.['count'] !== undefined) {


### PR DESCRIPTION
### Motivation
- The `AutocompleteTextboxComponent` spec was failing because the `TranslatePipe` subscribes to fallback-language events and calls language getters on `TranslateService`, which the test mock did not implement.

### Description
- Updated `MockTranslateService` in `apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts` to add an `onFallbackLangChange` subject.
- Added `getCurrentLang()` and `getFallbackLang()` methods to the mock to satisfy the `TranslatePipe` expectations while keeping existing `instant`, `get`, and `stream` behavior.

### Testing
- Ran `npm test -- --watch=false --browsers=ChromeHeadless` which failed before the fix due to missing Vitest browser packages (expected error from test runner configuration).
- Ran `npm test -- --watch=false` from `apps/frontend` after the change and all tests passed: `12 files, 103 tests, 103 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e150dd2a448327bbc76deccd596929)