### PR TITLE
test(frontend): add vitest tests for RangeSliderComponent

### DIFF
--- a/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RangeSliderComponent } from './range-slider.component';
+
+describe('RangeSliderComponent', () => {
+  let fixture: ComponentFixture<RangeSliderComponent>;
+  let component: RangeSliderComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RangeSliderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RangeSliderComponent);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('label', 'Volume');
+    fixture.componentRef.setInput('min', 0);
+    fixture.componentRef.setInput('max', 100);
+    fixture.componentRef.setInput('step', 5);
+
+    fixture.detectChanges();
+  });
+
+  it('should propagate input value through ControlValueAccessor onChange callback', () => {
+    const onChangeSpy = vi.fn();
+    component.registerOnChange(onChangeSpy);
+
+    const slider: HTMLInputElement = fixture.debugElement.query(By.css('input[type="range"]')).nativeElement;
+
+    slider.value = '40';
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(component.value).toBe(40);
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith(40);
+  });
+
+  it('should call onTouched callback on blur', () => {
+    const onTouchedSpy = vi.fn();
+    component.registerOnTouched(onTouchedSpy);
+
+    const slider: HTMLInputElement = fixture.debugElement.query(By.css('input[type="range"]')).nativeElement;
+
+    slider.dispatchEvent(new Event('blur', { bubbles: true }));
+
+    expect(onTouchedSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable native input when setDisabledState is called', () => {
+    component.setDisabledState(true);
+    fixture.detectChanges();
+
+    const slider: HTMLInputElement = fixture.debugElement.query(By.css('input[type="range"]')).nativeElement;
+
+    expect(component.disabled).toBe(true);
+    expect(slider.disabled).toBe(true);
+  });
+
+  it('should use provided inputId when present', () => {
+    fixture.componentRef.setInput('inputId', 'custom-slider-id');
+    fixture.detectChanges();
+
+    expect(component.sliderId()).toBe('custom-slider-id');
+  });
+
+  it('should generate a slider id when inputId is not provided', () => {
+    expect(component.sliderId()).toMatch(/^range-slider-/);
+  });
+
+  it('should expose the value text with unit when unit is configured', () => {
+    fixture.componentRef.setInput('unit', '%');
+    component.writeValue(55);
+
+    expect(component.valueText).toBe('55 %');
+  });
+
+  it('should return 0 progress when max is less than or equal to min', () => {
+    fixture.componentRef.setInput('min', 10);
+    fixture.componentRef.setInput('max', 10);
+    component.writeValue(10);
+
+    expect(component.progressPercent).toBe(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add unit tests for the `RangeSliderComponent` to ensure form integration and UI helpers behave correctly.

### Description
- Add a new Vitest spec at `apps/frontend/src/app/shared/ui/range-slider/range-slider.component.spec.ts` that uses `TestBed` to instantiate the standalone component.
- Cover `ControlValueAccessor` behaviors including `registerOnChange`, `registerOnTouched`, and `setDisabledState` via DOM `input` and `blur` events.
- Verify id resolution (`inputId` vs generated id), formatted `valueText` when `unit` is configured, and `progressPercent` when `max <= min`.

### Testing
- Ran `npm --prefix apps/frontend test -- --watch=false --include=src/app/shared/ui/range-slider/range-slider.component.spec.ts` which executed the single spec file.
- Test run succeeded: 1 test file, 7 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e159aa777c8327b1b075a85f21ccd4)