### PR TITLE
Refactorizar valores CSS hardcode en tokens semánticos

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
@@ -59,14 +59,14 @@
     align-items: center;
     justify-content: center;
 
-    padding: 0 0.66rem;
+    padding: 0 var(--autocomplete-clear-button-padding-inline);
     border: 0;
     border-left: var(--form-control-border);
 
     background: var(--form-control-text-accent-color);
     color: var(--form-control-background-color);
 
-    font-size: 1.66rem;
+    font-size: var(--autocomplete-clear-button-font-size);
     line-height: 1;
 
     cursor: pointer;
@@ -82,8 +82,8 @@
 }
 
 .clear-button:focus-visible {
-    outline: 2px solid var(--form-control-background-color);
-    outline-offset: -2px;
+    outline: var(--autocomplete-clear-button-focus-outline);
+    outline-offset: var(--autocomplete-clear-button-focus-outline-offset);
 }
 
 .clear-button:disabled {
@@ -92,18 +92,18 @@
 }
 
 .results-panel {
-    max-width: min(30rem, calc(100vw - 2rem));
+    max-width: var(--autocomplete-results-max-width);
 }
 
 .results {
     width: max-content;
     min-width: 100%;
-    max-height: 14rem;
+    max-height: var(--autocomplete-results-max-height);
     overflow-y: auto;
     box-sizing: border-box;
 
     margin: 0;
-    padding: 0.25rem 0;
+    padding: var(--autocomplete-results-padding-block) var(--autocomplete-results-padding-inline);
 
     list-style: none;
 
@@ -113,11 +113,11 @@
     background: var(--list-background-color);
     color: var(--form-control-text-color);
 
-    box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+    box-shadow: var(--autocomplete-results-shadow);
 }
 
 .results li {
-    padding: 0.5rem 0.75rem;
+    padding: var(--autocomplete-result-padding-block) var(--autocomplete-result-padding-inline);
 
     white-space: nowrap;
     text-align: left;

--- a/apps/frontend/src/app/shared/ui/chip/chip.component.css
+++ b/apps/frontend/src/app/shared/ui/chip/chip.component.css
@@ -3,26 +3,26 @@
 }
 
 .app-chip {
-    --bg: #f9d600;
-    --fg: #131313;
-    --chip-padding-block: 0.4rem;
-    --chip-padding-inline: 0.75rem;
-    --chip-font-size: 0.8rem;
-    --chip-icon-size: 0.8rem;
-    --chip-gap: 0.35rem;
+    --_chip-background-color: var(--chip-background-color);
+    --_chip-text-color: var(--chip-text-color);
+    --_chip-padding-block: var(--chip-padding-block);
+    --_chip-padding-inline: var(--chip-padding-inline);
+    --_chip-font-size: var(--chip-font-size);
+    --_chip-icon-size: var(--chip-icon-size);
+    --_chip-gap: var(--chip-gap);
 
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: var(--chip-gap);
+    gap: var(--_chip-gap);
 
-    padding: var(--chip-padding-block) var(--chip-padding-inline);
-    border-radius: 0.35rem;
+    padding: var(--_chip-padding-block) var(--_chip-padding-inline);
+    border-radius: var(--chip-border-radius);
 
-    background-color: var(--bg);
-    color: var(--fg);
+    background-color: var(--_chip-background-color);
+    color: var(--_chip-text-color);
 
-    font-size: var(--chip-font-size);
+    font-size: var(--_chip-font-size);
     font-weight: 600;
     line-height: 1;
     text-transform: uppercase;
@@ -33,7 +33,7 @@
     align-items: center;
     justify-content: center;
 
-    font-size: var(--chip-icon-size);
+    font-size: var(--_chip-icon-size);
     line-height: 1;
 }
 
