### PR TITLE
Rediseña pantalla detalle de worksite con pestañas

### DIFF
--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
@@ -46,3 +46,13 @@ input { width: 100%; box-sizing: border-box; border: 1px solid rgba(255,255,255,
   .content-grid { grid-template-columns: 1fr; }
   .field-row { grid-template-columns: 1fr; }
 }
+
+
+.message {
+  margin: 0.45rem 0 0;
+  font-size: 0.85rem;
+}
+
+.error {
+  color: #ff8a8a;
+}

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
@@ -1,52 +1,48 @@
-.worksite-create-content {
-  width: min(1080px, 100%);
-  display: flex;
+.worksite-detail-content {
+  width: min(1240px, 100%);
   color: #f9f9f9;
-}
-
-.worksite-create-content app-card {
-  display: block;
-  flex: 1;
-}
-
-form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  flex-grow: 1;
+  gap: 1.25rem;
 }
 
-.field-control {
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-}
-
-label {
-  color: #ffffff;
-  font-weight: 700;
-}
-
-input {
-  width: 100%;
-  box-sizing: border-box;
-  border: 1px solid #fece0b;
-  border-radius: 0.5rem;
-  background: #050505;
-  padding: 0.625rem 0.75rem;
-  color: #f9f9f9;
-  font-size: 0.95rem;
-}
-
-input:focus-visible {
-  outline: 0;
-  box-shadow: 0 0 0 2px rgba(249, 214, 0, 0.3);
-}
-
-.message {
+.page-title {
   margin: 0;
+  text-align: right;
+  letter-spacing: 0.14em;
+  font-size: 1.4rem;
 }
 
-.error {
-  color: #ff8a8a;
+.hero-card {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(90deg, rgba(28, 28, 28, 0.95), rgba(20, 20, 20, 0.85));
+}
+
+.scope-pill, .status-pill { background: #f7cb10; color: #1a1a1a; padding: 0.3rem 0.65rem; border-radius: 0.5rem; font-weight: 700; }
+.status-pill { background: rgba(70, 160, 85, 0.2); color: #8ceb99; border-radius: 999px; }
+
+.content-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+
+.panel-card h4 { margin: 0 0 1.25rem; color: #f7cb10; letter-spacing: 0.08em; }
+form { display: flex; flex-direction: column; gap: 0.9rem; }
+.field-row { display: grid; grid-template-columns: 160px 1fr; align-items: center; gap: 1rem; }
+label { font-weight: 700; opacity: 0.8; letter-spacing: 0.08em; }
+input { width: 100%; box-sizing: border-box; border: 1px solid rgba(255,255,255,0.18); background: rgba(0,0,0,.4); color: #fff; border-radius: .5rem; padding: .55rem .7rem; }
+
+.summary-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.9rem; }
+.summary-item { border: 1px solid rgba(255,255,255,0.08); border-radius: 1rem; padding: 1rem; min-height: 7.5rem; display: flex; flex-direction: column; justify-content: space-between; background: rgba(255,255,255,0.02); }
+.summary-item span { opacity: 0.85; letter-spacing: 0.08em; }
+.summary-item strong { font-size: 2.3rem; }
+
+.buttons { display: flex; justify-content: flex-end; gap: 0.75rem; margin-top: 0.5rem; }
+.empty-panel { min-height: 420px; }
+
+@media (max-width: 980px) {
+  .content-grid { grid-template-columns: 1fr; }
+  .field-row { grid-template-columns: 1fr; }
 }

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
@@ -1,79 +1,70 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.new">
-  <section page-body class="worksite-create-content">
-    <app-card styleClass="worksite-form-card">
-      <form [formGroup]="form" (ngSubmit)="save()">
-        <div class="field-control">
-          <label for="worksite-code">{{ 'worksite.code' | translate }}</label>
-          <input id="worksite-code" type="text" formControlName="code" autocomplete="off" />
+  <section page-body class="worksite-detail-content">
+    <h2 class="page-title">DETALLE DEL PUESTO DE TRABAJO</h2>
 
-          @if (form.controls.code.touched && form.controls.code.invalid) {
-            <p class="message error">{{ 'worksite.errors.invalidCode' | translate }}</p>
-          }
+    <app-tabs>
+      <ng-template appTabItem="GENERAL">
+        <article class="hero-card">
+          <div>
+            <h3>Barcelona Headquarters</h3>
+            <p>BCN-HQ <span class="scope-pill">GLOBAL</span></p>
+          </div>
+          <span class="status-pill">● ACTIVO</span>
+        </article>
+
+        <div class="content-grid">
+          <app-card styleClass="panel-card">
+            <h4>INFORMACIÓN GENERAL</h4>
+            <form [formGroup]="form" (ngSubmit)="save()">
+              <div class="field-row"><label for="worksite-code">CÓDIGO</label><input id="worksite-code" type="text" formControlName="code" /></div>
+              <div class="field-row"><label for="worksite-name">NOMBRE</label><input id="worksite-name" type="text" formControlName="name" /></div>
+              <div class="field-row">
+                <label for="worksite-scope">ÁMBITO</label>
+                <app-select inputId="worksite-scope" formControlName="scope" [options]="scopeOptions" />
+              </div>
+              <div class="field-row">
+                <label for="worksite-timezone">ZONA HORARIA</label>
+                <app-autocomplete-textbox
+                  id="worksite-timezone"
+                  formControlName="timeZone"
+                  [searchMethod]="searchMethod"
+                  [displayWith]="timezoneDisplayWith"
+                  [valueWith]="timezoneValueWith"
+                  [resolveByValue]="resolveTimezoneByValue"
+                />
+              </div>
+              <div class="field-row"><label for="worksite-address">DIRECCIÓN</label><input id="worksite-address" type="text" formControlName="address" /></div>
+              <div class="field-row">
+                <label for="worksite-description">DESCRIPCIÓN</label><input id="worksite-description" type="text" formControlName="description" />
+              </div>
+
+              <div class="buttons">
+                <app-button type="button" variant="secondary" (clicked)="cancel()">CANCELA</app-button>
+                <app-button type="submit" variant="main" [disabled]="form.invalid || saving">EDITA</app-button>
+              </div>
+            </form>
+          </app-card>
+
+          <app-card styleClass="panel-card">
+            <h4>RESUMEN</h4>
+            <div class="summary-grid">
+              <div class="summary-item"><span>👥 EMPLEADOS</span><strong>24</strong></div>
+              <div class="summary-item"><span>🕒 TURNOS ACTIVOS</span><strong>3</strong></div>
+              <div class="summary-item"><span>📝 FICHAJES HOY</span><strong>19</strong></div>
+              <div class="summary-item"><span>⚠️ INCIDENCIAS</span><strong>0</strong></div>
+            </div>
+          </app-card>
         </div>
+      </ng-template>
 
-        <div class="field-control">
-          <label for="worksite-name">{{ 'worksite.name' | translate }}</label>
-          <input id="worksite-name" type="text" formControlName="name" autocomplete="off" />
+      <ng-template appTabItem="EMPLEADOS">
+        <app-card styleClass="empty-panel">&nbsp;</app-card>
+      </ng-template>
 
-          @if (form.controls.name.touched && form.controls.name.invalid) {
-            <p class="message error">{{ 'worksite.errors.invalidName' | translate }}</p>
-          }
-        </div>
-
-        <div class="field-control">
-          <label for="worksite-scope">{{ 'worksite.scope' | translate }}</label>
-          <app-select inputId="worksite-scope" formControlName="scope" [options]="scopeOptions" />
-        </div>
-
-        <div class="field-control">
-          <label for="worksite-description">{{ 'worksite.description' | translate }}</label>
-          <input
-            id="worksite-description"
-            type="text"
-            formControlName="description"
-            autocomplete="off"
-          />
-        </div>
-
-        <div class="field-control">
-          <label for="worksite-address">{{ 'worksite.address' | translate }}</label>
-          <input id="worksite-address" type="text" formControlName="address" autocomplete="off" />
-        </div>
-
-        <div class="field-control">
-          <label for="worksite-timezone">{{ 'worksite.timeZone' | translate }}</label>
-          <app-autocomplete-textbox
-            id="worksite-timezone"
-            formControlName="timeZone"
-            [searchMethod]="searchMethod"
-            [displayWith]="timezoneDisplayWith"
-            [valueWith]="timezoneValueWith"
-            [resolveByValue]="resolveTimezoneByValue"
-            [emptyHint]="'worksite.fields.timeZoneHint' | translate"
-          />
-
-          @if (form.controls.timeZone.touched && form.controls.timeZone.invalid) {
-            <p class="message error">
-              {{ 'worksite.errors.invalidTimezone' | translate }}
-            </p>
-          }
-        </div>
-
-        @if (errorMessage) {
-          <p class="message error">{{ errorMessage | translate }}</p>
-        }
-
-        <div class="buttons">
-          <app-button type="button" variant="secondary" (clicked)="cancel()">
-            {{ 'actions.cancel' | translate }}
-          </app-button>
-
-          <app-button type="submit" variant="main" [disabled]="form.invalid || saving">
-            {{ 'actions.save' | translate }}
-          </app-button>
-        </div>
-      </form>
-    </app-card>
+      <ng-template appTabItem="HORARIOS">
+        <app-card styleClass="empty-panel">&nbsp;</app-card>
+      </ng-template>
+    </app-tabs>
   </section>
 
   <div page-footer></div>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
@@ -16,27 +16,62 @@
           <app-card styleClass="panel-card">
             <h4>INFORMACIÓN GENERAL</h4>
             <form [formGroup]="form" (ngSubmit)="save()">
-              <div class="field-row"><label for="worksite-code">CÓDIGO</label><input id="worksite-code" type="text" formControlName="code" /></div>
-              <div class="field-row"><label for="worksite-name">NOMBRE</label><input id="worksite-name" type="text" formControlName="name" /></div>
+              <div class="field-row">
+                <label for="worksite-code">CÓDIGO</label>
+                <div>
+                  <input id="worksite-code" type="text" formControlName="code" />
+                  @if (form.controls.code.touched && form.controls.code.invalid) {
+                    <p class="message error">{{ 'worksite.errors.invalidCode' | translate }}</p>
+                  }
+                </div>
+              </div>
+
+              <div class="field-row">
+                <label for="worksite-name">NOMBRE</label>
+                <div>
+                  <input id="worksite-name" type="text" formControlName="name" />
+                  @if (form.controls.name.touched && form.controls.name.invalid) {
+                    <p class="message error">{{ 'worksite.errors.invalidName' | translate }}</p>
+                  }
+                </div>
+              </div>
+
               <div class="field-row">
                 <label for="worksite-scope">ÁMBITO</label>
                 <app-select inputId="worksite-scope" formControlName="scope" [options]="scopeOptions" />
               </div>
+
               <div class="field-row">
                 <label for="worksite-timezone">ZONA HORARIA</label>
-                <app-autocomplete-textbox
-                  id="worksite-timezone"
-                  formControlName="timeZone"
-                  [searchMethod]="searchMethod"
-                  [displayWith]="timezoneDisplayWith"
-                  [valueWith]="timezoneValueWith"
-                  [resolveByValue]="resolveTimezoneByValue"
-                />
+                <div>
+                  <app-autocomplete-textbox
+                    id="worksite-timezone"
+                    formControlName="timeZone"
+                    [searchMethod]="searchMethod"
+                    [displayWith]="timezoneDisplayWith"
+                    [valueWith]="timezoneValueWith"
+                    [resolveByValue]="resolveTimezoneByValue"
+                  />
+
+                  @if (form.controls.timeZone.touched && form.controls.timeZone.invalid) {
+                    <p class="message error">{{ 'worksite.errors.invalidTimezone' | translate }}</p>
+                  }
+                </div>
               </div>
-              <div class="field-row"><label for="worksite-address">DIRECCIÓN</label><input id="worksite-address" type="text" formControlName="address" /></div>
+
               <div class="field-row">
-                <label for="worksite-description">DESCRIPCIÓN</label><input id="worksite-description" type="text" formControlName="description" />
+                <label for="worksite-address">DIRECCIÓN</label>
+                <input id="worksite-address" type="text" formControlName="address" />
               </div>
+
+              <div class="field-row">
+                <label for="worksite-description">DESCRIPCIÓN</label>
+                <input id="worksite-description" type="text" formControlName="description" />
+              </div>
+
+              @if (errorMessage) {
+                <p class="message error">{{ errorMessage | translate }}</p>
+              }
 
               <div class="buttons">
                 <app-button type="button" variant="secondary" (clicked)="cancel()">CANCELA</app-button>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.ts
@@ -17,6 +17,8 @@ import { AutocompleteTextboxComponent } from '../../../shared/ui/autocomplete-te
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { CardComponent } from '../../../shared/ui/card/card.component';
 import { SelectComponent, SelectOption } from '../../../shared/ui/select/select.component';
+import { TabItemDirective } from '../../../shared/ui/tabs/tab-item.directive';
+import { TabsComponent } from '../../../shared/ui/tabs/tabs.component';
 import { WorksiteScope } from '../models/worksite';
 import { WorksiteApiService } from '../services/worksite-api.service';
 
@@ -30,6 +32,8 @@ import { WorksiteApiService } from '../services/worksite-api.service';
     ButtonComponent,
     CardComponent,
     SelectComponent,
+    TabsComponent,
+    TabItemDirective,
     PageTemplateComponent,
   ],
   templateUrl: './worksite-create-page.component.html',


### PR DESCRIPTION
### Motivation
- Ajustar la pantalla de detalle de un worksite para que siga el diseño compartido con navegación por pestañas y paneles claros.

### Description
- Se reemplaza el layout de la página por una vista de detalle que usa `app-tabs` con tres pestañas `GENERAL`, `EMPLEADOS` y `HORARIOS`, manteniendo solo `GENERAL` con contenido y dejando las otras dos como paneles vacíos.
- Se actualiza la plantilla `worksite-create-page.component.html` y los estilos en `worksite-create-page.component.css` para introducir el hero card, paneles de información y el grid de resumen responsive.
- Se importan `TabsComponent` y `TabItemDirective` en `worksite-create-page.component.ts` y se conserva toda la lógica existente del formulario (`save`, `cancel`) y sus validaciones.
- Archivos modificados: `apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html`, `apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css`, `apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.ts`.

### Testing
- Se ejecutó `npm run lint` en `apps/frontend` como verificación automática y el comando falló por errores preexistentes en otros módulos del proyecto; no se introdujeron nuevos errores en los archivos modificados.
- No se añadieron nuevas pruebas unitarias en esta PR y la funcionalidad de guardado/navegación existente se mantiene sin cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b06be2e08327b6abb0225cb86183)