### PR TITLE
Add CSS custom-property validator and fix undefined CSS variable usages in frontend

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,0 +1,12 @@
+# Frontend
+
+## Linting
+
+Run the Angular lint and the CSS custom-property validation together before submitting frontend changes:
+
+```sh
+npm run lint
+npm run lint:styles
+```
+
+`npm run lint:styles` scans every `*.css` file under `src/`, compares custom properties defined as `--name:` with usages written as `var(--name)`, and fails when a usage has no matching definition.

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "lint": "ng lint"
+    "lint": "ng lint",
+    "lint:styles": "node scripts/validate-css-vars.mjs"
   },
   "prettier": {
     "printWidth": 100,

--- a/apps/frontend/scripts/validate-css-vars.mjs
+++ b/apps/frontend/scripts/validate-css-vars.mjs
@@ -1,0 +1,58 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const srcDir = join(process.cwd(), 'src');
+const definitionPattern = /--([A-Za-z0-9_-]+)\s*:/g;
+const usagePattern = /var\(\s*--([A-Za-z0-9_-]+)\b/g;
+
+async function collectCssFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return collectCssFiles(entryPath);
+      }
+
+      return entry.isFile() && entry.name.endsWith('.css') ? [entryPath] : [];
+    }),
+  );
+
+  return files.flat();
+}
+
+function extractMatches(pattern, content) {
+  return [...content.matchAll(pattern)].map((match) => match[1]);
+}
+
+const cssFiles = await collectCssFiles(srcDir);
+const definitions = new Set();
+const usages = [];
+
+for (const file of cssFiles) {
+  const content = await readFile(file, 'utf8');
+
+  for (const name of extractMatches(definitionPattern, content)) {
+    definitions.add(name);
+  }
+
+  for (const match of content.matchAll(usagePattern)) {
+    const line = content.slice(0, match.index).split('\n').length;
+    usages.push({ name: match[1], file, line });
+  }
+}
+
+const missingUsages = usages.filter(({ name }) => !definitions.has(name));
+
+if (missingUsages.length > 0) {
+  console.error('Undefined CSS custom properties found:');
+
+  for (const { name, file, line } of missingUsages) {
+    console.error(`- --${name} used in ${relative(process.cwd(), file)}:${line}`);
+  }
+
+  process.exit(1);
+}
+
+console.log(`Validated ${cssFiles.length} CSS files. All CSS custom properties are defined.`);

--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
@@ -10,7 +10,7 @@
     border-radius: var(--panel-medium-border-radius);
     border: var(--panel-border);
     background: var(--panel-background-color);
-    box-shadow: var(--panel-box-shadow);
+    box-shadow: var(--panel-shadow);
 }
 
 .identity,
@@ -41,7 +41,7 @@
     display: flex;
     align-items: center;
     color: var(--accent-strong-color);
-    font-size: var(--text-body-font-size);
+    font-size: var(--text-body-size);
     font-weight: 600;
     letter-spacing: 0.04em;
     white-space: nowrap;
@@ -57,7 +57,7 @@
     align-items: center;
     justify-content: center;
     color: var(--text-secondary-color);
-    font-size: var(--text-large-font-size);
+    font-size: var(--text-large-size);
     background: transparent;
     border-left: var(--panel-border);
     font-weight: 600;

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
@@ -5,5 +5,5 @@
 .timezone-control {
     display: flex;
     flex-direction: column;
-    gap: var(--label-gap);
+    gap: var(--form-label-gap);
 }

--- a/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
+++ b/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
@@ -19,7 +19,7 @@
 
 .data {
     display: flex;
-    border-top: var(--surface-border);
+    border-top: var(--panel-border);
     padding-block: var(--section-padding-block);
     justify-content: space-between;
 }