@@ -42,42 +42,42 @@
 }
 
 .chip--size-small {
-    --chip-padding-block: 0.25rem;
-    --chip-padding-inline: 0.5rem;
-    --chip-font-size: 0.7rem;
-    --chip-icon-size: 0.7rem;
-    --chip-gap: 0.25rem;
+    --_chip-padding-block: var(--chip-small-padding-block);
+    --_chip-padding-inline: var(--chip-small-padding-inline);
+    --_chip-font-size: var(--chip-small-font-size);
+    --_chip-icon-size: var(--chip-small-icon-size);
+    --_chip-gap: var(--chip-small-gap);
 }
 
 .chip--size-big {
-    --chip-padding-block: 0.55rem;
-    --chip-padding-inline: 1rem;
-    --chip-font-size: 0.95rem;
-    --chip-icon-size: 0.95rem;
-    --chip-gap: 0.45rem;
+    --_chip-padding-block: var(--chip-big-padding-block);
+    --_chip-padding-inline: var(--chip-big-padding-inline);
+    --_chip-font-size: var(--chip-big-font-size);
+    --_chip-icon-size: var(--chip-big-icon-size);
+    --_chip-gap: var(--chip-big-gap);
 }
 
 .chip--primary {
-    --bg: #7f06a5;
-    --fg: #ffffff;
+    --_chip-background-color: var(--chip-primary-background-color);
+    --_chip-text-color: var(--chip-primary-text-color);
 }
 
 .chip--secondary {
-    --bg: #1431a9;
-    --fg: #ffffff;
+    --_chip-background-color: var(--chip-secondary-background-color);
+    --_chip-text-color: var(--chip-secondary-text-color);
 }
 
 .chip--tertiary {
-    --bg: #615300;
-    --fg: #ffffff;
+    --_chip-background-color: var(--chip-tertiary-background-color);
+    --_chip-text-color: var(--chip-tertiary-text-color);
 }
 
 .chip--green {
-    --bg: rgba(104, 135, 72, 0.16);
-    --fg: #3baa37;
+    --_chip-background-color: var(--chip-success-background-color);
+    --_chip-text-color: var(--chip-success-text-color);
 }
 
 .chip--red {
-    --bg: rgba(187, 53, 53, 0.16);
-    --fg: #d24444;
+    --_chip-background-color: var(--chip-error-background-color);
+    --_chip-text-color: var(--chip-error-text-color);
 }

--- a/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.css
+++ b/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.css
@@ -1,14 +1,5 @@
 :host {
     display: block;
-
-    --bg: #050505;
-    --fg: #f9f9f9;
-    --muted-fg: #b3b3b3;
-    --accent: #fece0b;
-    --border-muted: #2f2f2f;
-
-    --radius: 0.5rem;
-    --focus-ring: 0 0 0 2px rgba(249, 214, 0, 0.3);
 }
 
 .search-bar {
@@ -20,34 +11,34 @@
     width: 100%;
     overflow: hidden;
 
-    border: 1px solid var(--accent);
-    border-radius: var(--radius);
+    border: var(--search-bar-border);
+    border-radius: var(--search-bar-border-radius);
 
-    background: var(--bg);
+    background: var(--search-bar-background-color);
 
     transition: box-shadow 0.2s ease;
 }
 
 .search-bar:focus-within {
-    box-shadow: var(--focus-ring);
+    box-shadow: var(--search-bar-focus-ring);
 }
 
 .search-bar input {
     flex: 1 1 auto;
     min-width: 0;
 
-    padding: 0.625rem 0.75rem;
+    padding: var(--search-bar-padding-block) var(--search-bar-padding-inline);
     border: 0;
     outline: 0;
 
     background: transparent;
-    color: var(--fg);
+    color: var(--search-bar-text-color);
 
-    font-size: 0.95rem;
+    font-size: var(--search-bar-font-size);
 }
 
 .search-bar input::placeholder {
-    color: var(--muted-fg);
+    color: var(--search-bar-placeholder-color);
 }
 
 .search-icon {

--- a/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
+++ b/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
@@ -5,32 +5,32 @@
 .summary-card {
     display: flex;
     flex-direction: column;
-    padding: 1.25rem 1.45rem;
-    border-radius: 22px;
-    background: rgba(255, 255, 255, 0.06);
+    padding: var(--summary-card-padding-block) var(--summary-card-padding-inline);
+    border-radius: var(--summary-card-border-radius);
+    background: var(--summary-card-background-color);
 }
 
 .summary-card__icon {
-    width: 3.7rem;
+    width: var(--summary-card-icon-size);
     aspect-ratio: 1;
     display: grid;
     place-items: center;
-    margin-bottom: 1.3rem;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.08);
-    color: #fece0b;
-    font-size: 1.75rem;
+    margin-bottom: var(--summary-card-icon-margin-bottom);
+    border-radius: var(--summary-card-icon-border-radius);
+    background: var(--summary-card-icon-background-color);
+    color: var(--summary-card-icon-color);
+    font-size: var(--summary-card-icon-font-size);
 }
 
 .summary-card__label {
-    color: rgba(249, 249, 249, 0.72);
+    color: var(--summary-card-label-color);
     font-weight: 600;
-    letter-spacing: 0.13em;
+    letter-spacing: var(--summary-card-label-letter-spacing);
     text-transform: uppercase;
 }
 
 .summary-card__value {
-    margin-top: 0.8rem;
-    color: #ffffff;
-    font-size: 2rem;
+    margin-top: var(--summary-card-value-margin-top);
+    color: var(--summary-card-value-color);
+    font-size: var(--summary-card-value-font-size);
 }

