### PR TITLE
Restrict action buttons to admin role

### DIFF
--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.html
@@ -33,15 +33,17 @@
                 <span aria-hidden="true"><fa-icon [icon]="faCalendarDays"></fa-icon></span>
             </button>
 
-            <button
-                type="button"
-                class="main-menu__icon-button main-menu__icon-button--settings"
-                [attr.aria-label]="'navigation.applicationSettings' | translate"
-                [attr.title]="'navigation.applicationSettings' | translate"
-                (click)="goToApplicationSettings()"
-            >
-                <span aria-hidden="true"><fa-icon [icon]="faGear"></fa-icon></span>
-            </button>
+            @if (user.isAdmin) {
+                <button
+                    type="button"
+                    class="main-menu__icon-button main-menu__icon-button--settings"
+                    [attr.aria-label]="'navigation.applicationSettings' | translate"
+                    [attr.title]="'navigation.applicationSettings' | translate"
+                    (click)="goToApplicationSettings()"
+                >
+                    <span aria-hidden="true"><fa-icon [icon]="faGear"></fa-icon></span>
+                </button>
+            }
 
             <button
                 type="button"

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.html
@@ -95,9 +95,15 @@
                         <app-button type="button" variant="secondary" (clicked)="goBack()">
                             {{ 'actions.cancel' | translate }}
                         </app-button>
-                        <app-button type="button" variant="main" (clicked)="editWorksite(worksite)">
-                            {{ 'actions.edit' | translate }}
-                        </app-button>
+                        @if (isAdmin | async) {
+                            <app-button
+                                type="button"
+                                variant="main"
+                                (clicked)="editWorksite(worksite)"
+                            >
+                                {{ 'actions.edit' | translate }}
+                            </app-button>
+                        }
                     </div>
                 </ng-template>
 

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.ts
@@ -24,6 +24,7 @@ import { TabsComponent } from '../../../shared/ui/tabs/tabs.component';
 import { SummaryCardComponent } from '../../../shared/ui/summary-card/summary-card.component';
 import { ChipComponent } from '../../../shared/ui/chip/chip.component';
 import { WorksiteHeroComponent } from '../components/worksite-hero/worksite-hero.component';
+import { CurrentUserFacade } from '../../../core/user/services/current-user.facade';
 
 @Component({
   selector: 'app-worksite-detail-page',
@@ -47,6 +48,7 @@ export class WorksiteDetailPageComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly worksiteApiService = inject(WorksiteApiService);
+  private readonly currentUser = inject(CurrentUserFacade);
 
   protected readonly worksiteCode = toSignal(
     this.route.paramMap.pipe(map((params) => params.get('code') ?? '')),
@@ -60,6 +62,7 @@ export class WorksiteDetailPageComponent {
   });
 
   protected readonly worksite = computed(() => this.worksiteResource.value());
+  protected readonly isAdmin = this.currentUser.isAdmin$;
 
   protected readonly faCalendarDays = faCalendarDays;
   protected readonly faClock = faClock;

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.ts
@@ -1,6 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
+import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { rxResource, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -34,6 +35,7 @@ import { CurrentUserFacade } from '../../../core/user/services/current-user.faca
     CardComponent,
     PageTemplateComponent,
     TranslatePipe,
+    AsyncPipe,
     TabsComponent,
     TabItemDirective,
     SummaryCardComponent,

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
@@ -2,9 +2,11 @@
   <section page-body class="worksites-content">
     <div class="worksites-toolbar">
       <app-search-bar (queryChange)="onQueryChange($event)" />
-      <app-button variant="main" (clicked)="createWorksite()">
-        {{ 'actions.new' | translate }}
-      </app-button>
+      @if (isAdmin | async) {
+        <app-button variant="main" (clicked)="createWorksite()">
+          {{ 'actions.new' | translate }}
+        </app-button>
+      }
     </div>
     <app-worksite-table [query]="searchQuery()" />
   </section>

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
@@ -1,6 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
+import { AsyncPipe } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -19,6 +20,7 @@ import { CurrentUserFacade } from '../../../core/user/services/current-user.faca
     SearchBarComponent,
     ButtonComponent,
     TranslatePipe,
+    AsyncPipe,
   ],
   templateUrl: './worksites-page.component.html',
   styleUrl: './worksites-page.component.css',

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.ts
@@ -8,6 +8,7 @@ import { PageTemplateComponent } from '../../../core/layout/page-template/page-t
 import { WorksiteTableComponent } from '../components/worksite-table/worksite-table.component';
 import { SearchBarComponent } from '../../../shared/ui/search-bar/search-bar.component';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
+import { CurrentUserFacade } from '../../../core/user/services/current-user.facade';
 
 @Component({
   selector: 'app-worksites-page',
@@ -24,8 +25,10 @@ import { ButtonComponent } from '../../../shared/ui/button/button.component';
 })
 export class WorksitesPageComponent {
   private readonly router = inject(Router);
+  private readonly currentUser = inject(CurrentUserFacade);
 
   protected readonly searchQuery = signal('');
+  protected readonly isAdmin = this.currentUser.isAdmin$;
 
   protected onQueryChange(query: string): void {
     this.searchQuery.set(query);


### PR DESCRIPTION
### Motivation
- Ensure action buttons that modify data are only visible to users with the admin role to prevent unauthorized UI actions.
- Use the existing `CurrentUserFacade.isAdmin$` observable to drive template-level visibility for role-based UI elements.

### Description
- Inject `CurrentUserFacade` and expose `isAdmin` observables in `WorksitesPageComponent` and `WorksiteDetailPageComponent` to evaluate admin privileges at the component level.
- Wrap the **New Worksite** button in `apps/frontend/src/app/features/worksites/pages/worksites-page.component.html` with `@if (isAdmin | async)` so it is shown only to admins.
- Wrap the **Edit Worksite** button in `apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.html` with `@if (isAdmin | async)` so it is shown only to admins.
- Update `apps/frontend/src/app/core/layout/main-menu/main-menu.component.html` to render the Application Settings icon only when `user.isAdmin` is truthy.

### Testing
- Ran frontend linter with `cd apps/frontend && npm run -s lint` to detect regressions, and the command completed but reported failures due to unrelated pre-existing lint issues in other files (lint did not pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0794ff029083279734f221baec3fa1)