### PR TITLE
Add reusable TabsComponent with lazy-loaded panels and TabItemDirective

### DIFF
--- a/apps/frontend/src/app/shared/ui/tabs/tab-item.directive.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tab-item.directive.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Directive, TemplateRef, inject, input } from '@angular/core';
+
+/**
+ * Tab panel template definition consumed by {@link TabsComponent}.
+ */
+@Directive({
+  selector: 'ng-template[appTabItem]',
+  standalone: true,
+})
+export class TabItemDirective {
+  /**
+   * Visible tab label.
+   */
+  readonly label = input.required<string>({ alias: 'appTabItem' });
+
+  readonly template = inject(TemplateRef<unknown>);
+}

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.css
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.css
@@ -1,0 +1,25 @@
+.tabs {
+    display: flex;
+    gap: 0.5rem;
+    border-bottom: 1px solid #d6d6d6;
+    margin-bottom: 1rem;
+}
+
+.tabs-trigger {
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    padding: 0.5rem 0.25rem;
+    cursor: pointer;
+    color: #4a4a4a;
+    font-weight: 600;
+}
+
+.tabs-trigger-active {
+    border-bottom-color: #2563eb;
+    color: #111827;
+}
+
+.tabs-panel {
+    min-height: 4rem;
+}

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
@@ -4,8 +4,8 @@
             type="button"
             class="tabs-trigger"
             role="tab"
-            [id]="'tab-trigger-' + index"
-            [attr.aria-controls]="'tab-panel-' + index"
+            [id]="triggerId(index)"
+            [attr.aria-controls]="panelId(index)"
             [attr.aria-selected]="activeIndex() === index"
             [class.tabs-trigger-active]="activeIndex() === index"
             (click)="selectTab(index)"
@@ -20,8 +20,8 @@
         <section
             class="tabs-panel"
             role="tabpanel"
-            [id]="'tab-panel-' + index"
-            [attr.aria-labelledby]="'tab-trigger-' + index"
+            [id]="panelId(index)"
+            [attr.aria-labelledby]="triggerId(index)"
         >
             <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
         </section>

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
@@ -1,0 +1,29 @@
+<div class="tabs" role="tablist" aria-label="Tabs navigation">
+    @for (tabItem of tabItems(); track $index; let index = $index) {
+        <button
+            type="button"
+            class="tabs-trigger"
+            role="tab"
+            [id]="'tab-trigger-' + index"
+            [attr.aria-controls]="'tab-panel-' + index"
+            [attr.aria-selected]="activeIndex() === index"
+            [class.tabs-trigger-active]="activeIndex() === index"
+            (click)="selectTab(index)"
+        >
+            {{ tabItem.label() }}
+        </button>
+    }
+</div>
+
+@for (tabItem of tabItems(); track $index; let index = $index) {
+    @if (isLoaded(index) && activeIndex() === index) {
+        <section
+            class="tabs-panel"
+            role="tabpanel"
+            [id]="'tab-panel-' + index"
+            [attr.aria-labelledby]="'tab-trigger-' + index"
+        >
+            <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
+        </section>
+    }
+}

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.spec.ts
@@ -4,7 +4,7 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { describe, expect, it, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { TabItemDirective } from './tab-item.directive';
 import { TabsComponent } from './tabs.component';
@@ -13,19 +13,29 @@ import { TabsComponent } from './tabs.component';
   standalone: true,
   imports: [TabsComponent, TabItemDirective],
   template: `
-    <app-tabs>
-      <ng-template appTabItem="Resumen">
-        <p id="summary-content">Contenido resumen</p>
-      </ng-template>
+    <section id="tabs-a">
+      <app-tabs>
+        <ng-template appTabItem="Resumen">
+          <p class="summary-content">Contenido resumen</p>
+        </ng-template>
 
-      <ng-template appTabItem="Detalles">
-        <p id="details-content">Contenido detalles</p>
-      </ng-template>
+        <ng-template appTabItem="Detalles">
+          <p class="details-content">Contenido detalles</p>
+        </ng-template>
+      </app-tabs>
+    </section>
 
-      <ng-template appTabItem="Histórico">
-        <p id="history-content">Contenido histórico</p>
-      </ng-template>
-    </app-tabs>
+    <section id="tabs-b">
+      <app-tabs>
+        <ng-template appTabItem="Uno">
+          <p class="one-content">Contenido uno</p>
+        </ng-template>
+
+        <ng-template appTabItem="Dos">
+          <p class="two-content">Contenido dos</p>
+        </ng-template>
+      </app-tabs>
+    </section>
   `,
 })
 class TestHostComponent {}