--- a/apps/frontend/src/styles/02-semantics.layout.css
+++ b/apps/frontend/src/styles/02-semantics.layout.css
@@ -35,4 +35,44 @@
     --panel-medium-padding-inline: var(--section-medium-padding-inline);
     --panel-medium-gap: var(--section-medium-gap);
     --panel-medium-border-radius: var(--section-medium-border-radius);
+
+    --summary-card-padding-block: var(--font-size-350);
+    --summary-card-padding-inline: 1.45rem;
+    --summary-card-border-radius: 22px;
+    --summary-card-background-color: rgba(255, 255, 255, 0.06);
+    --summary-card-icon-size: 3.7rem;
+    --summary-card-icon-margin-bottom: 1.3rem;
+    --summary-card-icon-border-radius: 50%;
+    --summary-card-icon-background-color: rgba(255, 255, 255, 0.08);
+    --summary-card-icon-color: var(--accent-color);
+    --summary-card-icon-font-size: 1.75rem;
+    --summary-card-label-color: rgba(249, 249, 249, 0.72);
+    --summary-card-label-letter-spacing: 0.13em;
+    --summary-card-value-margin-top: 0.8rem;
+    --summary-card-value-color: var(--color-white);
+    --summary-card-value-font-size: var(--text-big-size);
+
+    --table-section-gap: var(--section-medium-gap);
+    --table-section-title-font-size: var(--h2-font-size);
+    --table-section-title-color: var(--accent-color);
+    --table-section-table-background-color: var(--panel-background-color);
+    --table-section-table-border-radius: var(--panel-border-radius);
+    --table-section-table-border: var(--panel-border);
+    --table-section-table-shadow: var(--panel-shadow);
+    --table-section-header-cell-padding-inline: var(--panel-padding-inline);
+    --table-section-header-cell-padding-block: var(--panel-padding-block);
+    --table-section-header-cell-letter-spacing: 0.12em;
+    --table-section-header-cell-font-size: var(--text-small-size);
+    --table-section-body-cell-padding-inline: var(--panel-padding-inline);
+    --table-section-body-cell-padding-block: var(--panel-medium-padding-block);
+    --table-section-row-odd-background-color: var(--list-background-color-odd);
+    --table-section-row-even-background-color: var(--list-background-color);
+    --table-section-row-hover-background-color: var(--list-element-hover-background-color);
+    --table-section-message-padding-block: var(--size-400);
+    --table-section-message-padding-inline: var(--size-500);
+    --table-section-message-border-radius: var(--radius-300);
+    --table-section-message-background-color: var(--summary-card-background-color);
+    --table-section-message-text-color: var(--text-primary-color);
+    --table-section-compact-cell-padding-block: 0.75rem;
+    --table-section-compact-cell-padding-inline: var(--size-400);
 }

--- a/apps/frontend/src/styles/03-semantics.forms.css
+++ b/apps/frontend/src/styles/03-semantics.forms.css
@@ -77,5 +77,31 @@
     --form-switch-checked-knob-background-color: var(--color-gray-800);
     --form-switch-knob-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.35);
 
