### PR TITLE
Prefijar clases globales de frontend con `app-`

### DIFF
--- a/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
+++ b/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
@@ -1,7 +1,7 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.userPreferences">
     <div pageContent class="page-content preferences-content">
-        <section class="card preferences-card">
-            <div class="card-body preferences-card-body">
+        <section class="app-card preferences-card">
+            <div class="app-card-body preferences-card-body">
                 <form class="form" [formGroup]="form" (ngSubmit)="save()">
                     <app-select-field
                         inputId="preferences-locale"

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -1,7 +1,7 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.applicationSettings">
     <div pageContent class="page-content settings-content">
-        <section class="card settings-card">
-            <div class="card-body settings-card-body">
+        <section class="app-card settings-card">
+            <div class="app-card-body settings-card-body">
                 <form class="form" [formGroup]="form" (ngSubmit)="save()">
                     <app-range-slider-field
                         inputId="daysUntilLocked"

--- a/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.html
+++ b/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.html
@@ -1,13 +1,13 @@
-<section class="card employee-card" [attr.aria-labelledby]="titleElementId">
-    <header class="card-header employee-card-header">
+<section class="app-card employee-card" [attr.aria-labelledby]="titleElementId">
+    <header class="app-card-header employee-card-header">
         <img class="avatar" [src]="avatarSrc()" alt="" />
 
-        <h3 class="card-title employee-card-title" [id]="titleElementId">
+        <h3 class="app-card-title employee-card-title" [id]="titleElementId">
             {{ 'employee.employee' | translate }}
         </h3>
     </header>
 
-    <div class="card-body employee-card-body">
+    <div class="app-card-body employee-card-body">
         <dl class="employee-data">
             <div class="data">
                 <dt>{{ 'employee.fullName' | translate }}</dt>

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
@@ -1,6 +1,6 @@
-<section class="table-section table-section-schedule" aria-labelledby="schedule-title">
-    <header class="table-section-header schedule-table-section-header">
-        <h3 id="schedule-title" class="table-section-title schedule-table-section-title">
+<section class="app-table-section table-section-schedule" aria-labelledby="schedule-title">
+    <header class="app-table-section-header schedule-table-section-header">
+        <h3 id="schedule-title" class="app-table-section-title schedule-table-section-title">
             {{ 'schedule.schedules' | translate }}
         </h3>
         @if (totalItems() > 0) {
@@ -18,13 +18,13 @@
     </header>
 
     @if (schedulesResource.error() !== undefined) {
-        <div class="table-section-message schedule-table-section-message error" role="alert">
+        <div class="app-table-section-message schedule-table-section-message error" role="alert">
             {{ 'schedule.loadError' | translate }}
         </div>
     }
 
     @if (schedulesResource.isLoading()) {
-        <div class="table-section-message schedule-table-section-message" aria-live="polite">
+        <div class="app-table-section-message schedule-table-section-message" aria-live="polite">
             {{ 'schedule.loading' | translate }}
         </div>
     }
@@ -49,7 +49,7 @@
     }
 
     @if (isEmpty()) {
-        <div class="table-section-message schedule-table-section-message" aria-live="polite">
+        <div class="app-table-section-message schedule-table-section-message" aria-live="polite">
             {{ 'schedule.empty' | translate }}
         </div>
     }

--- a/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.html
@@ -1,6 +1,6 @@
 @if (vm$ | async; as vm) {
-    <section class="card clock-in-card" [attr.aria-labelledby]="titleElementId">
-        <h2 [id]="titleElementId" class="card-title clock-in-card-title visually-hidden-title">
+    <section class="app-card clock-in-card" [attr.aria-labelledby]="titleElementId">
+        <h2 [id]="titleElementId" class="app-card-title clock-in-card-title visually-hidden-title">
             {{ 'timelog.timeTracking' | translate }}
         </h2>
 
@@ -24,7 +24,7 @@
             }
         </div>
 
