### PR TITLE
Retry transient HTTP errors for timelog reads with backoff and jitter

### DIFF
--- a/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.ts
@@ -29,6 +29,7 @@ import { CardComponent } from '../../../../shared/ui/card/card.component';
 import { ClockComponent } from '../../../../shared/ui/clock/clock.component';
 import { TimeLog } from '../../models/timelog';
 import { TimeLogService } from '../../services/timelog-api.service';
+import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
 /**
  * Requested clock action mode.
@@ -319,6 +320,7 @@ export class TimelogClockCardComponent {
   private searchLatestTimeLog(employeeEmail: string): Observable<TimeLog | undefined> {
     return this.timeLogService
       .searchLatestByEmployee(employeeEmail)
+      .pipe(retryTransientHttpErrors(5_000))
       .pipe(catchError(() => of(undefined)));
   }
 

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
@@ -18,6 +18,7 @@ import { DurationPipe } from '../../../../shared/pipes/duration.pipe';
 import { TimeLogService, TimeLogPage } from '../../services/timelog-api.service';
 import { FALLBACK_LANGUAGE } from '../../../../core/i18n/language.util';
 import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
+import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
 @Component({
   selector: 'app-timelog-table',
@@ -80,7 +81,7 @@ export class TimelogTableComponent {
         params.employeeEmail,
         params.page - 1,
         TimelogTableComponent.PAGE_SIZE,
-      ),
+      ).pipe(retryTransientHttpErrors(5_000)),
     defaultValue: {
       items: [],
       totalItems: 0,

--- a/apps/frontend/src/app/shared/utils/http-retry.util.ts
+++ b/apps/frontend/src/app/shared/utils/http-retry.util.ts
@@ -1,0 +1,48 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { MonoTypeOperatorFunction, Observable, throwError, timer } from 'rxjs';
+import { mergeMap, retryWhen } from 'rxjs/operators';
+
+/**
+ * Retries transient HTTP failures while the caller keeps the subscription alive.
+ *
+ * Intended for read operations in active screens (e.g. polling-like UX without
+ * keeping an explicit interval in the component).
+ */
+export function retryTransientHttpErrors<T>(
+  retryDelayMs = 5_000,
+  maxRetries = Number.POSITIVE_INFINITY,
+): MonoTypeOperatorFunction<T> {
+  return (source: Observable<T>) =>
+    source.pipe(
+      retryWhen((errors) =>
+        errors.pipe(
+          mergeMap((error: unknown, attemptIndex) => {
+            const attempt = attemptIndex + 1;
+            const isRetryable = isRetryableHttpError(error);
+
+            if (!isRetryable || attempt > maxRetries) {
+              return throwError(() => error);
+            }
+
+            return timer(computeBackoffWithJitter(retryDelayMs, attempt));
+          }),
+        ),
+      ),
+    );
+}
+
+function isRetryableHttpError(error: unknown): boolean {
+  if (!(error instanceof HttpErrorResponse)) {
+    return false;
+  }
+
+  return error.status === 0 || error.status === 502 || error.status === 503 || error.status === 504;
+}
+
+function computeBackoffWithJitter(baseDelayMs: number, attempt: number): number {
+  const exponentialDelay = baseDelayMs * Math.pow(2, Math.max(0, attempt - 1));
+  const cappedDelay = Math.min(exponentialDelay, 30_000);
+  const jitterFactor = 0.85 + Math.random() * 0.3;
+
+  return Math.round(cappedDelay * jitterFactor);
+}

--- a/apps/frontend/src/app/shared/utils/http-retry.util.ts
+++ b/apps/frontend/src/app/shared/utils/http-retry.util.ts
@@ -3,14 +3,14 @@ import { MonoTypeOperatorFunction, Observable, throwError, timer } from 'rxjs';
 import { mergeMap, retryWhen } from 'rxjs/operators';
 
 /**
- * Retries transient HTTP failures while the caller keeps the subscription alive.
+ * Retries transient HTTP failures with capped attempts so errors still surface.
  *
  * Intended for read operations in active screens (e.g. polling-like UX without
  * keeping an explicit interval in the component).
  */
 export function retryTransientHttpErrors<T>(
   retryDelayMs = 5_000,
-  maxRetries = Number.POSITIVE_INFINITY,
+  maxRetries = 5,
 ): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) =>
     source.pipe(


### PR DESCRIPTION
### Motivation

- Improve resilience of timelog read operations against transient network/server failures by retrying on retryable HTTP errors with backoff and jitter.  

### Description

- Add a reusable `retryTransientHttpErrors` operator in `apps/frontend/src/app/shared/utils/http-retry.util.ts` that uses `retryWhen`, exponential backoff with jitter, and only retries on retryable HTTP statuses (`0`, `502`, `503`, `504`).  
- Apply the new retry operator to `searchLatestByEmployee` in `timelog-clock-card.component.ts` to make the latest timelog lookup more robust.  
- Apply the new retry operator to the `searchByEmployee` stream in `timelog-table.component.ts` so table pagination requests are retried on transient errors.  
- Add the necessary imports for `retryTransientHttpErrors` where used.  

### Testing

- Ran the frontend unit test suite with `npm test`, and tests completed successfully.  
- Performed a local dev build with `npm run build` to validate TypeScript and bundling, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f239ee5f488327ae30b2e2919e6406)