+
+    --search-bar-background-color: var(--form-control-background-color);
+    --search-bar-text-color: var(--form-control-text-color);
+    --search-bar-placeholder-color: var(--text-secondary-color);
+    --search-bar-accent-color: var(--accent-color);
+    --search-bar-border-width: var(--border-width-thin);
+    --search-bar-border-style: var(--border-style);
+    --search-bar-border: var(--search-bar-border-width) var(--search-bar-border-style) var(--search-bar-accent-color);
+    --search-bar-border-radius: var(--form-control-border-radius);
+    --search-bar-focus-ring: 0 0 0 var(--focus-ring-width) rgba(249, 214, 0, 0.3);
+    --search-bar-padding-block: 0.625rem;
+    --search-bar-padding-inline: 0.75rem;
+    --search-bar-font-size: 0.95rem;
+
+    --autocomplete-clear-button-padding-inline: 0.66rem;
+    --autocomplete-clear-button-font-size: 1.66rem;
+    --autocomplete-clear-button-focus-outline: var(--focus-ring-width) var(--border-style) var(--form-control-background-color);
+    --autocomplete-clear-button-focus-outline-offset: calc(var(--focus-ring-width) * -1);
+    --autocomplete-results-max-width: min(30rem, calc(100vw - var(--size-600)));
+    --autocomplete-results-max-height: 14rem;
+    --autocomplete-results-padding-block: var(--size-100);
+    --autocomplete-results-padding-inline: 0;
+    --autocomplete-results-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+    --autocomplete-result-padding-block: var(--size-200);
+    --autocomplete-result-padding-inline: 0.75rem;
+
     /* form-actions      → buttons */
 }

--- a/apps/frontend/src/styles/04-semantics.controls.css
+++ b/apps/frontend/src/styles/04-semantics.controls.css
@@ -23,4 +23,33 @@
         inset 0 1px 0 rgba(255, 255, 255, 0.42), 0 0.5rem 1rem rgba(255, 212, 0, 0.13);
     --control-accent-hover-glow:
         inset 0 1px 0 rgba(255, 255, 255, 0.48), 0 0.5rem 1rem rgba(255, 212, 0, 0.18);
+
+    --chip-background-color: #f9d600;
+    --chip-text-color: #131313;
+    --chip-padding-block: 0.4rem;
+    --chip-padding-inline: 0.75rem;
+    --chip-border-radius: 0.35rem;
+    --chip-font-size: 0.8rem;
+    --chip-icon-size: var(--chip-font-size);
+    --chip-gap: 0.35rem;
+    --chip-small-padding-block: var(--size-100);
+    --chip-small-padding-inline: var(--size-200);
+    --chip-small-font-size: 0.7rem;
+    --chip-small-icon-size: var(--chip-small-font-size);
+    --chip-small-gap: var(--size-100);
+    --chip-big-padding-block: 0.55rem;
+    --chip-big-padding-inline: var(--size-400);
+    --chip-big-font-size: 0.95rem;
+    --chip-big-icon-size: var(--chip-big-font-size);
+    --chip-big-gap: 0.45rem;
+    --chip-primary-background-color: #7f06a5;
+    --chip-primary-text-color: var(--color-white);
+    --chip-secondary-background-color: #1431a9;
+    --chip-secondary-text-color: var(--color-white);
+    --chip-tertiary-background-color: #615300;
+    --chip-tertiary-text-color: var(--color-white);
+    --chip-success-background-color: rgba(104, 135, 72, 0.16);
+    --chip-success-text-color: #3baa37;
+    --chip-error-background-color: rgba(187, 53, 53, 0.16);
+    --chip-error-text-color: #d24444;
 }

