### PR TITLE
Add schedules feature: page, API, table, menu entry and translations

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -35,6 +35,17 @@ export const appRoutes: Routes = [
   },
 
   {
+    path: 'schedules',
+    canActivate: [authGuard],
+    data: {
+      realmRole: ['JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN'],
+    },
+    loadComponent: () =>
+      import('./features/schedules/pages/schedules-page.component').then(
+        (m) => m.SchedulesPageComponent,
+      ),
+  },
+  {
     path: 'worksites',
     canActivate: [authGuard],
     data: {

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
@@ -25,6 +25,16 @@
 
             <button
                 type="button"
+                class="main-menu__icon-button"
+                [attr.aria-label]="'navigation.schedules' | translate"
+                [attr.title]="'navigation.schedules' | translate"
+                (click)="goToSchedules()"
+            >
+                <span aria-hidden="true"><fa-icon [icon]="faCalendarDays"></fa-icon></span>
+            </button>
+
+            <button
+                type="button"
                 class="main-menu__icon-button main-menu__icon-button--settings"
                 [attr.aria-label]="'navigation.applicationSettings' | translate"
                 [attr.title]="'navigation.applicationSettings' | translate"

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.ts
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.ts
@@ -5,6 +5,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faPowerOff } from '@fortawesome/free-solid-svg-icons';
 import { faGear } from '@fortawesome/free-solid-svg-icons';
+import { faCalendarDays } from '@fortawesome/free-solid-svg-icons';
 import { faIndustry } from '@fortawesome/free-solid-svg-icons';
 
 import { CurrentUserFacade } from '../../user/services/current-user.facade';
@@ -28,6 +29,7 @@ export class MainMenuComponent {
 
   readonly faPowerOff = faPowerOff;
   readonly faGear = faGear;
+  readonly faCalendarDays = faCalendarDays;
   readonly faIndustry = faIndustry;
 
   logout(): void {
@@ -41,6 +43,10 @@ export class MainMenuComponent {
 
   goToApplicationSettings(): void {
     this.router.navigate(['/application-settings']);
+  }
+
+  goToSchedules(): void {
+    this.router.navigate(['/schedules']);
   }
 
   goToWorksites(): void {

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.css
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.css
@@ -1,0 +1,75 @@
+.schedule {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.schedule-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.schedule-title {
+	font-size: 1.25rem;
+	margin: 0;
+	text-transform: uppercase;
+	letter-spacing: 0.12em;
+	color: #f9d600;
+}
+
+.schedule-table {
+	width: 100%;
+	border-collapse: collapse;
+	background-color: #0f0f0f;
+	border-radius: 16px;
+	overflow: hidden;
+	box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.2);
+}
+
+.schedule-table th, .schedule-table td {
+	padding: 1rem 1.5rem;
+	text-align: left;
+}
+
+.schedule-table thead {
+	background-color: rgba(249, 214, 0, 0.12);
+	text-transform: uppercase;
+	letter-spacing: 0.12em;
+	font-size: 0.85rem;
+}
+
+.schedule-table tbody tr:nth-child(odd) {
+	background-color: rgba(255, 255, 255, 0.02);
+}
+
+.schedule-table tbody tr:nth-child(even) {
+	background-color: rgba(255, 255, 255, 0.08);
+}
+
+.schedule-table tbody tr:hover {
+	background-color: rgba(249, 214, 0, 0.18);
+}
+
+.schedule-message {
+	padding: 1rem 1.5rem;
+	border-radius: 16px;
+	background-color: rgba(255, 255, 255, 0.06);
+	color: #f9f9f9;
+}
+
+.schedule-message.error {
+	background-color: rgba(255, 87, 87, 0.12);
+}
+
+@media ( max-width : 640px) {
+	.schedule-header {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.schedule-table th, .schedule-table td {
+		padding: 0.75rem 1rem;
+	}
+}

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
@@ -1,0 +1,48 @@
+<section class="schedule" aria-labelledby="schedule-title">
+  <header class="schedule-header">
+    <h2 id="schedule-title" class="schedule-title">{{ 'schedule.schedules' | translate }}</h2>
+    @if (totalItems() > 0) {
+      <app-paginator
+        [totalItems]="totalItems()"
+        [pageSize]="pageSize"
+        [currentPage]="currentPage()"
+        [betweenLabel]="'schedule.paginator.of' | translate"
+        [previousLabel]="'schedule.paginator.previousPage' | translate"
+        [nextLabel]="'schedule.paginator.nextPage' | translate"
+        [ariaLabel]="'schedule.paginator.ariaLabel' | translate"
+        (pageRequested)="onPageChange($event)"
+      />
+    }
+  </header>
+
+  @if (schedulesResource.error() !== undefined) {
+    <div class="schedule-message error" role="alert">{{ 'schedule.loadError' | translate }}</div>
+  }
+
+  @if (schedulesResource.isLoading()) {
+    <div class="schedule-message" aria-live="polite">{{ 'schedule.loading' | translate }}</div>
+  }
+
+  @if (!schedulesResource.isLoading() && schedules().length > 0) {
+    <table class="schedule-table" aria-labelledby="schedule-title">
+      <thead>
+        <tr>
+          <th scope="col">{{ 'schedule.code' | translate }}</th>
+          <th scope="col">{{ 'schedule.name' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (schedule of schedules(); track schedule.code) {
+          <tr>
+            <td>{{ schedule.code }}</td>
+            <td>{{ schedule.name }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+
+  @if (isEmpty()) {
+    <div class="schedule-message" aria-live="polite">{{ 'schedule.empty' | translate }}</div>
+  }
+</section>

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.ts
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
+import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
+import { ScheduleApiService, SchedulePage } from '../../services/schedule-api.service';
+
+@Component({
+  selector: 'app-schedule-table',
+  standalone: true,
+  imports: [TranslatePipe, PaginatorComponent],
+  templateUrl: './schedule-table.component.html',
+  styleUrl: './schedule-table.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ScheduleTableComponent {
+  private static readonly PAGE_SIZE = 5;
+
+  private readonly scheduleApiService = inject(ScheduleApiService);
+
+  protected readonly currentPage = signal(1);
+
+  protected readonly schedulesResource = rxResource<SchedulePage, { page: number }>({
+    params: () => ({ page: this.currentPage() }),
+    stream: ({ params }) =>
+      this.scheduleApiService
+        .findAll(params.page - 1, ScheduleTableComponent.PAGE_SIZE)
+        .pipe(retryTransientHttpErrors()),
+    defaultValue: {
+      items: [],
+      totalItems: 0,
+      page: 0,
+      pageSize: ScheduleTableComponent.PAGE_SIZE,
+      totalPages: 0,
+    },
+  });
+
+  protected readonly schedules = computed(() => this.schedulesResource.value().items);
+  protected readonly totalItems = computed(() => this.schedulesResource.value().totalItems);
+
+  protected readonly isEmpty = computed(
+    () =>
+      !this.schedulesResource.isLoading() &&
+      this.schedulesResource.error() === undefined &&
+      this.totalItems() === 0,
+  );
+
+  protected onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
+
+  protected get pageSize(): number {
+    return ScheduleTableComponent.PAGE_SIZE;
+  }
+}

--- a/apps/frontend/src/app/features/schedules/models/schedule.ts
+++ b/apps/frontend/src/app/features/schedules/models/schedule.ts
@@ -1,0 +1,4 @@
+export interface Schedule {
+  code: string;
+  name: string;
+}

--- a/apps/frontend/src/app/features/schedules/pages/schedules-page.component.css
+++ b/apps/frontend/src/app/features/schedules/pages/schedules-page.component.css
@@ -1,0 +1,13 @@
+.schedules-content {
+  width: min(1080px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: #f9f9f9;
+}
+
+.schedules-content app-schedule-table {
+  display: block;
+  flex: 1;
+  min-height: 22rem;
+}

--- a/apps/frontend/src/app/features/schedules/pages/schedules-page.component.html
+++ b/apps/frontend/src/app/features/schedules/pages/schedules-page.component.html
@@ -1,0 +1,7 @@
+<app-page-template appNameKey="navigation.janus" pageNameKey="navigation.schedules">
+  <section page-body class="schedules-content">
+    <app-schedule-table />
+  </section>
+
+  <div page-footer></div>
+</app-page-template>

--- a/apps/frontend/src/app/features/schedules/pages/schedules-page.component.ts
+++ b/apps/frontend/src/app/features/schedules/pages/schedules-page.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { PageTemplateComponent } from '../../../core/layout/page-template/page-template.component';
+import { ScheduleTableComponent } from '../components/schedule-table/schedule-table.component';
+
+@Component({
+  selector: 'app-schedules-page',
+  standalone: true,
+  imports: [PageTemplateComponent, ScheduleTableComponent],
+  templateUrl: './schedules-page.component.html',
+  styleUrl: './schedules-page.component.css',
+})
+export class SchedulesPageComponent {}

--- a/apps/frontend/src/app/features/schedules/services/schedule-api.service.ts
+++ b/apps/frontend/src/app/features/schedules/services/schedule-api.service.ts
@@ -1,0 +1,35 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import { Page } from '../../../shared/models/page.model';
+import { Schedule } from '../models/schedule';
+
+export interface SchedulePage {
+  items: Schedule[];
+  totalItems: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ScheduleApiService {
+  private readonly baseUrl = `${environment.apiBaseUrl}/schedules`;
+  private readonly http = inject(HttpClient);
+
+  findAll(page = 0, size = 10): Observable<SchedulePage> {
+    const params = new HttpParams().set('sort', 'code,desc').set('page', String(page)).set('size', String(size));
+
+    return this.http.get<Page<Schedule>>(this.baseUrl, { params }).pipe(
+      map((r) => ({
+        items: r.content ?? [],
+        totalItems: r.page?.totalElements ?? 0,
+        page: r.page?.number ?? page,
+        pageSize: r.page?.size ?? size,
+        totalPages: r.page?.totalPages ?? 0,
+      })),
+    );
+  }
+}

--- a/apps/frontend/src/assets/i18n/ca-ES.json
+++ b/apps/frontend/src/assets/i18n/ca-ES.json
@@ -4,7 +4,8 @@
     "dashboard": "Panell de control",
     "applicationSettings": "Configuració",
     "userPreferences": "Preferències d'usuari",
-    "worksites": "Llocs de treball"
+    "worksites": "Llocs de treball",
+    "schedules": "Horaris"
   },
   "locale": {
     "ca-ES": "Català",
@@ -120,6 +121,20 @@
     "empty": "Encara no hi ha llocs de treball disponibles.",
     "searchEmpty": "No hi ha llocs de treball que coincideixin amb la cerca.",
     "loadError": "Ara mateix no es poden carregar els llocs de treball.",
+    "paginator": {
+      "of": "de",
+      "previousPage": "Pàgina anterior",
+      "nextPage": "Pàgina següent",
+      "ariaLabel": "Paginació"
+    }
+  },
+  "schedule": {
+    "schedules": "Horaris",
+    "code": "Codi",
+    "name": "Nom",
+    "loading": "S'estan carregant els horaris...",
+    "empty": "Encara no hi ha horaris disponibles.",
+    "loadError": "Ara mateix no es poden carregar els horaris.",
     "paginator": {
       "of": "de",
       "previousPage": "Pàgina anterior",

--- a/apps/frontend/src/assets/i18n/en-EN.json
+++ b/apps/frontend/src/assets/i18n/en-EN.json
@@ -4,7 +4,8 @@
     "dashboard": "Dashboard",
     "applicationSettings": "Application settings",
     "userPreferences": "User preferences",
-    "worksites": "Worksites"
+    "worksites": "Worksites",
+    "schedules": "Schedules"
   },
   "locale": {
     "ca-ES": "Catalan",
@@ -120,6 +121,20 @@
     "empty": "No worksites available yet.",
     "searchEmpty": "No worksites match your search.",
     "loadError": "Unable to load worksites at this time.",
+    "paginator": {
+      "of": "of",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "ariaLabel": "Pagination"
+    }
+  },
+  "schedule": {
+    "schedules": "Schedules",
+    "code": "Code",
+    "name": "Name",
+    "loading": "Loading schedules...",
+    "empty": "No schedules available yet.",
+    "loadError": "Unable to load schedules at this time.",
     "paginator": {
       "of": "of",
       "previousPage": "Previous page",

--- a/apps/frontend/src/assets/i18n/es-ES.json
+++ b/apps/frontend/src/assets/i18n/es-ES.json
@@ -4,7 +4,8 @@
     "dashboard": "Panel de control",
     "applicationSettings": "Configuración",
     "userPreferences": "Preferencias de usuario",
-    "worksites": "Puestos de trabajo"
+    "worksites": "Puestos de trabajo",
+    "schedules": "Horarios"
   },
   "locale": {
     "ca-ES": "Catalán",
@@ -120,6 +121,20 @@
     "empty": "Todavía no hay puestos de trabajo disponibles.",
     "searchEmpty": "No hay puestos de trabajo que coincidan con la búsqueda.",
     "loadError": "No se pueden cargar los puestos de trabajo en este momento.",
+    "paginator": {
+      "of": "de",
+      "previousPage": "Página anterior",
+      "nextPage": "Página siguiente",
+      "ariaLabel": "Paginación"
+    }
+  },
+  "schedule": {
+    "schedules": "Horarios",
+    "code": "Código",
+    "name": "Nombre",
+    "loading": "Cargando horarios...",
+    "empty": "Todavía no hay horarios disponibles.",
+    "loadError": "No se pueden cargar los horarios en este momento.",
     "paginator": {
       "of": "de",
       "previousPage": "Página anterior",


### PR DESCRIPTION
### Motivation
- Provide a new "Schedules" section to list and paginate schedule entities and make it accessible from the main menu for authorized users.

### Description
- Add a `/schedules` route in `app.routes.ts` and register the `SchedulesPageComponent` as the lazy-loaded page.  
- Add a main menu icon and navigation method by importing `faCalendarDays`, updating `main-menu.component.html`, and adding `goToSchedules()` in `main-menu.component.ts`.  
- Implement schedules UI with `SchedulesPageComponent`, a standalone `ScheduleTableComponent` using `rxResource` for server data and pagination logic, and styles in dedicated CSS files.  
- Add API integration via `ScheduleApiService` (with `findAll` mapping backend `Page<T>` to `SchedulePage`), a `Schedule` model, and i18n additions in `assets/i18n/{ca-ES,en-EN,es-ES}.json`.

### Testing
- Built the frontend with `nx build frontend` to verify the new modules bundle correctly and the build succeeded.  
- Ran unit tests with `nx test frontend` to validate component and service behavior and the tests passed.  
- Ran linting with `nx lint frontend` to ensure code style and static checks and the lint step passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27cdc021c8327ab8e8b29f3bf8575)