-        <footer class="card-footer clock-in-card-footer">
+        <footer class="app-card-footer clock-in-card-footer">
             @if (vm.hasClockInOutPermission) {
                 <button
                     type="button"

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -1,6 +1,6 @@
-<section class="table-section timelog-table-section" aria-labelledby="timelog-title">
-    <header class="table-section-header timelog-table-section-header">
-        <h2 id="timelog-title" class="table-section-title timelog-title">
+<section class="app-table-section timelog-table-section" aria-labelledby="timelog-title">
+    <header class="app-table-section-header timelog-table-section-header">
+        <h2 id="timelog-title" class="app-table-section-title timelog-title">
             {{ 'timelog.timelogs' | translate }}
         </h2>
         @if (totalItems() > 0) {
@@ -18,13 +18,13 @@
     </header>
 
     @if (timelogsResource.error() !== undefined) {
-        <div class="table-section-message timelog-table-section-message error" role="alert">
+        <div class="app-table-section-message timelog-table-section-message error" role="alert">
             {{ 'timelog.loadError' | translate }}
         </div>
     }
 
     @if (timelogsResource.isLoading()) {
-        <div class="table-section-message timelog-table-section-message" aria-live="polite">
+        <div class="app-table-section-message timelog-table-section-message" aria-live="polite">
             {{ 'timelog.loading' | translate }}
         </div>
     }
@@ -75,7 +75,7 @@
     }
 
     @if (isEmpty()) {
-        <div class="table-section-message timelog-table-section-message" aria-live="polite">
+        <div class="app-table-section-message timelog-table-section-message" aria-live="polite">
             {{ 'timelog.empty' | translate }}
         </div>
     }

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
@@ -1,6 +1,6 @@
-<section class="table-section worksite-table-section" aria-labelledby="worksite-title">
-    <header class="table-section-header worksite-table-section-header">
-        <h3 id="worksite-title" class="table-section-title worksite-table-section-title">
+<section class="app-table-section worksite-table-section" aria-labelledby="worksite-title">
+    <header class="app-table-section-header worksite-table-section-header">
+        <h3 id="worksite-title" class="app-table-section-title worksite-table-section-title">
             {{ 'worksite.worksites' | translate }}
         </h3>
         @if (totalItems() > 0) {
@@ -18,13 +18,13 @@
     </header>
 
     @if (worksitesResource.error() !== undefined) {
-        <div class="table-section-message worksite-table-section-message error" role="alert">
+        <div class="app-table-section-message worksite-table-section-message error" role="alert">
             {{ 'worksite.loadError' | translate }}
         </div>
     }
 
     @if (worksitesResource.isLoading()) {
-        <div class="table-section-message worksite-table-section-message" aria-live="polite">
+        <div class="app-table-section-message worksite-table-section-message" aria-live="polite">
             {{ 'worksite.loading' | translate }}
         </div>
     }
@@ -66,7 +66,7 @@
     }
 
     @if (isEmpty()) {
-        <div class="table-section-message worksite-table-section-message" aria-live="polite">
+        <div class="app-table-section-message worksite-table-section-message" aria-live="polite">
             {{ 'worksite.empty' | translate }}
         </div>
     }

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
@@ -1,7 +1,7 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.new">
     <div pageContent class="page-content worksite-create-content">
-        <section class="card worksites-card">
-            <div class="card-body worksites-card-body">
+        <section class="app-card worksites-card">
+            <div class="app-card-body worksites-card-body">
                 <form [formGroup]="form" (ngSubmit)="save()">
                     <app-text-field
                         inputId="worksite-code"

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.css
@@ -74,7 +74,7 @@
     margin-top: 1.55rem;
 }
 
