### PR TITLE
Resolve supported locale in preferences and sync native select value (add inputId)

### DIFF
--- a/apps/frontend/src/app/core/user/pages/user-preferences-page.component.ts
+++ b/apps/frontend/src/app/core/user/pages/user-preferences-page.component.ts
@@ -7,7 +7,7 @@ import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { Observable, finalize, of, take } from 'rxjs';
 
-import { supportedLanguages } from '../../i18n/language.util';
+import { resolveSupportedLanguage, supportedLanguages } from '../../i18n/language.util';
 import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
 import { TimezoneOption } from '../../../shared/models/timezone-option.model';
 import {
@@ -268,8 +268,10 @@ export class UserPreferencesPageComponent implements OnInit {
    * @param preferences Preferences to display
    */
   private applyPreferences(preferences: UserPreferences): void {
+    const resolvedLocale = resolveSupportedLanguage(preferences.locale);
+
     this.form.reset({
-      locale: preferences.locale,
+      locale: resolvedLocale,
       timeFormat: preferences.timeFormat,
       defaultTimezone: preferences.defaultTimezone,
     });

--- a/apps/frontend/src/app/shared/ui/select/select.component.html
+++ b/apps/frontend/src/app/shared/ui/select/select.component.html
@@ -1,5 +1,7 @@
 <div class="select" [class.disabled]="disabled">
     <select
+        #nativeSelect
+        [id]="inputId()"
         [disabled]="disabled"
         [attr.aria-label]="ariaLabel()"
         [value]="value ?? ''"

--- a/apps/frontend/src/app/shared/ui/select/select.component.ts
+++ b/apps/frontend/src/app/shared/ui/select/select.component.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Component, forwardRef, input } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, ViewChild, effect, forwardRef, input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -44,7 +44,9 @@ export interface SelectOption<TValue extends string = string> {
     },
   ],
 })
-export class SelectComponent<TValue extends string = string> implements ControlValueAccessor {
+export class SelectComponent<TValue extends string = string>
+  implements ControlValueAccessor, AfterViewInit
+{
   /**
    * List of options rendered in the native select element.
    */
@@ -54,6 +56,16 @@ export class SelectComponent<TValue extends string = string> implements ControlV
    * Optional accessible label used when no visible external label is present.
    */
   readonly ariaLabel = input<string>();
+
+  /**
+   * Optional id forwarded to the native select element.
+   */
+  readonly inputId = input<string>();
+
+  /**
+   * Reference to the underlying native select element.
+   */
+  @ViewChild('nativeSelect') private nativeSelect?: ElementRef<HTMLSelectElement>;
 
   /**
    * Currently selected value.
@@ -75,6 +87,17 @@ export class SelectComponent<TValue extends string = string> implements ControlV
    */
   private onTouched: () => void = () => {};
 
+  constructor() {
+    effect(() => {
+      this.options();
+      this.syncNativeSelection();
+    });
+  }
+
+  ngAfterViewInit(): void {
+    this.syncNativeSelection();
+  }
+
   /**
    * Writes an external form value into the component.
    *
@@ -82,6 +105,7 @@ export class SelectComponent<TValue extends string = string> implements ControlV
    */
   writeValue(value: TValue | null): void {
     this.value = value;
+    this.syncNativeSelection();
   }
 
   /**
@@ -129,5 +153,16 @@ export class SelectComponent<TValue extends string = string> implements ControlV
    */
   markTouched(): void {
     this.onTouched();
+  }
+
+  /**
+   * Synchronizes the native select value with the internal model value.
+   */
+  private syncNativeSelection(): void {
+    if (!this.nativeSelect) {
+      return;
+    }
+
+    this.nativeSelect.nativeElement.value = this.value ?? '';
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure user locale stored in preferences is normalized to a supported language before being shown in the form.
- Keep the native `<select>` element in sync with the component model and allow forwarding an `id` to the native element for accessibility.

### Description
- Import and use `resolveSupportedLanguage` in `UserPreferencesPageComponent.applyPreferences` to normalize `preferences.locale` before resetting the form (`apps/frontend/src/app/core/user/pages/user-preferences-page.component.ts`).
- Add a template reference `#nativeSelect` and bind `id` via `inputId()` in the select template (`apps/frontend/src/app/shared/ui/select/select.component.html`).
- Extend `SelectComponent` to accept `inputId` input, expose a `@ViewChild('nativeSelect')` handle, implement `AfterViewInit`, and add a `syncNativeSelection()` helper to synchronize the native select value with the internal model; call this helper from the constructor effect, `ngAfterViewInit`, and `writeValue` (`apps/frontend/src/app/shared/ui/select/select.component.ts`).
- Add a reactive `effect` to re-sync the native selection when `options` change.

### Testing
- Built the frontend with `ng build` and TypeScript compilation succeeded.
- Ran unit tests with `ng test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e606a88cdc83279379f5faeca6e441)