### PR TITLE
Unify frontend typography token naming

### DIFF
--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
@@ -41,7 +41,7 @@
     display: flex;
     align-items: center;
     color: var(--accent-strong-color);
-    font-size: var(--text-body-size);
+    font-size: var(--font-size-body);
     font-weight: 600;
     letter-spacing: 0.04em;
     white-space: nowrap;
@@ -57,7 +57,7 @@
     align-items: center;
     justify-content: center;
     color: var(--text-secondary-color);
-    font-size: var(--text-large-size);
+    font-size: var(--font-size-large);
     background: transparent;
     border-left: var(--panel-border);
     font-weight: 600;

--- a/apps/frontend/src/app/core/layout/page-template/page-template.component.css
+++ b/apps/frontend/src/app/core/layout/page-template/page-template.component.css
@@ -33,7 +33,7 @@
 }
 
 .page-title {
-    font-size: var(--h1-font-size);
+    font-size: var(--font-size-heading-1);
     color: var(--text-secondary-color);
     text-transform: uppercase;
     font-weight: 600;

--- a/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
+++ b/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
@@ -5,7 +5,7 @@
 }
 
 .employee-card-title {
-    font-size: var(--h3-font-size);
+    font-size: var(--font-size-large);
     color: var(--text-primary-color);
     font-weight: 600;
 }