--- a/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.css
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.css
@@ -22,7 +22,7 @@
 
 .secondary-action {
     color: var(--text-secondary-color);
-    font-size: var(--text-small-font-size);
+    font-size: var(--text-small-size);
     cursor: pointer;
     background: transparent;
     border: 0px;

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
@@ -33,13 +33,13 @@
 
 .paginator-button:not(:disabled):focus-visible {
     color: var(--accent-hover-color);
-    outline: 2px solid var(--color-focus-ring);
+    outline: 2px solid var(--focus-ring-color);
     outline-offset: 2px;
 }
 
 .paginator-text {
     color: var(--text-secondary-color);
-    font-size: var(--text-small-font-size);
+    font-size: var(--text-small-size);
     letter-spacing: 0.04em;
     font-weight: 600;
 }

--- a/apps/frontend/src/styles/01-semantics.css
+++ b/apps/frontend/src/styles/01-semantics.css
@@ -63,6 +63,7 @@
     --control-accent-pressed-background-color: var(--accent-active-color);
     --control-accent-disabled-background-color: var(--accent-muted-color);
     --control-accent-text-color: var(--color-black);
+    --control-accent-disabled-text-color: var(--color-gray-800);
     --control-accent-glow:
         inset 0 1px 0 rgba(255, 255, 255, 0.42), 0 0.5rem 1rem rgba(255, 212, 0, 0.13);
     --control-accent-pressed-glow:

--- a/apps/frontend/src/styles/button.css
+++ b/apps/frontend/src/styles/button.css
@@ -8,11 +8,13 @@
     --button-font-size: var(--text-body-size);
     --button-font-weight: 600;
     --button-height: var(--size-800);
+    --button-size: var(--button-height);
     --button-border: 0;
 
     --button-icon-padding: 0;
     --button-icon-min-width: 0;
     --button-icon-font-size: var(--text-large-size);
+    --button-icon-border-radius: var(--button-border-radius);
 
     --button-primary-background-color: var(--control-accent-background-color);
     --button-primary-hover-background-color: var(--control-accent-hover-background-color);

--- a/apps/frontend/src/styles/table-section.css
+++ b/apps/frontend/src/styles/table-section.css
@@ -24,7 +24,7 @@
     border-radius: var(--panel-border-radius);
     border: var(--panel-border);
     border-collapse: separate;
-    box-shadow: var(--panel-box-shadow);
+    box-shadow: var(--panel-shadow);
     overflow: hidden;
 }
 
@@ -55,7 +55,7 @@
     text-align: left;
     text-transform: uppercase;
     letter-spacing: 0.12em;
-    font-size: var(--text-small-font-size);
+    font-size: var(--text-small-size);
     font-weight: 600;
 }
 


### PR DESCRIPTION
### Motivation

- Ensure all CSS custom properties used in the frontend are actually defined to avoid runtime style regressions.
- Provide an automated check that can be run as part of local linting/workflows to catch missing tokens early.

### Description

- Add a Node-based validator `apps/frontend/scripts/validate-css-vars.mjs` that recursively scans `src/` for `--name:` definitions and `var(--name)` usages and fails when usages are undefined.
- Expose the validator as an npm script `lint:styles` in `apps/frontend/package.json` and document running it alongside `npm run lint` in `apps/frontend/README.md`.
- Replace undefined/incorrect CSS custom-property usages with existing tokens in multiple files, notably `main-menu.component.css`, `table-section.css`, `paginator.component.css`, `employee-card.component.css`, `application-settings-page.component.css`, and `timelog-clock-card.component.css`.
- Define missing button-related tokens in `apps/frontend/src/styles/button.css` and add the missing `--control-accent-disabled-text-color` in `apps/frontend/src/styles/01-semantics.css` so button styles resolve correctly.

### Testing

- Ran `cd apps/frontend && npm run lint:styles` which validated 46 CSS files and exited successfully with no undefined custom properties.
- Ran `cd apps/frontend && npm run lint` which executed `ng lint` and failed with existing TypeScript lint errors unrelated to the style changes (5 errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305cefb2248327a5290f1631af1588)