### PR TITLE
Limit worksite search by employee and enforce employee-only access

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
@@ -26,6 +26,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -96,22 +97,26 @@ public class WorksiteController {
 	public ResponseEntity<Page<WorksiteResponse>> searchWorksites(
 			final @RequestParam(required = false) @Pattern(regexp = "[A-Za-z0-9_-]{1,50}", message = "query must contain only letters, digits, underscores or hyphens (max 50)") String query,
 			final @RequestParam(required = false) @Pattern(regexp = "^(?=.{1,254}$)[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$", message = "employeeEmail must be a valid and safe email address (max 254)") String employeeEmail,
-			final Pageable pageable, final @AuthenticationPrincipal Jwt jwt) {
+			final Pageable pageable, final @AuthenticationPrincipal Jwt jwt, final Authentication authentication) {
 		logger.debug("Search worksites ACTION performed");
 		final String authenticatedEmail = jwt.getClaimAsString("email");
-		final var roles = KeycloakJwtRolesConverter.extract(jwt);
-		final boolean adminOrUserRole = roles.stream().anyMatch(authority -> {
+		final boolean adminOrUserRole = authentication.getAuthorities().stream().anyMatch(authority -> {
 			final String role = authority.getAuthority();
 			return "ROLE_JANUS_ADMIN".equals(role) || "ROLE_JANUS_USER".equals(role);
 		});
+		final boolean employeeOnlyRole = authentication.getAuthorities().stream()
+				.anyMatch(authority -> "ROLE_JANUS_EMPLOYEE".equals(authority.getAuthority())) && !adminOrUserRole;
 		final String effectiveEmployeeEmail;
-		if (adminOrUserRole) {
-			effectiveEmployeeEmail = employeeEmail;
-		} else {
+		if (employeeOnlyRole) {
+			if (authenticatedEmail == null || authenticatedEmail.isBlank()) {
+				throw new AccessDeniedException("Employee email claim is required");
+			}
 			if (employeeEmail != null && !employeeEmail.equalsIgnoreCase(authenticatedEmail)) {
 				throw new AccessDeniedException("Employees can only search worksites for themselves");
 			}
 			effectiveEmployeeEmail = authenticatedEmail;
+		} else {
+			effectiveEmployeeEmail = employeeEmail;
 		}
 
 		final Page<WorksiteResponse> worksites = this.worksiteService.searchWorksites(query, effectiveEmployeeEmail, pageable)

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
@@ -95,10 +95,26 @@ public class WorksiteController {
 	@PreAuthorize("hasAnyRole('JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN')")
 	public ResponseEntity<Page<WorksiteResponse>> searchWorksites(
 			final @RequestParam(required = false) @Pattern(regexp = "[A-Za-z0-9_-]{1,50}", message = "query must contain only letters, digits, underscores or hyphens (max 50)") String query,
-			final Pageable pageable) {
+			final @RequestParam(required = false) @Pattern(regexp = "^(?=.{1,254}$)[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$", message = "employeeEmail must be a valid and safe email address (max 254)") String employeeEmail,
+			final Pageable pageable, final @AuthenticationPrincipal Jwt jwt) {
 		logger.debug("Search worksites ACTION performed");
+		final String authenticatedEmail = jwt.getClaimAsString("email");
+		final var roles = KeycloakJwtRolesConverter.extract(jwt);
+		final boolean adminOrUserRole = roles.stream().anyMatch(authority -> {
+			final String role = authority.getAuthority();
+			return "ROLE_JANUS_ADMIN".equals(role) || "ROLE_JANUS_USER".equals(role);
+		});
+		final String effectiveEmployeeEmail;
+		if (adminOrUserRole) {
+			effectiveEmployeeEmail = employeeEmail;
+		} else {
+			if (employeeEmail != null && !employeeEmail.equalsIgnoreCase(authenticatedEmail)) {
+				throw new AccessDeniedException("Employees can only search worksites for themselves");
+			}
+			effectiveEmployeeEmail = authenticatedEmail;
+		}
 
-		final Page<WorksiteResponse> worksites = this.worksiteService.searchWorksites(query, pageable)
+		final Page<WorksiteResponse> worksites = this.worksiteService.searchWorksites(query, effectiveEmployeeEmail, pageable)
 				.map(this.worksiteResponseMapper::map);
 		return ResponseEntity.ok(worksites);
 	}

--- a/apps/backend/src/main/java/es/nivel36/janus/service/worksite/WorksiteRepository.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/worksite/WorksiteRepository.java
@@ -15,8 +15,6 @@
  */
 package es.nivel36.janus.service.worksite;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,8 +29,9 @@ import es.nivel36.janus.service.employee.Employee;
  *
  * <p>
  * Provides access methods to query {@link Worksite} data, including custom
- * queries for retrieving worksites visible to a given {@link Employee} and
- * checking whether a worksite still has explicit employee assignments.
+ * queries for searching worksites (with optional visibility filtering by
+ * employee) and checking whether a worksite still has explicit employee
+ * assignments.
  * </p>
  *
  * <p>
@@ -42,27 +41,6 @@ import es.nivel36.janus.service.employee.Employee;
  */
 @Repository
 interface WorksiteRepository extends JpaRepository<Worksite, Long> {
-
-	/**
-	 * Retrieves all worksites visible to the specified employee.
-	 * <p>
-	 * Global worksites are visible to everyone. Personal worksites are visible to
-	 * their owner. The legacy employee-worksite assignment is still considered so
-	 * the existing association can keep any secondary purpose it may still have.
-	 * </p>
-	 *
-	 * @param employeeEmail email of the employee whose visible worksites are to be
-	 *                      retrieved
-	 * @return the worksites visible to the employee
-	 */
-	@Query("""
-			    SELECT DISTINCT w
-			    FROM Worksite w
-			    LEFT JOIN w.employees e
-			    WHERE w.scope = es.nivel36.janus.service.worksite.WorksiteScope.GLOBAL
-			       OR e.email = :employeeEmail
-			""")
-	List<Worksite> findVisibleByEmployeeEmail(String employeeEmail);
 
 	Worksite findByCode(String code);
 
@@ -76,11 +54,18 @@ interface WorksiteRepository extends JpaRepository<Worksite, Long> {
 	boolean hasEmployees(String worksiteCode);
 
 	@Query("""
-			SELECT w
+			SELECT DISTINCT w
 			FROM Worksite w
-			WHERE LOWER(w.name) LIKE LOWER(CONCAT('%', :query, '%'))
-			   OR LOWER(w.code) LIKE LOWER(CONCAT('%', :query, '%'))
+			WHERE (LOWER(w.name) LIKE LOWER(CONCAT('%', :query, '%'))
+			   OR LOWER(w.code) LIKE LOWER(CONCAT('%', :query, '%')))
+			  AND (:employeeEmail IS NULL
+			   OR w.scope = es.nivel36.janus.service.worksite.WorksiteScope.GLOBAL
+			   OR EXISTS (
+					SELECT 1
+					FROM w.employees e
+					WHERE e.email = :employeeEmail
+			   ))
 			""")
-	Page<Worksite> search(String query, Pageable pageable);
+	Page<Worksite> search(String query, String employeeEmail, Pageable pageable);
 
 }

--- a/apps/backend/src/main/java/es/nivel36/janus/service/worksite/WorksiteService.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/worksite/WorksiteService.java
@@ -16,7 +16,6 @@
 package es.nivel36.janus.service.worksite;
 
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Objects;
 
 import org.slf4j.Logger;
@@ -69,40 +68,18 @@ public class WorksiteService {
 	 * @return a list containing every existing {@link Worksite}; never {@code null}
 	 */
 	@Transactional(readOnly = true)
-	public Page<Worksite> searchWorksites(final String query, final Pageable pageable) {
+	public Page<Worksite> searchWorksites(final String query, final String employeeEmail, final Pageable pageable) {
 		logger.debug("Retrieving all worksites");
+		final String sanitizedQuery = query == null ? "" : query.strip();
+		final String sanitizedEmployeeEmail = employeeEmail == null || employeeEmail.isBlank() ? null : employeeEmail.strip();
 		final Page<Worksite> worksites;
-		if (query == null || query.isBlank()) {
+		if (sanitizedQuery.isEmpty() && sanitizedEmployeeEmail == null) {
 			worksites = this.worksiteRepository.findAll(pageable);
 		} else {
-			worksites = this.worksiteRepository.search(query, pageable);
+			worksites = this.worksiteRepository.search(sanitizedQuery, sanitizedEmployeeEmail, pageable);
 		}
 
 		logger.trace("Found {} worksites", worksites.getTotalElements());
-		return worksites;
-	}
-
-	/**
-	 * Retrieves all worksites visible to the specified employee.
-	 *
-	 * <p>
-	 * Visibility is primarily driven by {@link WorksiteScope}: global worksites are
-	 * visible to everyone, assigned worksites are visible to explicitly assigned
-	 * employees and personal worksites are visible to their owner.
-	 * </p>
-	 *
-	 * @param employeeEmail email of the employee whose visible worksites should be
-	 *                      retrieved; must not be {@code null}
-	 * @return a list of worksites visible to the given employee; never {@code null}
-	 * @throws NullPointerException if {@code employee} is {@code null}
-	 */
-	@Transactional(readOnly = true)
-	public List<Worksite> findWorksitesByEmployee(final String employeeEmail) {
-		Objects.requireNonNull(employeeEmail, "employeeEmail");
-		logger.debug("Finding worksites visible by employee {}", employeeEmail);
-
-		final List<Worksite> worksites = this.worksiteRepository.findVisibleByEmployeeEmail(employeeEmail);
-		logger.trace("Found {} worksites", worksites.size());
 		return worksites;
 	}
 

--- a/apps/backend/src/test/java/es/nivel36/janus/api/v1/worksite/WorksiteControllerIT.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/api/v1/worksite/WorksiteControllerIT.java
@@ -26,6 +26,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -68,6 +71,7 @@ class WorksiteControllerIT {
 			"INSERT INTO worksite(code,name,time_zone,scope) VALUES('BCN-HQ','Barcelona Headquarters','UTC+2','GLOBAL')" })
 	void testListAsEmployeeShouldRejectSearchingOtherEmployee() throws Exception {
 		this.mvc.perform(get(BASE).param("employeeEmail", "bperson@nivel36.es").with(jwt()//
+				.jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("janus_employee"))))
 				.jwt(jwt -> jwt.claim("email", "aferrer@nivel36.es"))
 				.authorities(createAuthorityList("ROLE_JANUS_EMPLOYEE"))))
 				.andExpect(status().isForbidden());
@@ -84,12 +88,24 @@ class WorksiteControllerIT {
 			"INSERT INTO employee_worksite(employee_id, worksite_id) SELECT 2, w.id FROM worksite w WHERE w.code='ASG-BERTA'" })
 	void testListAsEmployeeShouldBeForcedToOwnEmailWhenNoFilterProvided() throws Exception {
 		this.mvc.perform(get(BASE).with(jwt()//
+				.jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("janus_employee"))))
 				.jwt(jwt -> jwt.claim("email", "aferrer@nivel36.es"))
 				.authorities(createAuthorityList("ROLE_JANUS_EMPLOYEE"))))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
 				.andExpect(jsonPath("$.content[?(@.code=='GLOBAL-1')]").exists())
 				.andExpect(jsonPath("$.content[?(@.code=='ASG-BERTA')]").doesNotExist());
+	}
+
+	@Test
+	@Sql(statements = {
+			"INSERT INTO application_settings (days_until_locked, employee_workplace_creation_allowed, worksite_change_during_shift_allowed, default_timezone) VALUES (7, true, false, 'Europe/Madrid')",
+			"INSERT INTO worksite(code,name,time_zone,scope) VALUES('GLOBAL-1','Global Worksite','UTC+2','GLOBAL')" })
+	void testListAsEmployeeShouldRejectWhenJwtEmailClaimMissing() throws Exception {
+		this.mvc.perform(get(BASE).with(jwt()//
+				.jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("janus_employee"))))
+				.authorities(createAuthorityList("ROLE_JANUS_EMPLOYEE"))))
+				.andExpect(status().isForbidden());
 	}
 
 	@Test

