### PR TITLE
Add worksite statistics endpoint for date ranges

### DIFF
--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
@@ -15,6 +15,7 @@
  */
 package es.nivel36.janus.api.v1.worksite;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Objects;
 
@@ -135,6 +136,27 @@ public class WorksiteController {
 		final Worksite worksite = this.worksiteService.findWorksiteByCode(worksiteCode);
 		final WorksiteResponse response = this.worksiteResponseMapper.map(worksite);
 		return ResponseEntity.ok(response);
+	}
+
+
+	@GetMapping("/{worksiteCode}/stats")
+	@PreAuthorize("hasAnyRole('JANUS_EMPLOYEE', 'JANUS_USER', 'JANUS_ADMIN')")
+	public ResponseEntity<WorksiteStatsResponse> stats(
+			@PathVariable("worksiteCode") @Pattern(regexp = "[A-Za-z0-9_-]{1,50}", message = "code must contain only letters, digits, underscores or hyphens (max 50)") final String worksiteCode,
+			@RequestParam("start") final Instant start,
+			@RequestParam("end") final Instant end) {
+		if (end.isBefore(start)) {
+			throw new IllegalArgumentException("end must be greater than or equal to start");
+		}
+		this.worksiteService.findWorksiteByCode(worksiteCode);
+		final long employeesWhoClockedIn = this.employeeService.countDistinctEmployeesWithTimeLogsInRange(worksiteCode,
+				start, end);
+		final long erroneousTimeLogs = this.employeeService.countOpenTimeLogsInRange(worksiteCode, start, end);
+		final long totalTimeLogs = this.employeeService.countTimeLogsInRange(worksiteCode, start, end);
+		final long employeesAllowedToClockIn = this.employeeService.countEmployeesAssignedToWorksite(worksiteCode);
+		final long distinctSchedules = this.employeeService.countDistinctSchedulesInRange(worksiteCode, start, end);
+		return ResponseEntity.ok(new WorksiteStatsResponse(worksiteCode, start, end, employeesWhoClockedIn,
+				erroneousTimeLogs, totalTimeLogs, employeesAllowedToClockIn, distinctSchedules));
 	}
 
 	/**

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteController.java
@@ -144,10 +144,23 @@ public class WorksiteController {
 	public ResponseEntity<WorksiteStatsResponse> stats(
 			@PathVariable("worksiteCode") @Pattern(regexp = "[A-Za-z0-9_-]{1,50}", message = "code must contain only letters, digits, underscores or hyphens (max 50)") final String worksiteCode,
 			@RequestParam("start") final Instant start,
-			@RequestParam("end") final Instant end) {
+			@RequestParam("end") final Instant end,
+			final Authentication authentication) {
 		if (end.isBefore(start)) {
 			throw new IllegalArgumentException("end must be greater than or equal to start");
 		}
+
+		final String authenticatedEmail = authentication.getName();
+		final boolean hasOnlyEmployeeRole = Roles.hasOnlyEmployeeRole(authentication.getAuthorities());
+		if (hasOnlyEmployeeRole) {
+			if (authenticatedEmail == null || authenticatedEmail.isBlank()) {
+				throw new AccessDeniedException("Employee email claim is required");
+			}
+			if (!this.employeeService.isAssignedToWorksite(authenticatedEmail, worksiteCode)) {
+				throw new AccessDeniedException("Employees can only view stats for their assigned worksites");
+			}
+		}
+
 		this.worksiteService.findWorksiteByCode(worksiteCode);
 		final long employeesWhoClockedIn = this.employeeService.countDistinctEmployeesWithTimeLogsInRange(worksiteCode,
 				start, end);

--- a/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteStatsResponse.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/api/v1/worksite/WorksiteStatsResponse.java
@@ -1,0 +1,8 @@
+package es.nivel36.janus.api.v1.worksite;
+
+import java.time.Instant;
+
+public record WorksiteStatsResponse(String worksiteCode, Instant startInclusive, Instant endInclusive,
+		long employeesWhoClockedIn, long erroneousTimeLogs, long totalTimeLogs, long employeesAllowedToClockIn,
+		long distinctSchedulesFromEmployeesWhoClockedIn) {
+}

--- a/apps/backend/src/main/java/es/nivel36/janus/service/employee/EmployeeRepository.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/employee/EmployeeRepository.java
@@ -34,6 +34,51 @@ import es.nivel36.janus.service.workshift.WorkShift;
 @Repository
 interface EmployeeRepository extends CrudRepository<Employee, Long> {
 
+	@Query("""
+			SELECT COUNT(DISTINCT e.id)
+			FROM Employee e
+			JOIN e.worksites w
+			WHERE w.code = :worksiteCode
+			""")
+	long countByWorksiteCode(String worksiteCode);
+
+	@Query("""
+			SELECT COUNT(DISTINCT t.employee.id)
+			FROM TimeLog t
+			WHERE t.worksite.code = :worksiteCode
+			AND t.entryTime >= :startInclusive
+			AND t.entryTime <= :endInclusive
+			""")
+	long countDistinctEmployeesWithTimeLogsInRange(String worksiteCode, Instant startInclusive, Instant endInclusive);
+
+	@Query("""
+			SELECT COUNT(t.id)
+			FROM TimeLog t
+			WHERE t.worksite.code = :worksiteCode
+			AND t.entryTime >= :startInclusive
+			AND t.entryTime <= :endInclusive
+			""")
+	long countTimeLogsInRange(String worksiteCode, Instant startInclusive, Instant endInclusive);
+
+	@Query("""
+			SELECT COUNT(t.id)
+			FROM TimeLog t
+			WHERE t.worksite.code = :worksiteCode
+			AND t.entryTime >= :startInclusive
+			AND t.entryTime <= :endInclusive
+			AND t.exitTime IS NULL
+			""")
+	long countOpenTimeLogsInRange(String worksiteCode, Instant startInclusive, Instant endInclusive);
+
+	@Query("""
+			SELECT COUNT(DISTINCT t.employee.schedule.id)
+			FROM TimeLog t
+			WHERE t.worksite.code = :worksiteCode
+			AND t.entryTime >= :startInclusive
+			AND t.entryTime <= :endInclusive
+			""")
+	long countDistinctSchedulesInRange(String worksiteCode, Instant startInclusive, Instant endInclusive);
+
 	/**
 	 * Checks whether a {@link Employee} exists for the specified email.
 	 *

--- a/apps/backend/src/main/java/es/nivel36/janus/service/employee/EmployeeService.java
+++ b/apps/backend/src/main/java/es/nivel36/janus/service/employee/EmployeeService.java
@@ -310,4 +310,47 @@ public class EmployeeService {
 		logger.debug("Checking if the employee {} is assigned to schedule {}", employeeEmail, worksiteCode);
 		return this.employeeRepository.existsByEmailAndWorksites_Code(employeeEmail, worksiteCode);
 	}
+
+	@Transactional(readOnly = true)
+	public long countEmployeesAssignedToWorksite(final String worksiteCode) {
+		Strings.requireNonBlank(worksiteCode, "worksiteCode cannot be null or blank.");
+		return this.employeeRepository.countByWorksiteCode(worksiteCode);
+	}
+
+	@Transactional(readOnly = true)
+	public long countDistinctEmployeesWithTimeLogsInRange(final String worksiteCode, final Instant startInclusive,
+			final Instant endInclusive) {
+		Strings.requireNonBlank(worksiteCode, "worksiteCode cannot be null or blank.");
+		Objects.requireNonNull(startInclusive, "startInclusive cannot be null.");
+		Objects.requireNonNull(endInclusive, "endInclusive cannot be null.");
+		return this.employeeRepository.countDistinctEmployeesWithTimeLogsInRange(worksiteCode, startInclusive,
+				endInclusive);
+	}
+
+	@Transactional(readOnly = true)
+	public long countTimeLogsInRange(final String worksiteCode, final Instant startInclusive,
+			final Instant endInclusive) {
+		Strings.requireNonBlank(worksiteCode, "worksiteCode cannot be null or blank.");
+		Objects.requireNonNull(startInclusive, "startInclusive cannot be null.");
+		Objects.requireNonNull(endInclusive, "endInclusive cannot be null.");
+		return this.employeeRepository.countTimeLogsInRange(worksiteCode, startInclusive, endInclusive);
+	}
+
+	@Transactional(readOnly = true)
+	public long countOpenTimeLogsInRange(final String worksiteCode, final Instant startInclusive,
+			final Instant endInclusive) {
+		Strings.requireNonBlank(worksiteCode, "worksiteCode cannot be null or blank.");
+		Objects.requireNonNull(startInclusive, "startInclusive cannot be null.");
+		Objects.requireNonNull(endInclusive, "endInclusive cannot be null.");
+		return this.employeeRepository.countOpenTimeLogsInRange(worksiteCode, startInclusive, endInclusive);
+	}
+
+	@Transactional(readOnly = true)
+	public long countDistinctSchedulesInRange(final String worksiteCode, final Instant startInclusive,
+			final Instant endInclusive) {
+		Strings.requireNonBlank(worksiteCode, "worksiteCode cannot be null or blank.");
+		Objects.requireNonNull(startInclusive, "startInclusive cannot be null.");
+		Objects.requireNonNull(endInclusive, "endInclusive cannot be null.");
+		return this.employeeRepository.countDistinctSchedulesInRange(worksiteCode, startInclusive, endInclusive);
+	}
 }


### PR DESCRIPTION
## Summary
- Added a new endpoint `GET /api/v1/worksites/{worksiteCode}/stats`.
- Endpoint accepts `start` and `end` query params (ISO-8601 instants) to define the period.
- Returns aggregated metrics for the selected worksite and date range.

## Metrics included
- `employeesWhoClockedIn`: distinct people with timelogs in range.
- `erroneousTimeLogs`: timelogs considered erroneous (open entries with `exitTime IS NULL`) in range.
- `totalTimeLogs`: total timelog count in range.
- `employeesAllowedToClockIn`: total employees assigned to the worksite.
- `distinctSchedulesFromEmployeesWhoClockedIn`: distinct schedules among employees who logged in range.

## Implementation details
- New response DTO: `WorksiteStatsResponse`.
- New repository aggregate queries in `EmployeeRepository`.
- New service methods in `EmployeeService` to expose those aggregates.
- Controller validates period (`end >= start`) and verifies worksite exists before computing stats.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078d2e45f0832788a6f7122a3ec172)