@@ -34,43 +44,6 @@ describe('TabsComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(async () => {
-    TestBed.overrideComponent(TabsComponent, {
-      set: {
-        template: `
-          <div class="tabs" role="tablist" aria-label="Tabs navigation">
-              @for (tabItem of tabItems(); track $index; let index = $index) {
-                  <button
-                      type="button"
-                      class="tabs-trigger"
-                      role="tab"
-                      [id]="'tab-trigger-' + index"
-                      [attr.aria-controls]="'tab-panel-' + index"
-                      [attr.aria-selected]="activeIndex() === index"
-                      [class.tabs-trigger-active]="activeIndex() === index"
-                      (click)="selectTab(index)"
-                  >
-                      {{ tabItem.label() }}
-                  </button>
-              }
-          </div>
-
-          @for (tabItem of tabItems(); track $index; let index = $index) {
-              @if (isLoaded(index) && activeIndex() === index) {
-                  <section
-                      class="tabs-panel"
-                      role="tabpanel"
-                      [id]="'tab-panel-' + index"
-                      [attr.aria-labelledby]="'tab-trigger-' + index"
-                  >
-                      <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
-                  </section>
-              }
-          }
-        `,
-        styles: [''],
-      },
-    });
-
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
     }).compileComponents();
@@ -80,30 +53,48 @@ describe('TabsComponent', () => {
   });
 
   it('should create', () => {
-    const tabsDebugEl = fixture.debugElement.query(By.directive(TabsComponent));
-    expect(tabsDebugEl).toBeTruthy();
+    const tabsDebugEls = fixture.debugElement.queryAll(By.directive(TabsComponent));
+    expect(tabsDebugEls.length).toBe(2);
   });
 
   it('should render only the first tab panel on initial load', () => {
-    expect(fixture.nativeElement.querySelector('#summary-content')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('#details-content')).toBeNull();
-    expect(fixture.nativeElement.querySelector('#history-content')).toBeNull();
+    const firstTabs = fixture.nativeElement.querySelector('#tabs-a');
+
+    expect(firstTabs.querySelector('.summary-content')).toBeTruthy();
+    expect(firstTabs.querySelector('.details-content')).toBeNull();
   });
 
   it('should lazy-load a panel only when its tab is clicked', () => {
-    const tabButtons: NodeListOf<HTMLButtonElement> = fixture.nativeElement.querySelectorAll('button[role="tab"]');
+    const firstTabs = fixture.nativeElement.querySelector('#tabs-a');
+    const tabButtons: NodeListOf<HTMLButtonElement> = firstTabs.querySelectorAll('button[role="tab"]');
 
     tabButtons[1].click();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelector('#summary-content')).toBeNull();
-    expect(fixture.nativeElement.querySelector('#details-content')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('#history-content')).toBeNull();
+    expect(firstTabs.querySelector('.summary-content')).toBeNull();
+    expect(firstTabs.querySelector('.details-content')).toBeTruthy();
+  });
 