--- a/apps/frontend/src/styles/table-section.css
+++ b/apps/frontend/src/styles/table-section.css
@@ -1,7 +1,7 @@
 .table-section {
     display: flex;
     flex-direction: column;
-    gap: var(--section-medium-gap);
+    gap: var(--table-section-gap);
 }
 
 .table-section-header {
@@ -11,25 +11,25 @@
 }
 
 .table-section-title {
-    font-size: var(--h2-font-size);
+    font-size: var(--table-section-title-font-size);
     margin: 0;
     text-transform: uppercase;
-    color: var(--accent-color);
+    color: var(--table-section-title-color);
     font-weight: 600;
 }
 
 .table-section .table {
     width: 100%;
-    background-color: var(--panel-background-color);
-    border-radius: var(--panel-border-radius);
-    border: var(--panel-border);
+    background-color: var(--table-section-table-background-color);
+    border-radius: var(--table-section-table-border-radius);
+    border: var(--table-section-table-border);
     border-collapse: separate;
-    box-shadow: var(--panel-shadow);
+    box-shadow: var(--table-section-table-shadow);
     overflow: hidden;
 }
 
 .table-section .table thead {
-    background-color: var(--panel-background-color);
+    background-color: var(--table-section-table-background-color);
 }
 
 .table-section .table tbody tr td {
@@ -37,52 +37,52 @@
 }
 
 .table-section .table tbody tr:first-child td {
-    border-top: var(--panel-border);
+    border-top: var(--table-section-table-border);
 }
 
 .table-section .table tbody tr:first-child td:first-child {
-    border-top-left-radius: var(--panel-border-radius);
+    border-top-left-radius: var(--table-section-table-border-radius);
 }
 
 .table-section .table tbody tr:first-child td:last-child {
     border-collapse: separate;
-    border-top-right-radius: var(--panel-border-radius);
+    border-top-right-radius: var(--table-section-table-border-radius);
 }
 
 .table-section .table th {
-    padding-inline: var(--panel-padding-inline);
-    padding-block: var(--panel-padding-block);
+    padding-inline: var(--table-section-header-cell-padding-inline);
+    padding-block: var(--table-section-header-cell-padding-block);
     text-align: left;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
-    font-size: var(--text-small-size);
+    letter-spacing: var(--table-section-header-cell-letter-spacing);
+    font-size: var(--table-section-header-cell-font-size);
     font-weight: 600;
 }
 
 .table-section .table td {
-    padding-inline: var(--panel-padding-inline);
-    padding-block: var(--panel-medium-padding-block);
+    padding-inline: var(--table-section-body-cell-padding-inline);
+    padding-block: var(--table-section-body-cell-padding-block);
     text-align: left;
 }
 
 .table-section .table tbody tr:nth-child(odd) {
-    background-color: var(--list-background-color-odd);
+    background-color: var(--table-section-row-odd-background-color);
 }
 
 .table-section .table tbody tr:nth-child(even) {
-    background-color: var(--list-background-color);
+    background-color: var(--table-section-row-even-background-color);
 }
 
 .table-section .table tbody tr:hover {
-    background-color: var(--list-element-hover-background-color);
+    background-color: var(--table-section-row-hover-background-color);
     overflow: hidden;
 }
 
 .table-section-message {
-    padding: 1rem 1.5rem;
-    border-radius: 16px;
-    background-color: rgba(255, 255, 255, 0.06);
-    color: #f9f9f9;
+    padding: var(--table-section-message-padding-block) var(--table-section-message-padding-inline);
+    border-radius: var(--table-section-message-border-radius);
+    background-color: var(--table-section-message-background-color);
+    color: var(--table-section-message-text-color);
 }
 
 @media (max-width: 640px) {
@@ -93,6 +93,6 @@
 
     .table-section .table th,
     .table-section .table td {
-        padding: 0.75rem 1rem;
+        padding: var(--table-section-compact-cell-padding-block) var(--table-section-compact-cell-padding-inline);
     }
 }


### PR DESCRIPTION
### Motivation
- El proyecto tenía valores visuales repetidos (colores, spacing, radios, sombras y tamaños de fuente) hardcodeados en componentes compartidos, lo que dificulta mantener la coherencia y la reusabilidad. 
- Se buscó mover estos valores a la capa de primitives/semántica para permitir temas y ajustes globales manteniendo valores estructurales locales cuando corresponda.

### Description
- Se añadieron tokens semánticos en `apps/frontend/src/styles/02-semantics.layout.css`, `03-semantics.forms.css` y `04-semantics.controls.css` para `summary-card`, `table-section`, `search-bar`, `autocomplete` y `chip` (colores, gaps, radios, sombras y tamaños). 
- Se refactorizaron los estilos de componentes para usar los tokens: `apps/frontend/src/app/shared/ui/chip/chip.component.css`, `search-bar/search-bar.component.css`, `summary-card/summary-card.component.css`, `autocomplete-textbox/autocomplete-textbox.component.css` y `apps/frontend/src/styles/table-section.css`. 
- Los `chip` conservan variables locales (aliases) dentro del componente para permitir overrides de tamaño/variant sin hardcodear valores globales. 
- Se mantuvieron valores estrictamente estructurales específicos de componente cuando son necesarios para comportamiento de layout o accesibilidad.

### Testing
- `npm run lint:styles` (ejecuta `node scripts/validate-css-vars.mjs`) pasó correctamente y validó las propiedades CSS. 
- `npm run build` fue ejecutado y falló por un error existente e independiente en una plantilla Angular (`ClockComponent` referencia `clock.currentTime` sin que exista la propiedad `clock`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3064c1c64c83278f8fe47fa573bf0b)