### PR TITLE
Fix clock component template bindings

### DIFF
--- a/apps/frontend/src/app/shared/ui/clock/clock.component.html
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.html
@@ -1,4 +1,10 @@
-<time class="clock-time" [attr.datetime]="isoDateTime">
-    <span class="visually-hidden">{{ clock.currentTime }}: </span>
+<time
+    class="clock-time"
+    [attr.datetime]="isoDateTime"
+    role="timer"
+    aria-live="off"
+    aria-atomic="true"
+    [attr.aria-label]="ariaLabel()"
+>
     {{ time }}
 </time>


### PR DESCRIPTION
### Motivation
- Corrige la plantilla de `ClockComponent` que referenciaba `clock.currentTime` inexistente y no incluía los atributos semánticos/ARIA esperados para un timer.

### Description
- Sustituye `apps/frontend/src/app/shared/ui/clock/clock.component.html` para renderizar `{{ time }}` directamente y añade `role="timer"`, `aria-live="off"`, `aria-atomic="true"` y el binding de `aria-label` a `ariaLabel()`.

### Testing
- Ejecutado `npm test -- --watch=false --include src/app/shared/ui/clock/clock.component.spec.ts` y los tests unitarios incluidos pasaron (1 test file, 8 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3068d13cb483278644c574899f8526)