--- a/apps/backend/src/test/java/es/nivel36/janus/api/v1/worksite/WorksiteControllerIT.java
+++ b/apps/backend/src/test/java/es/nivel36/janus/api/v1/worksite/WorksiteControllerIT.java
@@ -62,6 +62,39 @@ class WorksiteControllerIT {
 	@Test
 	@Sql(statements = {
 			"INSERT INTO application_settings (days_until_locked, employee_workplace_creation_allowed, worksite_change_during_shift_allowed, default_timezone) VALUES (7, true, false, 'Europe/Madrid')",
+			"INSERT INTO schedule(id,code,name) VALUES(1,'STD-WH', 'Standard Work Hours')",
+			"INSERT INTO employee(id,name,surname,email,schedule_id) VALUES(1,'Abel','Ferrer','aferrer@nivel36.es',1)",
+			"INSERT INTO employee(id,name,surname,email,schedule_id) VALUES(2,'Berta','Person','bperson@nivel36.es',1)",
+			"INSERT INTO worksite(code,name,time_zone,scope) VALUES('BCN-HQ','Barcelona Headquarters','UTC+2','GLOBAL')" })
+	void testListAsEmployeeShouldRejectSearchingOtherEmployee() throws Exception {
+		this.mvc.perform(get(BASE).param("employeeEmail", "bperson@nivel36.es").with(jwt()//
+				.jwt(jwt -> jwt.claim("email", "aferrer@nivel36.es"))
+				.authorities(createAuthorityList("ROLE_JANUS_EMPLOYEE"))))
+				.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@Sql(statements = {
+			"INSERT INTO application_settings (days_until_locked, employee_workplace_creation_allowed, worksite_change_during_shift_allowed, default_timezone) VALUES (7, true, false, 'Europe/Madrid')",
+			"INSERT INTO schedule(id,code,name) VALUES(1,'STD-WH', 'Standard Work Hours')",
+			"INSERT INTO employee(id,name,surname,email,schedule_id) VALUES(1,'Abel','Ferrer','aferrer@nivel36.es',1)",
+			"INSERT INTO employee(id,name,surname,email,schedule_id) VALUES(2,'Berta','Person','bperson@nivel36.es',1)",
+			"INSERT INTO worksite(code,name,time_zone,scope) VALUES('GLOBAL-1','Global Worksite','UTC+2','GLOBAL')",
+			"INSERT INTO worksite(code,name,time_zone,scope) VALUES('ASG-BERTA','Assigned Berta','UTC+2','ASSIGNED')",
+			"INSERT INTO employee_worksite(employee_id, worksite_id) SELECT 2, w.id FROM worksite w WHERE w.code='ASG-BERTA'" })
+	void testListAsEmployeeShouldBeForcedToOwnEmailWhenNoFilterProvided() throws Exception {
+		this.mvc.perform(get(BASE).with(jwt()//
+				.jwt(jwt -> jwt.claim("email", "aferrer@nivel36.es"))
+				.authorities(createAuthorityList("ROLE_JANUS_EMPLOYEE"))))
+				.andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+				.andExpect(jsonPath("$.content[?(@.code=='GLOBAL-1')]").exists())
+				.andExpect(jsonPath("$.content[?(@.code=='ASG-BERTA')]").doesNotExist());
+	}
+
+	@Test
+	@Sql(statements = {
+			"INSERT INTO application_settings (days_until_locked, employee_workplace_creation_allowed, worksite_change_during_shift_allowed, default_timezone) VALUES (7, true, false, 'Europe/Madrid')",
 			"INSERT INTO worksite(code,name,time_zone,scope) VALUES('BCN-HQ','Barcelona Headquarters','UTC+2','GLOBAL')" })
 	void testFindByCodeShouldReturnWorksite() throws Exception {
 		this.mvc.perform(get(BASE + "/{code}", "BCN-HQ").with(jwt()//


### PR DESCRIPTION
### Motivation
- Ensure worksite search respects worksite visibility rules and that non-admin employees cannot query other employees' assigned worksites.
- Centralize filtering logic so searches optionally consider an `employeeEmail` filter for visibility and security.

### Description
- Updated `WorksiteController` to accept an optional `employeeEmail` request parameter, validate it with an email regex, obtain the authenticated `Jwt`, and enforce that users with only `ROLE_JANUS_EMPLOYEE` can only search using their own email; admins and users can specify any email.
- Changed `WorksiteService.searchWorksites` signature to `searchWorksites(String query, String employeeEmail, Pageable pageable)`, added input sanitization, and route calls to the repository using the effective employee email.
- Modified `WorksiteRepository.search` JPQL to add `DISTINCT`, accept `:employeeEmail`, and filter results to global worksites or worksites assigned to the provided email when `employeeEmail` is present, and removed the now-unused `findVisibleByEmployeeEmail` method.
- Added integration tests in `WorksiteControllerIT` to verify admin listing, that an employee is forbidden from searching for other employees, and that employee searches without a filter are constrained to the authenticated user's visibility.

### Testing
- Ran `WorksiteControllerIT` integration tests which include the new cases for employee access control and visibility, and they passed.
- Existing controller tests for `GET /api/v1/worksites` and `GET /api/v1/worksites/{code}` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e782974d3c8327a6aae13da8f32167)