### PR TITLE
feat(frontend): add reusable chip component

### DIFF
--- a/apps/frontend/src/app/shared/ui/chip/chip.component.css
+++ b/apps/frontend/src/app/shared/ui/chip/chip.component.css
@@ -1,0 +1,33 @@
+:host {
+    display: inline-block;
+}
+
+.app-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 0.75rem;
+    border-radius: 0.35rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1;
+    text-transform: uppercase;
+    color: #ffffff;
+}
+
+.chip--default {
+    background-color: #f9d600;
+    color: #040404;
+}
+
+.chip--primary {
+    background-color: #7f06a5;
+}
+
+.chip--secondary {
+    background-color: #1431a9;
+}
+
+.chip--tertiary {
+    background-color: #615300;
+}

--- a/apps/frontend/src/app/shared/ui/chip/chip.component.html
+++ b/apps/frontend/src/app/shared/ui/chip/chip.component.html
@@ -1,0 +1,1 @@
+<span [class]="chipClass">{{ label() }}</span>

--- a/apps/frontend/src/app/shared/ui/chip/chip.component.ts
+++ b/apps/frontend/src/app/shared/ui/chip/chip.component.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component, input } from '@angular/core';
+
+/**
+ * Visual variants supported by the chip component.
+ */
+type ChipType = 'default' | 'primary' | 'secondary' | 'tertiary';
+
+@Component({
+  selector: 'app-chip',
+  standalone: true,
+  imports: [],
+  templateUrl: './chip.component.html',
+  styleUrl: './chip.component.css',
+})
+export class ChipComponent {
+  /**
+   * Text rendered inside the chip.
+   */
+  readonly label = input.required<string>();
+
+  /**
+   * Visual type used to style the chip background.
+   */
+  readonly type = input<ChipType>('default');
+
+  /**
+   * Extra CSS classes added to the chip root element.
+   */
+  readonly styleClass = input<string>('');
+
+  /**
+   * Builds the BEM modifier class for the selected type.
+   */
+  get typeClass(): string {
+    return `chip--${this.type()}`;
+  }
+
+  /**
+   * Builds the complete CSS class list for the root chip element.
+   */
+  get chipClass(): string {
+    const extraClass = this.styleClass().trim();
+    return extraClass ? `app-chip ${this.typeClass} ${extraClass}` : `app-chip ${this.typeClass}`;
+  }
+}


### PR DESCRIPTION
### Motivation
- Añadir un componente genérico de UI `chip` para mostrar texto en un recuadro con fondo y facilitar su reutilización en la aplicación. 
- Soportar variantes visuales `default`, `primary`, `secondary` y `tertiary` con los colores solicitados (`#F9D600`, `#7F06A5`, `#1431A9`, `#615300`).

### Description
- Se añadieron los archivos `apps/frontend/src/app/shared/ui/chip/chip.component.ts`, `chip.component.html` y `chip.component.css` que implementan un componente standalone con selector `app-chip`.
- El componente expone los inputs `label` (requerido), `type` (`default | primary | secondary | tertiary`) y `styleClass` (opcional) y construye la clase raíz con `chipClass` basada en el tipo.
- El template renderiza un único `span` con la clase calculada y el texto proveniente de `label`.
- Los estilos definen la presentación del chip (padding, bordes, tipografía) y mapean cada `type` al color de fondo solicitado.

### Testing
- Ejecuté `npm run build` desde `apps/frontend` y la compilación de la aplicación frontend finalizó correctamente. 
- No se añadieron pruebas unitarias automáticas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2191e5a088327ab5dc53698eadf7b)