-    tabButtons[2].click();
-    fixture.detectChanges();
+  it('should generate unique ids across different app-tabs instances', () => {
+    const tabElements: NodeListOf<HTMLElement> = fixture.nativeElement.querySelectorAll('[role="tab"]');
+    const panelElements: NodeListOf<HTMLElement> = fixture.nativeElement.querySelectorAll('[role="tabpanel"]');
 
-    expect(fixture.nativeElement.querySelector('#details-content')).toBeNull();
-    expect(fixture.nativeElement.querySelector('#history-content')).toBeTruthy();
+    const tabIds = Array.from(tabElements, (tab) => tab.id);
+    const panelIds = Array.from(panelElements, (panel) => panel.id);
+
+    expect(new Set(tabIds).size).toBe(tabIds.length);
+    expect(new Set(panelIds).size).toBe(panelIds.length);
+
+    tabElements.forEach((tab) => {
+      const controlledPanelId = tab.getAttribute('aria-controls');
+      expect(controlledPanelId).toBeTruthy();
+      expect(fixture.nativeElement.querySelector(`#${controlledPanelId}`)).toBeTruthy();
+    });
+
+    panelElements.forEach((panel) => {
+      const labelledById = panel.getAttribute('aria-labelledby');
+      expect(labelledById).toBeTruthy();
+      expect(fixture.nativeElement.querySelector(`#${labelledById}`)).toBeTruthy();
+    });
   });
 });

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { TabItemDirective } from './tab-item.directive';
+import { TabsComponent } from './tabs.component';
+
+@Component({
+  standalone: true,
+  imports: [TabsComponent, TabItemDirective],
+  template: `
+    <app-tabs>
+      <ng-template appTabItem="Resumen">
+        <p id="summary-content">Contenido resumen</p>
+      </ng-template>
+
+      <ng-template appTabItem="Detalles">
+        <p id="details-content">Contenido detalles</p>
+      </ng-template>
+
+      <ng-template appTabItem="Histórico">
+        <p id="history-content">Contenido histórico</p>
+      </ng-template>
+    </app-tabs>
+  `,
+})
+class TestHostComponent {}
+
+describe('TabsComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    TestBed.overrideComponent(TabsComponent, {
+      set: {
+        template: `
+          <div class="tabs" role="tablist" aria-label="Tabs navigation">
+              @for (tabItem of tabItems(); track $index; let index = $index) {
+                  <button
+                      type="button"
+                      class="tabs-trigger"
+                      role="tab"
+                      [id]="'tab-trigger-' + index"
+                      [attr.aria-controls]="'tab-panel-' + index"
+                      [attr.aria-selected]="activeIndex() === index"
+                      [class.tabs-trigger-active]="activeIndex() === index"
+                      (click)="selectTab(index)"
+                  >
+                      {{ tabItem.label() }}
+                  </button>
+              }
+          </div>
+
+          @for (tabItem of tabItems(); track $index; let index = $index) {
+              @if (isLoaded(index) && activeIndex() === index) {
+                  <section
+                      class="tabs-panel"
+                      role="tabpanel"
+                      [id]="'tab-panel-' + index"
+                      [attr.aria-labelledby]="'tab-trigger-' + index"
+                  >
+                      <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
+                  </section>
+              }
+          }
+        `,
+        styles: [''],
+      },
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    const tabsDebugEl = fixture.debugElement.query(By.directive(TabsComponent));
+    expect(tabsDebugEl).toBeTruthy();
+  });
+
+  it('should render only the first tab panel on initial load', () => {
+    expect(fixture.nativeElement.querySelector('#summary-content')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('#details-content')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#history-content')).toBeNull();
+  });
+
+  it('should lazy-load a panel only when its tab is clicked', () => {
+    const tabButtons: NodeListOf<HTMLButtonElement> = fixture.nativeElement.querySelectorAll('button[role="tab"]');
+
+    tabButtons[1].click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('#summary-content')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#details-content')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('#history-content')).toBeNull();
+
+    tabButtons[2].click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('#details-content')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#history-content')).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
@@ -1,0 +1,40 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, contentChildren, signal } from '@angular/core';
+import { TabItemDirective } from './tab-item.directive';
+
+/**
+ * Reusable tab container with lazy panel instantiation.
+ *
+ * <p>Panels are only created after selecting their tab, so expensive content
+ * is not rendered upfront.</p>
+ */
+@Component({
+  selector: 'app-tabs',
+  standalone: true,
+  imports: [NgTemplateOutlet],
+  templateUrl: './tabs.component.html',
+  styleUrls: ['./tabs.component.css'],
+})
+export class TabsComponent {
+  readonly tabItems = contentChildren(TabItemDirective);
+
+  readonly activeIndex = signal(0);
+
+  private readonly loadedIndices = signal<Set<number>>(new Set([0]));
+
+  selectTab(index: number): void {
+    this.activeIndex.set(index);
+    this.loadedIndices.update((loaded) => {
+      const next = new Set(loaded);
+      next.add(index);
+      return next;
+    });
+  }
+
+  isLoaded(index: number): boolean {
+    return this.loadedIndices().has(index);
+  }
+}

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
@@ -3,6 +3,7 @@
  */
 import { NgTemplateOutlet } from '@angular/common';
 import { Component, contentChildren, signal } from '@angular/core';
+import { createUuid } from '../../utils/uuid.utils';
 import { TabItemDirective } from './tab-item.directive';
 
 /**
@@ -23,6 +24,8 @@ export class TabsComponent {
 
   readonly activeIndex = signal(0);
 
+  private readonly instanceId = `tabs-${createUuid()}`;
+
   private readonly loadedIndices = signal<Set<number>>(new Set([0]));
 
   selectTab(index: number): void {
@@ -36,5 +39,13 @@ export class TabsComponent {
 
   isLoaded(index: number): boolean {
     return this.loadedIndices().has(index);
+  }
+
+  triggerId(index: number): string {
+    return `${this.instanceId}-trigger-${index}`;
+  }
+
+  panelId(index: number): string {
+    return `${this.instanceId}-panel-${index}`;
   }
 }


### PR DESCRIPTION
### Motivation

- Provide a reusable tab container that accepts tab panel templates and avoids rendering expensive panel content until the panel is selected.

### Description

- Add `TabItemDirective` to tag `ng-template` panels and expose a required `label` input and the template reference. 
- Implement `TabsComponent` that collects panels via `contentChildren(TabItemDirective)`, tracks `activeIndex` with Angular `signal`, and lazily instantiates panels using a `loadedIndices` set. 
- Add component template `tabs.component.html` and styling `tabs.component.css` to render tab triggers and accessible tab panels. 
- Add unit tests in `tabs.component.spec.ts` that verify component creation, initial-panel rendering, and lazy-loading behavior.

### Testing

- Ran the component unit tests in `tabs.component.spec.ts` with Vitest and the tests for creation, initial load, and lazy-load behavior passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0498ca95148327b446fce1570aad96)