-:host ::ng-deep .empty-panel .card-body {
+:host ::ng-deep .empty-panel .app-card-body {
     min-height: 24rem;
 }
 

--- a/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
@@ -1,7 +1,7 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.edit">
     <div pageContent class="page-content worksite-create-content">
-        <section class="card worksites-card">
-            <div class="card-body worksites-card-body">
+        <section class="app-card worksites-card">
+            <div class="app-card-body worksites-card-body">
                 @if (loading) {
                     <p class="message">{{ 'worksite.detailLoading' | translate }}</p>
                 } @else {

--- a/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
@@ -64,7 +64,7 @@ describe('ButtonComponent', () => {
 
     expect(buttonEl).toBeTruthy();
     expect(buttonEl.type).toBe('button');
-    expect(buttonEl.classList).toContain('button--default');
+    expect(buttonEl.classList).toContain('app-button--default');
   });
 
   it('should disable the button when disabled is true', () => {

--- a/apps/frontend/src/app/shared/ui/card/card.component.html
+++ b/apps/frontend/src/app/shared/ui/card/card.component.html
@@ -1,12 +1,12 @@
 <section
-    [class]="'card ' + styleClass()"
+    [class]="'app-card ' + styleClass()"
     [attr.aria-labelledby]="title() ? titleElementId : null"
     [attr.aria-label]="title() ? null : ariaLabel()"
 >
     @if (hasHeader) {
-        <header class="card-header">
+        <header class="app-card-header">
             @if (title()) {
-                <h3 [id]="titleElementId" class="card-title">{{ title() }}</h3>
+                <h3 [id]="titleElementId" class="app-card-title">{{ title() }}</h3>
             }
             @if (headerTpl) {
                 <ng-container [ngTemplateOutlet]="headerTpl"></ng-container>
@@ -14,12 +14,12 @@
         </header>
     }
 
-    <div class="card-body">
+    <div class="app-card-body">
         <ng-content></ng-content>
     </div>
 
     @if (hasFooter) {
-        <footer class="card-footer">
+        <footer class="app-card-footer">
             <ng-container [ngTemplateOutlet]="footerTpl"></ng-container>
         </footer>
     }

--- a/apps/frontend/src/app/shared/ui/card/card.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/card/card.component.spec.ts
@@ -82,7 +82,7 @@ describe('CardComponent', () => {
       hostComponent.title = 'My card title';
       fixture.detectChanges();
 
-      const titleElement = fixture.nativeElement.querySelector('.card-title');
+      const titleElement = fixture.nativeElement.querySelector('.app-card-title');
 
       expect(titleElement).toBeTruthy();
       expect(titleElement.textContent.trim()).toBe('My card title');
@@ -112,7 +112,7 @@ describe('CardComponent', () => {
 
       fixture.detectChanges();
 
-      const cardElement = fixture.nativeElement.querySelector('.card');
+      const cardElement = fixture.nativeElement.querySelector('.app-card');
 
       expect(cardElement.classList.contains('custom-card')).toBe(true);
     });
@@ -138,7 +138,7 @@ describe('CardComponent', () => {
     it('should render the header element when a header template exists even if title is undefinied', () => {
       fixture.detectChanges();
 
-      const headerElement = fixture.nativeElement.querySelector('.card-header');
+      const headerElement = fixture.nativeElement.querySelector('.app-card-header');
 
       expect(headerElement).toBeTruthy();
     });
@@ -147,8 +147,8 @@ describe('CardComponent', () => {
       hostComponent.title = 'Accessible title';
       fixture.detectChanges();
 
-      const cardElement = fixture.nativeElement.querySelector('section.card');
-      const titleElement = fixture.nativeElement.querySelector('.card-title');
+      const cardElement = fixture.nativeElement.querySelector('section.app-card');
+      const titleElement = fixture.nativeElement.querySelector('.app-card-title');
 
       expect(cardElement.getAttribute('aria-labelledby')).toBe(titleElement.id);
       expect(cardElement.hasAttribute('aria-label')).toBe(false);
@@ -157,7 +157,7 @@ describe('CardComponent', () => {
     it('should render the footer element when a footer template exists', () => {
       fixture.detectChanges();
 
-      const footerElement = fixture.nativeElement.querySelector('.card-footer');
+      const footerElement = fixture.nativeElement.querySelector('.app-card-footer');
 
       expect(footerElement).toBeTruthy();
     });
@@ -179,7 +179,7 @@ describe('CardComponent', () => {
     it('should not render the header when there is no title and no header template', () => {
       fixture.detectChanges();
 
-      const headerElement = fixture.nativeElement.querySelector('.card-header');
+      const headerElement = fixture.nativeElement.querySelector('.app-card-header');
       const cardDebugElement = fixture.debugElement.query(By.directive(CardComponent));
       const cardComponent = cardDebugElement.componentInstance as CardComponent;
 
@@ -191,8 +191,8 @@ describe('CardComponent', () => {
       hostComponent.title = 'Title only';
       fixture.detectChanges();
 
-      const headerElement = fixture.nativeElement.querySelector('.card-header');
-      const titleElement = fixture.nativeElement.querySelector('.card-title');
+      const headerElement = fixture.nativeElement.querySelector('.app-card-header');
+      const titleElement = fixture.nativeElement.querySelector('.app-card-title');
       const cardDebugElement = fixture.debugElement.query(By.directive(CardComponent));
       const cardComponent = cardDebugElement.componentInstance as CardComponent;
 
@@ -205,7 +205,7 @@ describe('CardComponent', () => {
     it('should not render the footer when there is no footer template', () => {
       fixture.detectChanges();
 
-      const footerElement = fixture.nativeElement.querySelector('.card-footer');
+      const footerElement = fixture.nativeElement.querySelector('.app-card-footer');
       const cardDebugElement = fixture.debugElement.query(By.directive(CardComponent));
       const cardComponent = cardDebugElement.componentInstance as CardComponent;
 
@@ -226,7 +226,7 @@ describe('CardComponent', () => {
       hostComponent.ariaLabel = 'Timesheet summary';
       fixture.detectChanges();
 
-      const cardElement = fixture.nativeElement.querySelector('section.card');
+      const cardElement = fixture.nativeElement.querySelector('section.app-card');
 
       expect(cardElement.getAttribute('aria-label')).toBe('Timesheet summary');
       expect(cardElement.hasAttribute('aria-labelledby')).toBe(false);
@@ -235,7 +235,7 @@ describe('CardComponent', () => {
     it('should not expose landmark role when card has no accessible name', () => {
       fixture.detectChanges();
 
-      const cardElement = fixture.nativeElement.querySelector('section.card');
+      const cardElement = fixture.nativeElement.querySelector('section.app-card');
 
       expect(cardElement.hasAttribute('role')).toBe(false);
       expect(cardElement.hasAttribute('aria-labelledby')).toBe(false);

--- a/apps/frontend/src/styles/card.css
+++ b/apps/frontend/src/styles/card.css
@@ -8,7 +8,7 @@
     --card-box-shadow: var(--panel-shadow);
 }
 
-.card {
+.app-card {
     display: flex;
     flex: 1;
     flex-direction: column;
@@ -20,25 +20,25 @@
     box-shadow: var(--card-box-shadow);
 }
 
-.card-header,
-.card-body,
-.card-footer {
+.app-card-header,
+.app-card-body,
+.app-card-footer {
     padding-inline: var(--card-padding-inline);
 }
 
-.card-header {
+.app-card-header {
     flex: 0 0 auto;
     padding-top: var(--card-padding-block);
 }
 
-.card-body {
+.app-card-body {
     flex: 1 1 auto;
     min-height: 0;
     overflow: auto;
     padding-block: var(--card-padding-block);
 }
 
-.card-footer {
+.app-card-footer {
     flex: 0 0 auto;
     padding-bottom: var(--card-padding-block);
 }

--- a/apps/frontend/src/styles/headings.css
+++ b/apps/frontend/src/styles/headings.css
@@ -12,20 +12,20 @@ h3 {
     line-height: 1.1;
 }
 
-.title {
+.app-title {
     font-size: var(--font-size-200);
     color: var(--text-secondary-color);
     text-transform: uppercase;
     font-weight: 600;
 }
 
-.card-title {
+.app-card-title {
     font-size: var(--font-size-400);
     color: var(--text-primary-color);
     font-weight: 600;
 }
 
-.section-title {
+.app-section-title {
     font-size: var(--font-size-500);
     margin: 0;
     text-transform: uppercase;

--- a/apps/frontend/src/styles/table-section.css
+++ b/apps/frontend/src/styles/table-section.css
@@ -1,16 +1,16 @@
-.table-section {
+.app-table-section {
     display: flex;
     flex-direction: column;
     gap: var(--table-section-gap);
 }
 
-.table-section-header {
+.app-table-section-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
 }
 
-.table-section-title {
+.app-table-section-title {
     font-size: var(--table-section-title-font-size);
     margin: 0;
     text-transform: uppercase;
@@ -18,7 +18,7 @@
     font-weight: 600;
 }
 
-.table-section .table {
+.app-table-section .table {
     width: 100%;
     background-color: var(--table-section-table-background-color);
     border-radius: var(--table-section-table-border-radius);
@@ -28,28 +28,28 @@
     overflow: hidden;
 }
 
-.table-section .table thead {
+.app-table-section .table thead {
     background-color: var(--table-section-table-background-color);
 }
 
-.table-section .table tbody tr td {
+.app-table-section .table tbody tr td {
     overflow: hidden;
 }
 
-.table-section .table tbody tr:first-child td {
+.app-table-section .table tbody tr:first-child td {
     border-top: var(--table-section-table-border);
 }
 
-.table-section .table tbody tr:first-child td:first-child {
+.app-table-section .table tbody tr:first-child td:first-child {
     border-top-left-radius: var(--table-section-table-border-radius);
 }
 
-.table-section .table tbody tr:first-child td:last-child {
+.app-table-section .table tbody tr:first-child td:last-child {
     border-collapse: separate;
     border-top-right-radius: var(--table-section-table-border-radius);
 }
 
-.table-section .table th {
+.app-table-section .table th {
     padding-inline: var(--table-section-header-cell-padding-inline);
     padding-block: var(--table-section-header-cell-padding-block);
     text-align: left;
@@ -59,26 +59,26 @@
     font-weight: 600;
 }
 
-.table-section .table td {
+.app-table-section .table td {
     padding-inline: var(--table-section-body-cell-padding-inline);
     padding-block: var(--table-section-body-cell-padding-block);
     text-align: left;
 }
 
-.table-section .table tbody tr:nth-child(odd) {
+.app-table-section .table tbody tr:nth-child(odd) {
     background-color: var(--table-section-row-odd-background-color);
 }
 
-.table-section .table tbody tr:nth-child(even) {
+.app-table-section .table tbody tr:nth-child(even) {
     background-color: var(--table-section-row-even-background-color);
 }
 
-.table-section .table tbody tr:hover {
+.app-table-section .table tbody tr:hover {
     background-color: var(--table-section-row-hover-background-color);
     overflow: hidden;
 }
 
-.table-section-message {
+.app-table-section-message {
     padding: var(--table-section-message-padding-block) var(--table-section-message-padding-inline);
     border-radius: var(--table-section-message-border-radius);
     background-color: var(--table-section-message-background-color);
@@ -86,13 +86,13 @@
 }
 
 @media (max-width: 640px) {
-    .table-section-header {
+    .app-table-section-header {
         flex-direction: column;
         align-items: flex-start;
     }
 
-    .table-section .table th,
-    .table-section .table td {
+    .app-table-section .table th,
+    .app-table-section .table td {
         padding: var(--table-section-compact-cell-padding-block) var(--table-section-compact-cell-padding-inline);
     }
 }


### PR DESCRIPTION
### Motivation
- Evitar clases CSS genéricas globales (`.card`, `.title`, `.table-section`, `..`) que pueden colisionar entre features y dificultar el mantenimiento del frontend.
- Normalizar el namespace visual compartido usando el prefijo `app-` para distinguir utilidades de presentación reutilizables.

### Description
- Prefijé selectores globales en estilos: `card` → `.app-card` (y sus subclases), `title` → `.app-title`, `card-title` → `.app-card-title`, `section-title` → `.app-section-title`, y `table-section` → `.app-table-section` junto con sus selectores relacionados en `apps/frontend/src/styles/card.css`, `headings.css` y `table-section.css`.
- Actualicé los templates consumidores para usar las nuevas clases prefijadas en múltiples componentes (`schedules`, `timelogs`, `worksites`, `employees`, `applicationsettings`, `user-preferences`, etc.).
- Ajusté el componente reutilizable `app-card` (`apps/frontend/src/app/shared/ui/card/card.component.html`) para emitir las clases prefijadas y actualicé sus tests en `card.component.spec.ts` para buscar las nuevas clases.
- Corregí el spec del botón para validar el modificador prefijado (`app-button--default`) y dejé intactas las clases de feature específicas (por ejemplo `worksite-table-section`).

### Testing
- Ejecuté `git diff --check` y no mostró problemas.
- Ejecuté `npm run lint:styles` y la validación de variables CSS pasó correctamente.
- Ejecuté la suite de tests con `npm test -- --watch=false`; se corrigió un fallo puntual en el spec del botón durante la migración y finalmente todos los tests unitarios pasaron (`160 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306a9e2ea48327a93952f883c4dcb3)