--- a/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.css
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.css
@@ -16,13 +16,13 @@
 
 .clock-in {
     color: var(--text-primary-color);
-    font-size: var(--text-large-size);
+    font-size: var(--font-size-large);
     font-weight: 600;
 }
 
 .secondary-action {
     color: var(--text-secondary-color);
-    font-size: var(--text-small-size);
+    font-size: var(--font-size-small);
     cursor: pointer;
     background: transparent;
     border: 0px;

--- a/apps/frontend/src/app/shared/ui/clock/clock.component.css
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.css
@@ -1,4 +1,4 @@
 .clock-time {
-    font-size: var(--text-giant-size);
+    font-size: var(--font-size-900);
     color: var(--accent-color);
 }

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
@@ -39,7 +39,7 @@
 
 .paginator-text {
     color: var(--text-secondary-color);
-    font-size: var(--text-small-size);
+    font-size: var(--font-size-small);
     letter-spacing: 0.04em;
     font-weight: 600;
 }

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.css
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.css
@@ -16,7 +16,7 @@
     border-right: var(--panel-border);
     background: transparent;
     color: var(--text-primary-color);
-    font-size: var(--text-small-size);
+    font-size: var(--font-size-small);
     font-weight: 800;
     letter-spacing: 0.14em;
     text-transform: uppercase;

--- a/apps/frontend/src/styles/01-semantics.color.css
+++ b/apps/frontend/src/styles/01-semantics.color.css
@@ -1,15 +1,9 @@
 :root {
-    --text-small-size: var(--font-size-200);
-    --text-body-size: var(--font-size-300);
-    --text-large-size: var(--font-size-400);
-    --text-big-size: var(--font-size-500);
-    --text-giant-size: var(--font-size-900);
-
-    --h1-font-size: var(--font-size-200);
-    --h2-font-size: var(--font-size-500);
-    --h3-font-size: var(--font-size-400);
-    --h4-font-size: var(--font-size-300);
-    --h5-font-size: var(--font-size-200);
+    --font-size-body: var(--font-size-300);
+    --font-size-small: var(--font-size-200);
+    --font-size-large: var(--font-size-400);
+    --font-size-heading-1: var(--font-size-200);
+    --font-size-heading-2: var(--font-size-500);
 
     --focus-ring-width: var(--stroke-200);
     --focus-ring: 0 0 0 var(--focus-ring-width) var(--focus-ring-color);

--- a/apps/frontend/src/styles/02-semantics.layout.css
+++ b/apps/frontend/src/styles/02-semantics.layout.css
@@ -44,10 +44,10 @@
     --summary-card-icon-font-size: 1.75rem;
     --summary-card-label-letter-spacing: 0.13em;
     --summary-card-value-margin-top: 0.8rem;
-    --summary-card-value-font-size: var(--text-big-size);
+    --summary-card-value-font-size: var(--font-size-heading-2);
 
     --table-section-gap: var(--section-medium-gap);
-    --table-section-title-font-size: var(--h2-font-size);
+    --table-section-title-font-size: var(--font-size-heading-2);
     --table-section-title-color: var(--accent-color);
     --table-section-table-background-color: var(--panel-background-color);
     --table-section-table-border-radius: var(--panel-border-radius);
@@ -56,7 +56,7 @@
     --table-section-header-cell-padding-inline: var(--panel-padding-inline);
     --table-section-header-cell-padding-block: var(--panel-padding-block);
     --table-section-header-cell-letter-spacing: 0.12em;
-    --table-section-header-cell-font-size: var(--text-small-size);
+    --table-section-header-cell-font-size: var(--font-size-small);
     --table-section-body-cell-padding-inline: var(--panel-padding-inline);
     --table-section-body-cell-padding-block: var(--panel-medium-padding-block);
     --table-section-row-odd-background-color: var(--list-background-color-odd);

--- a/apps/frontend/src/styles/03-semantics.forms.css
+++ b/apps/frontend/src/styles/03-semantics.forms.css
@@ -4,15 +4,15 @@
 
     --form-label-gap: var(--size-300);
     --form-label-text-color: var(--text-primary-color);
-    --form-label-font-size: var(--text-body-size);
+    --form-label-font-size: var(--font-size-body);
     --form-label-font-weight: 600;
 
     --form-hint-text-color: var(--text-secondary-color);
-    --form-hint-font-size: var(--text-small-size);
+    --form-hint-font-size: var(--font-size-small);
     --form-hint-font-weight: 300;
 
     --form-error-text-color: var(--color-error-500);
-    --form-error-font-size: var(--text-body-size);
+    --form-error-font-size: var(--font-size-body);
     --form-error-font-weight: 300;
 
     /* form-control      → input text / textarea / select */
@@ -21,7 +21,7 @@
     --form-control-background-color: var(--color-gray-900);
     --form-control-text-color: var(--text-primary-color);
     --form-control-text-accent-color: var(--accent-color);
-    --form-control-text-size: var(--text-body-size);
+    --form-control-text-size: var(--font-size-body);
     --form-control-padding-inline: var(--size-300);
     --form-control-padding-block: 0;
     --form-control-focus-ring: 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
@@ -30,7 +30,7 @@
     /* form-range        → slider */
     --form-range-text-color: var(--color-gray-800);
     --form-range-focus-ring: var(--focus-ring);
-    --form-range-text-size: var(--text-body-size);
+    --form-range-text-size: var(--font-size-body);
     --form-range-text-weight: 800;
 
     --form-range-focus-ring: var(--focus-ring);
@@ -40,7 +40,7 @@
     --form-range-color: var(--accent-color);
 
     --form-range-value-text-color: var(--color-gray-800);
-    --form-range-value-text-size: var(--text-body-size);
+    --form-range-value-text-size: var(--font-size-body);
     --form-range-value-text-weight: 800;
     --form-range-value-background-color: var(--accent-color);
     --form-range-value-border-radius: var(--size-200);

--- a/apps/frontend/src/styles/brand.css
+++ b/apps/frontend/src/styles/brand.css
@@ -1,4 +1,4 @@
 :root {
     --brand-color: var(--accent-strong-color);
-    --brand-font-size: var(--text-large-size);
+    --brand-font-size: var(--font-size-large);
 }

--- a/apps/frontend/src/styles/button.css
+++ b/apps/frontend/src/styles/button.css
@@ -5,7 +5,7 @@
 
     --button-border-radius: var(--radius-100);
     --button-min-width: 15rem;
-    --button-font-size: var(--text-body-size);
+    --button-font-size: var(--font-size-body);
     --button-font-weight: 600;
     --button-height: var(--size-800);
     --button-size: var(--button-height);
@@ -13,7 +13,7 @@
 
     --button-icon-padding: 0;
     --button-icon-min-width: 0;
-    --button-icon-font-size: var(--text-large-size);
+    --button-icon-font-size: var(--font-size-large);
     --button-icon-border-radius: var(--button-border-radius);
 
     --button-primary-background-color: var(--control-accent-background-color);

--- a/apps/frontend/src/styles/header-detail.css
+++ b/apps/frontend/src/styles/header-detail.css
@@ -46,7 +46,7 @@
 }
 
 .header-detail__title {
-    font-size: var(--h2-font-size);
+    font-size: var(--font-size-heading-2);
 }
 
 .header-detail__info {


### PR DESCRIPTION
### Motivation
- Normalize typography tokens so primitive and semantic layers follow a single `--font-size-*` convention for clarity and consistency.
- Replace legacy mixed names like `--text-*` and `--h*-font-size` with semantic tokens that map to numeric primitives and meaningful roles.
- Apply the change project-wide in the frontend styles to avoid fragmented usage and simplify future maintenance.

### Description
- Introduced semantic typography tokens in `apps/frontend/src/styles/01-semantics.color.css` as `--font-size-body`, `--font-size-small`, `--font-size-large`, `--font-size-heading-1`, and `--font-size-heading-2` mapped to the existing numeric primitives.
- Replaced occurrences of `--text-small-size`, `--text-body-size`, `--text-large-size`, `--text-big-size`, `--text-giant-size`, and `--h1-font-size`, `--h2-font-size`, `--h3-font-size` etc. across component and semantic CSS files with the new `--font-size-*` tokens.
- Updated semantic consumers to use the new tokens (layout, forms, brand, buttons, header-detail and multiple components) via a mechanical search-and-replace across `apps/frontend/src/**/*.css` and committed the tidy-up changes across 13 files.

### Testing
- Ran `npm run lint:styles` which validated CSS custom properties across the frontend and reported success.
- Built the frontend with `npm run build` (`ng build`) which completed successfully and produced the application bundle in `apps/frontend/dist/frontend`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307041123083278cae40ae054499a1)