### PR TITLE
Rename global button group styles to form-actions

### DIFF
--- a/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
+++ b/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
@@ -40,7 +40,7 @@
                         <p class="message error">{{ errorMessage | translate }}</p>
                     }
 
-                    <div class="buttons">
+                    <div class="form-actions">
                         <app-button type="button" variant="secondary" (clicked)="cancel()">
                             {{ 'actions.cancel' | translate }}
                         </app-button>

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -62,7 +62,7 @@
                         <p class="message error">{{ errorMessage | translate }}</p>
                     }
 
-                    <div class="buttons">
+                    <div class="form-actions">
                         <app-button type="button" variant="secondary" (clicked)="cancel()">
                             {{ 'actions.cancel' | translate }}
                         </app-button>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
@@ -91,7 +91,7 @@
                         <p class="message error">{{ errorMessage | translate }}</p>
                     }
 
-                    <div class="buttons">
+                    <div class="form-actions">
                         <app-button type="button" variant="secondary" (clicked)="cancel()">
                             {{ 'actions.cancel' | translate }}
                         </app-button>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
@@ -100,7 +100,7 @@
                             <p class="message error">{{ errorMessage | translate }}</p>
                         }
 
-                        <div class="buttons">
+                        <div class="form-actions">
                             <app-button type="button" variant="secondary" (clicked)="cancel()">
                                 {{ 'actions.cancel' | translate }}
                             </app-button>

--- a/apps/frontend/src/app/shared/ui/button/button.component.css
+++ b/apps/frontend/src/app/shared/ui/button/button.component.css
@@ -1,3 +1,4 @@
+/* Consumes the public button tokens defined in the global styles/button.css layer. */
 .app-button {
     box-sizing: border-box;
 

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -8,7 +8,7 @@
 @import './styles/avatar.css';
 @import './styles/brand.css';
 @import './styles/button.css';
-@import './styles/buttons.css';
+@import './styles/form-actions.css';
 @import './styles/card.css';
 @import './styles/forms.css';
 @import './styles/header-detail.css';

--- a/apps/frontend/src/styles/form-actions.css
+++ b/apps/frontend/src/styles/form-actions.css
@@ -1,8 +1,8 @@
-.buttons {
+.form-actions {
     margin-left: auto;
     margin-top: 2rem;
 }
 
-.buttons > * + * {
+.form-actions > * + * {
     margin-left: 1rem;
 }


### PR DESCRIPTION
### Motivation
- Evitar la ambigüedad entre tokens de botón (capa global) y estilos de layout de grupos de botones, dejando los tokens en `apps/frontend/src/styles/button.css` y renombrando la capa de layout para reflejar su uso real como acciones de formulario.
- Alinear los nombres CSS y las plantillas para que la clase global describa su responsabilidad (`form-actions` en lugar de `buttons`).

### Description
- Renombrado de `apps/frontend/src/styles/buttons.css` a `apps/frontend/src/styles/form-actions.css` y actualización del `@import` en `apps/frontend/src/styles.css` para usar `./styles/form-actions.css`.
- Reemplazo de `class="buttons"` por `class="form-actions"` en las plantillas de formulario afectadas (`worksite-create`, `worksite-edit`, `application-settings`, `user-preferences`).
- Actualización del selector dentro del archivo renombrado de `.buttons` a `.form-actions` para preservar el layout (márgenes y separación entre botones).
- Añadido un comentario breve en `apps/frontend/src/app/shared/ui/button/button.component.css` que documenta que el componente consume los tokens públicos definidos en la capa global `styles/button.css`.

### Testing
- `npm run lint:styles` se ejecutó y pasó correctamente (validó variables CSS en 49 ficheros).
- `npm run build` se ejecutó pero falló por un error existente y no relacionado con este cambio: `TS2339` en la plantilla de `ClockComponent` donde se referencia `clock.currentTime` aunque la propiedad `clock` no existe (archivo afectado: `src/app/shared/ui/clock/clock.component.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3067bb243c8327af5dbce2831bc8f0)