### PR TITLE
Añadir verificación de estilos en apps/frontend

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "lint": "ng lint",
+    "lint": "ng lint && npm run lint:styles",
     "lint:styles": "node scripts/validate-css-vars.mjs"
   },
   "prettier": {

--- a/apps/frontend/scripts/validate-css-vars.mjs
+++ b/apps/frontend/scripts/validate-css-vars.mjs
@@ -1,9 +1,36 @@
 import { readdir, readFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { basename, join, relative } from 'node:path';
 
 const srcDir = join(process.cwd(), 'src');
+const globalStylesDir = join(srcDir, 'styles');
 const definitionPattern = /--([A-Za-z0-9_-]+)\s*:/g;
 const usagePattern = /var\(\s*--([A-Za-z0-9_-]+)\b/g;
+const disallowedColorPattern = /#[0-9a-fA-F]{3,8}\b|rgba\([^)]*\)/g;
+const classSelectorPattern = /\.(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)/g;
+const allowedGlobalElements = new Set([
+  'html',
+  'body',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'p',
+  'a',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'label',
+  'form',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+]);
 
 async function collectCssFiles(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -26,9 +53,67 @@ function extractMatches(pattern, content) {
   return [...content.matchAll(pattern)].map((match) => match[1]);
 }
 
+function lineForIndex(content, index) {
+  return content.slice(0, index).split('\n').length;
+}
+
+function isColorDefinitionFile(file) {
+  const name = basename(file);
+
+  return name === '00-primitives.css' || /^theme\..+\.css$/.test(name);
+}
+
+function stripCssComments(content) {
+  return content.replace(/\/\*[\s\S]*?\*\//g, (comment) => ' '.repeat(comment.length));
+}
+
+function collectGlobalClassViolations(file, content) {
+  if (!file.startsWith(globalStylesDir) || basename(file) === '00-primitives.css') {
+    return [];
+  }
+
+  const violations = [];
+  const css = stripCssComments(content);
+  const rulePattern = /([^{}]+)\{/g;
+
+  for (const rule of css.matchAll(rulePattern)) {
+    const selectorText = rule[1].trim();
+
+    if (selectorText.startsWith('@') || selectorText.startsWith(':root')) {
+      continue;
+    }
+
+    const selectors = selectorText.split(',');
+
+    for (const selector of selectors) {
+      const normalizedSelector = selector.trim();
+
+      if (allowedGlobalElements.has(normalizedSelector.toLowerCase())) {
+        continue;
+      }
+
+      for (const classMatch of normalizedSelector.matchAll(classSelectorPattern)) {
+        const className = classMatch[1];
+
+        if (!className.startsWith('app-')) {
+          violations.push({
+            className,
+            file,
+            line: lineForIndex(content, rule.index + rule[1].indexOf(selector) + classMatch.index),
+          });
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
 const cssFiles = await collectCssFiles(srcDir);
 const definitions = new Set();
 const usages = [];
+const colorViolations = [];
+const classViolations = [];
 
 for (const file of cssFiles) {
   const content = await readFile(file, 'utf8');
@@ -38,21 +123,48 @@ for (const file of cssFiles) {
   }
 
   for (const match of content.matchAll(usagePattern)) {
-    const line = content.slice(0, match.index).split('\n').length;
-    usages.push({ name: match[1], file, line });
+    usages.push({ name: match[1], file, line: lineForIndex(content, match.index) });
   }
+
+  if (!isColorDefinitionFile(file)) {
+    for (const match of content.matchAll(disallowedColorPattern)) {
+      colorViolations.push({ value: match[0], file, line: lineForIndex(content, match.index) });
+    }
+  }
+
+  classViolations.push(...collectGlobalClassViolations(file, content));
 }
 
 const missingUsages = usages.filter(({ name }) => !definitions.has(name));
+const failures = [];
 
 if (missingUsages.length > 0) {
-  console.error('Undefined CSS custom properties found:');
+  failures.push('Undefined CSS custom properties found:');
 
   for (const { name, file, line } of missingUsages) {
-    console.error(`- --${name} used in ${relative(process.cwd(), file)}:${line}`);
+    failures.push(`- --${name} used in ${relative(process.cwd(), file)}:${line}`);
   }
+}
 
+if (colorViolations.length > 0) {
+  failures.push('Disallowed raw CSS colors found outside 00-primitives.css and theme files:');
+
+  for (const { value, file, line } of colorViolations) {
+    failures.push(`- ${value} in ${relative(process.cwd(), file)}:${line}`);
+  }
+}
+
+if (classViolations.length > 0) {
+  failures.push('Global style classes without the app- prefix found:');
+
+  for (const { className, file, line } of classViolations) {
+    failures.push(`- .${className} in ${relative(process.cwd(), file)}:${line}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
   process.exit(1);
 }
 
-console.log(`Validated ${cssFiles.length} CSS files. All CSS custom properties are defined.`);
+console.log(`Validated ${cssFiles.length} CSS files: custom properties, raw colors, and global class prefixes are valid.`);

--- a/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
+++ b/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
@@ -1,8 +1,8 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.userPreferences">
-    <div pageContent class="page-content preferences-content">
+    <div pageContent class="app-page-content preferences-content">
         <section class="app-card preferences-card">
             <div class="app-card-body preferences-card-body">
-                <form class="form" [formGroup]="form" (ngSubmit)="save()">
+                <form class="app-form" [formGroup]="form" (ngSubmit)="save()">
                     <app-select-field
                         inputId="preferences-locale"
                         formControlName="locale"
@@ -40,7 +40,7 @@
                         <p class="message error">{{ errorMessage | translate }}</p>
                     }
 
-                    <div class="form-actions">
+                    <div class="app-form-actions">
                         <app-button type="button" variant="secondary" (clicked)="cancel()">
                             {{ 'actions.cancel' | translate }}
                         </app-button>

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -1,8 +1,8 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.applicationSettings">
-    <div pageContent class="page-content settings-content">
+    <div pageContent class="app-page-content settings-content">
         <section class="app-card settings-card">
             <div class="app-card-body settings-card-body">
-                <form class="form" [formGroup]="form" (ngSubmit)="save()">
+                <form class="app-form" [formGroup]="form" (ngSubmit)="save()">
                     <app-range-slider-field
                         inputId="daysUntilLocked"
                         formControlName="daysUntilLocked"
@@ -62,7 +62,7 @@
                         <p class="message error">{{ errorMessage | translate }}</p>
                     }
 
-                    <div class="form-actions">
+                    <div class="app-form-actions">
                         <app-button type="button" variant="secondary" (clicked)="cancel()">
                             {{ 'actions.cancel' | translate }}
                         </app-button>

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard-page.component.html
@@ -1,5 +1,5 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.dashboard">
-    <div pageContent class="page-content dashboard-content">
+    <div pageContent class="app-page-content dashboard-content">
         @if (employeeEmail$ | async; as employeeEmail) {
             <app-timelog-clock-card
                 id="clock"

--- a/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
+++ b/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
@@ -31,5 +31,5 @@
 .employee-data dt {
     color: var(--accent-color);
     font-weight: 600;
-    text-shadow: 0 1px 0 #000;
+    text-shadow: 0 1px 0 var(--color-black);
 }

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
@@ -30,7 +30,7 @@
     }
 
     @if (!schedulesResource.isLoading() && schedules().length > 0) {
-        <table class="table schedule-table" aria-labelledby="schedule-title">
+        <table class="app-table schedule-table" aria-labelledby="schedule-title">
             <thead>
                 <tr>
                     <th scope="col">{{ 'schedule.code' | translate }}</th>

--- a/apps/frontend/src/app/features/schedules/pages/schedules-page.component.html
+++ b/apps/frontend/src/app/features/schedules/pages/schedules-page.component.html
@@ -1,5 +1,5 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.schedules">
-    <div pageContent class="page-content schedules-content">
+    <div pageContent class="app-page-content schedules-content">
         <div class="schedules-toolbar">
             <app-search-bar (queryChange)="onQueryChange($event)" />
             @if (isAdmin | async) {

--- a/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-clock-card/timelog-clock-card.component.html
@@ -1,6 +1,6 @@
 @if (vm$ | async; as vm) {
     <section class="app-card clock-in-card" [attr.aria-labelledby]="titleElementId">
-        <h2 [id]="titleElementId" class="app-card-title clock-in-card-title visually-hidden-title">
+        <h2 [id]="titleElementId" class="app-card-title clock-in-card-title app-visually-hidden-title">
             {{ 'timelog.timeTracking' | translate }}
         </h2>
 

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -30,7 +30,7 @@
     }
 
     @if (!timelogsResource.isLoading() && timelogs().length > 0) {
-        <table class="table timelog-table" aria-labelledby="timelog-title">
+        <table class="app-table timelog-table" aria-labelledby="timelog-title">
             <thead>
                 <tr>
                     <th scope="col">{{ 'timelog.date' | translate }}</th>

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
@@ -30,7 +30,7 @@
     }
 
     @if (!worksitesResource.isLoading() && worksites().length > 0) {
-        <table class="table worksite-table" aria-labelledby="worksite-title">
+        <table class="app-table worksite-table" aria-labelledby="worksite-title">
             <thead>
                 <tr>
                     <th scope="col">{{ 'worksite.code' | translate }}</th>

--- a/apps/frontend/src/app/features/worksites/components/worsite-detail-header/worsite-detail-header.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worsite-detail-header/worsite-detail-header.component.html
@@ -1,14 +1,14 @@
-<article class="worksite-header-detail header-detail">
-    <div class="worksite-header-detail__identity header-detail__identity">
-        <div class="worksite-header-detail__icon header-detail__icon" aria-hidden="true">
+<article class="worksite-header-detail app-header-detail">
+    <div class="worksite-header-detail__identity app-header-detail__identity">
+        <div class="worksite-header-detail__icon app-header-detail__icon" aria-hidden="true">
             <fa-icon [icon]="faBuilding"></fa-icon>
         </div>
 
         <div>
-            <h2 class="worksite-header-detail__title header-detail__title">
+            <h2 class="worksite-header-detail__title app-header-detail__title">
                 {{ worksite().name }}
             </h2>
-            <p class="worksite-header-detail__info header-detail__info">
+            <p class="worksite-header-detail__info app-header-detail__info">
                 <span>{{ worksite().code }}</span>
                 <app-chip [label]="'worksite.scopes.' + worksite().scope | translate"></app-chip>
             </p>
@@ -16,7 +16,7 @@
     </div>
 
     <app-chip
-        class="worksite-header-detail__status header-detail__status"
+        class="worksite-header-detail__status app-header-detail__status"
         [type]="worksite().active ? 'green' : 'red'"
         [icon]="faCircle"
         size="big"

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
@@ -10,5 +10,5 @@ form {
 }
 
 .error {
-    color: #ff8a8a;
+    color: var(--color-error-soft);
 }

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
@@ -1,5 +1,5 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.new">
-    <div pageContent class="page-content worksite-create-content">
+    <div pageContent class="app-page-content worksite-create-content">
         <section class="app-card worksites-card">
             <div class="app-card-body worksites-card-body">
                 <form [formGroup]="form" (ngSubmit)="save()">
@@ -91,7 +91,7 @@
                         <p class="message error">{{ errorMessage | translate }}</p>
                     }
 
-                    <div class="form-actions">
+                    <div class="app-form-actions">
                         <app-button type="button" variant="secondary" (clicked)="cancel()">
                             {{ 'actions.cancel' | translate }}
                         </app-button>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.css
@@ -39,7 +39,7 @@
     gap: 1.5rem;
     align-items: center;
     min-height: 4.15rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    border-bottom: 1px solid var(--color-white-alpha-10);
 }
 
 .detail-row:last-child {
@@ -47,7 +47,7 @@
 }
 
 .detail-row dt {
-    color: rgba(249, 249, 249, 0.72);
+    color: var(--summary-card-label-color);
     font-weight: 900;
     letter-spacing: 0.11em;
     text-transform: uppercase;
@@ -56,7 +56,7 @@
 .detail-row dd {
     min-width: 0;
     margin: 0;
-    color: #ffffff;
+    color: var(--color-white);
     font-size: 1.05rem;
     overflow-wrap: anywhere;
 }
@@ -81,12 +81,12 @@
 .worksite-detail-message {
     padding: 1rem 1.5rem;
     border-radius: 0.5rem;
-    background: rgba(255, 255, 255, 0.06);
+    background: var(--color-white-alpha-06);
 }
 
 .worksite-detail-message.error {
-    background: rgba(255, 87, 87, 0.12);
-    color: #ff8a8a;
+    background: var(--color-error-soft-alpha-12);
+    color: var(--color-error-soft);
 }
 
 @media (max-width: 900px) {

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.html
@@ -1,5 +1,5 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.detail">
-    <section pageContent class="page-content worksite-detail-content">
+    <section pageContent class="app-page-content worksite-detail-content">
         @if (worksiteResource.error() !== undefined) {
             <div class="worksite-detail-message error" role="alert">
                 {{ 'worksite.detailLoadError' | translate }}

--- a/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
@@ -1,5 +1,5 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.edit">
-    <div pageContent class="page-content worksite-create-content">
+    <div pageContent class="app-page-content worksite-create-content">
         <section class="app-card worksites-card">
             <div class="app-card-body worksites-card-body">
                 @if (loading) {
@@ -100,7 +100,7 @@
                             <p class="message error">{{ errorMessage | translate }}</p>
                         }
 
-                        <div class="form-actions">
+                        <div class="app-form-actions">
                             <app-button type="button" variant="secondary" (clicked)="cancel()">
                                 {{ 'actions.cancel' | translate }}
                             </app-button>

--- a/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksites-page.component.html
@@ -1,5 +1,5 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.worksites">
-    <div pageContent class="page-content worksites-content">
+    <div pageContent class="app-page-content worksites-content">
         <div class="worksites-toolbar">
             <app-search-bar (queryChange)="onQueryChange($event)" />
             @if (isAdmin | async) {

--- a/apps/frontend/src/styles/00-primitives.css
+++ b/apps/frontend/src/styles/00-primitives.css
@@ -54,6 +54,18 @@
     --color-warning-500: #f59e0b;
     --color-info-500: #38bdf8;
 
+    --color-black-alpha-35: rgba(0, 0, 0, 0.35);
+    --color-white-alpha-06: rgba(255, 255, 255, 0.06);
+    --color-white-alpha-10: rgba(255, 255, 255, 0.1);
+    --color-white-alpha-12: rgba(255, 255, 255, 0.12);
+    --color-error-soft: #ff8a8a;
+    --color-error-soft-alpha-12: rgba(255, 87, 87, 0.12);
+    --color-primary-focus-alpha-30: rgba(249, 214, 0, 0.3);
+    --color-success-muted-alpha-16: rgba(104, 135, 72, 0.16);
+    --color-error-muted-alpha-16: rgba(187, 53, 53, 0.16);
+    --color-success-muted-text: #3baa37;
+    --color-error-muted-text: #d24444;
+
     --size-100: 0.25rem;
     --size-200: 0.5rem;
     --size-300: 0.875rem;

--- a/apps/frontend/src/styles/03-semantics.forms.css
+++ b/apps/frontend/src/styles/03-semantics.forms.css
@@ -75,7 +75,7 @@
         var(--form-switch-width) - var(--form-switch-knob-size) - (var(--form-switch-padding) * 2)
     );
     --form-switch-checked-knob-background-color: var(--color-gray-800);
-    --form-switch-knob-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.35);
+    --form-switch-knob-shadow: 0 0.2rem 0.5rem var(--color-black-alpha-35);
 
 
     --search-bar-background-color: var(--form-control-background-color);
@@ -86,7 +86,7 @@
     --search-bar-border-style: var(--border-style);
     --search-bar-border: var(--search-bar-border-width) var(--search-bar-border-style) var(--search-bar-accent-color);
     --search-bar-border-radius: var(--form-control-border-radius);
-    --search-bar-focus-ring: 0 0 0 var(--focus-ring-width) rgba(249, 214, 0, 0.3);
+    --search-bar-focus-ring: 0 0 0 var(--focus-ring-width) var(--color-primary-focus-alpha-30);
     --search-bar-padding-block: 0.625rem;
     --search-bar-padding-inline: 0.75rem;
     --search-bar-font-size: 0.95rem;
@@ -99,9 +99,9 @@
     --autocomplete-results-max-height: 14rem;
     --autocomplete-results-padding-block: var(--size-100);
     --autocomplete-results-padding-inline: 0;
-    --autocomplete-results-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+    --autocomplete-results-shadow: 0 1rem 2rem var(--color-black-alpha-35);
     --autocomplete-result-padding-block: var(--size-200);
     --autocomplete-result-padding-inline: 0.75rem;
 
-    /* form-actions      → buttons */
+    /* app-form-actions      → buttons */
 }

--- a/apps/frontend/src/styles/04-semantics.controls.css
+++ b/apps/frontend/src/styles/04-semantics.controls.css
@@ -1,6 +1,6 @@
 :root {
-    --chip-background-color: #f9d600;
-    --chip-text-color: #131313;
+    --chip-background-color: var(--color-primary-500);
+    --chip-text-color: var(--color-gray-800);
     --chip-padding-block: 0.4rem;
     --chip-padding-inline: 0.75rem;
     --chip-border-radius: 0.35rem;
@@ -17,14 +17,14 @@
     --chip-big-font-size: 0.95rem;
     --chip-big-icon-size: var(--chip-big-font-size);
     --chip-big-gap: 0.45rem;
-    --chip-primary-background-color: #7f06a5;
+    --chip-primary-background-color: var(--color-secondary-500);
     --chip-primary-text-color: var(--color-white);
-    --chip-secondary-background-color: #1431a9;
+    --chip-secondary-background-color: var(--color-tertiary-700);
     --chip-secondary-text-color: var(--color-white);
-    --chip-tertiary-background-color: #615300;
+    --chip-tertiary-background-color: var(--color-primary-900);
     --chip-tertiary-text-color: var(--color-white);
-    --chip-success-background-color: rgba(104, 135, 72, 0.16);
-    --chip-success-text-color: #3baa37;
-    --chip-error-background-color: rgba(187, 53, 53, 0.16);
-    --chip-error-text-color: #d24444;
+    --chip-success-background-color: var(--color-success-muted-alpha-16);
+    --chip-success-text-color: var(--color-success-muted-text);
+    --chip-error-background-color: var(--color-error-muted-alpha-16);
+    --chip-error-text-color: var(--color-error-muted-text);
 }

--- a/apps/frontend/src/styles/base.css
+++ b/apps/frontend/src/styles/base.css
@@ -23,7 +23,7 @@ body {
     overflow-x: hidden;
 }
 
-.page-content {
+.app-page-content {
     display: flex;
     width: min(var(--layout-page-max-width), 100%);
     gap: var(--layout-main-gap);

--- a/apps/frontend/src/styles/form-actions.css
+++ b/apps/frontend/src/styles/form-actions.css
@@ -1,8 +1,8 @@
-.form-actions {
+.app-form-actions {
     margin-left: auto;
     margin-top: 2rem;
 }
 
-.form-actions > * + * {
+.app-form-actions > * + * {
     margin-left: 1rem;
 }

--- a/apps/frontend/src/styles/forms.css
+++ b/apps/frontend/src/styles/forms.css
@@ -1,4 +1,4 @@
-.form {
+.app-form {
     padding-block: var(--panel-padding-block);
     padding-inline: var(--panel-padding-inline);
     display: flex;

--- a/apps/frontend/src/styles/header-detail.css
+++ b/apps/frontend/src/styles/header-detail.css
@@ -1,81 +1,81 @@
 :root {
-    --header-detail-gap: var(--panel-gap);
-    --header-detail-padding-inline: var(--panel-padding-inline);
-    --header-detail-padding-block: var(--panel-padding-block);
-    --header-detail-background-color: var(--panel-background-color);
-    --header-detail-border: var(--panel-border);
-    --header-detail-border-radius: var(--panel-border-radius);
-    --header-detail-icon-size: 6rem;
-    --header-detail-icon-border: var(--stroke-400) solid rgba(255, 255, 255, 0.12);
-    --header-detail-icon-border-radius: var(--radius-400);
-    --header-detail-icon-color: var(--accent-color);
-    --header-detail-icon-font-size: var(--font-size-700);
-    --header-detail-info-gap: var(--size-300);
-    --header-detail-info-font-size: var(--font-size-350);
-    --header-detail-compact-padding-inline-end: 1.85rem;
+    --app-header-detail-gap: var(--panel-gap);
+    --app-header-detail-padding-inline: var(--panel-padding-inline);
+    --app-header-detail-padding-block: var(--panel-padding-block);
+    --app-header-detail-background-color: var(--panel-background-color);
+    --app-header-detail-border: var(--panel-border);
+    --app-header-detail-border-radius: var(--panel-border-radius);
+    --app-header-detail-icon-size: 6rem;
+    --app-header-detail-icon-border: var(--stroke-400) solid var(--color-white-alpha-12);
+    --app-header-detail-icon-border-radius: var(--radius-400);
+    --app-header-detail-icon-color: var(--accent-color);
+    --app-header-detail-icon-font-size: var(--font-size-700);
+    --app-header-detail-info-gap: var(--size-300);
+    --app-header-detail-info-font-size: var(--font-size-350);
+    --app-header-detail-compact-padding-inline-end: 1.85rem;
 }
 
-.header-detail {
+.app-header-detail {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--header-detail-gap);
-    padding-inline: var(--header-detail-padding-inline);
-    padding-block: var(--header-detail-padding-block);
-    border: var(--header-detail-border);
-    border-radius: var(--header-detail-border-radius);
-    background: var(--header-detail-background-color);
+    gap: var(--app-header-detail-gap);
+    padding-inline: var(--app-header-detail-padding-inline);
+    padding-block: var(--app-header-detail-padding-block);
+    border: var(--app-header-detail-border);
+    border-radius: var(--app-header-detail-border-radius);
+    background: var(--app-header-detail-background-color);
 }
 
-.header-detail__identity {
+.app-header-detail__identity {
     display: flex;
     align-items: center;
-    gap: var(--header-detail-gap);
+    gap: var(--app-header-detail-gap);
 }
 
-.header-detail__icon {
+.app-header-detail__icon {
     display: grid;
-    width: var(--header-detail-icon-size);
-    flex: 0 0 var(--header-detail-icon-size);
+    width: var(--app-header-detail-icon-size);
+    flex: 0 0 var(--app-header-detail-icon-size);
     aspect-ratio: 1;
     place-items: center;
-    border: var(--header-detail-icon-border);
-    border-radius: var(--header-detail-icon-border-radius);
-    color: var(--header-detail-icon-color);
-    font-size: var(--header-detail-icon-font-size);
+    border: var(--app-header-detail-icon-border);
+    border-radius: var(--app-header-detail-icon-border-radius);
+    color: var(--app-header-detail-icon-color);
+    font-size: var(--app-header-detail-icon-font-size);
 }
 
-.header-detail__title {
+.app-header-detail__title {
     font-size: var(--font-size-heading-2);
 }
 
-.header-detail__info {
+.app-header-detail__info {
     display: flex;
     align-items: center;
-    gap: var(--header-detail-info-gap);
+    gap: var(--app-header-detail-info-gap);
     margin: 0;
-    font-size: var(--header-detail-info-font-size);
+    font-size: var(--app-header-detail-info-font-size);
 }
 
 @media (max-width: 900px) {
-    .header-detail {
+    .app-header-detail {
         align-items: flex-start;
-        padding-inline-end: var(--header-detail-compact-padding-inline-end);
+        padding-inline-end: var(--app-header-detail-compact-padding-inline-end);
     }
 }
 
 @media (max-width: 640px) {
-    .header-detail,
-    .header-detail__identity {
+    .app-header-detail,
+    .app-header-detail__identity {
         flex-direction: column;
     }
 
-    .header-detail__icon {
-        --header-detail-icon-size: 4.8rem;
-        --header-detail-icon-font-size: var(--font-size-500);
+    .app-header-detail__icon {
+        --app-header-detail-icon-size: 4.8rem;
+        --app-header-detail-icon-font-size: var(--font-size-500);
     }
 
-    .header-detail__status {
+    .app-header-detail__status {
         width: 100%;
     }
 }

--- a/apps/frontend/src/styles/headings.css
+++ b/apps/frontend/src/styles/headings.css
@@ -33,6 +33,6 @@ h3 {
     font-weight: 600;
 }
 
-.visually-hidden-title {
+.app-visually-hidden-title {
     visibility: hidden;
 }

--- a/apps/frontend/src/styles/table-section.css
+++ b/apps/frontend/src/styles/table-section.css
@@ -18,7 +18,7 @@
     font-weight: 600;
 }
 
-.app-table-section .table {
+.app-table-section .app-table {
     width: 100%;
     background-color: var(--table-section-table-background-color);
     border-radius: var(--table-section-table-border-radius);
@@ -28,28 +28,28 @@
     overflow: hidden;
 }
 
-.app-table-section .table thead {
+.app-table-section .app-table thead {
     background-color: var(--table-section-table-background-color);
 }
 
-.app-table-section .table tbody tr td {
+.app-table-section .app-table tbody tr td {
     overflow: hidden;
 }
 
-.app-table-section .table tbody tr:first-child td {
+.app-table-section .app-table tbody tr:first-child td {
     border-top: var(--table-section-table-border);
 }
 
-.app-table-section .table tbody tr:first-child td:first-child {
+.app-table-section .app-table tbody tr:first-child td:first-child {
     border-top-left-radius: var(--table-section-table-border-radius);
 }
 
-.app-table-section .table tbody tr:first-child td:last-child {
+.app-table-section .app-table tbody tr:first-child td:last-child {
     border-collapse: separate;
     border-top-right-radius: var(--table-section-table-border-radius);
 }
 
-.app-table-section .table th {
+.app-table-section .app-table th {
     padding-inline: var(--table-section-header-cell-padding-inline);
     padding-block: var(--table-section-header-cell-padding-block);
     text-align: left;
@@ -59,21 +59,21 @@
     font-weight: 600;
 }
 
-.app-table-section .table td {
+.app-table-section .app-table td {
     padding-inline: var(--table-section-body-cell-padding-inline);
     padding-block: var(--table-section-body-cell-padding-block);
     text-align: left;
 }
 
-.app-table-section .table tbody tr:nth-child(odd) {
+.app-table-section .app-table tbody tr:nth-child(odd) {
     background-color: var(--table-section-row-odd-background-color);
 }
 
-.app-table-section .table tbody tr:nth-child(even) {
+.app-table-section .app-table tbody tr:nth-child(even) {
     background-color: var(--table-section-row-even-background-color);
 }
 
-.app-table-section .table tbody tr:hover {
+.app-table-section .app-table tbody tr:hover {
     background-color: var(--table-section-row-hover-background-color);
     overflow: hidden;
 }
@@ -91,8 +91,8 @@
         align-items: flex-start;
     }
 
-    .app-table-section .table th,
-    .app-table-section .table td {
+    .app-table-section .app-table th,
+    .app-table-section .app-table td {
         padding: var(--table-section-compact-cell-padding-block) var(--table-section-compact-cell-padding-inline);
     }
 }


### PR DESCRIPTION
### Motivation
- Enforzar calidad y consistencia de los estilos en `apps/frontend` detectando variables CSS usadas pero no definidas, colores en crudo fuera de ficheros de primitives/themes y clases globales sin el prefijo `app-`.
- Facilitar la integración de la verificación en el pipeline de lint existente sin necesidad inmediata de Stylelint completo.

### Description
- Añadido el script Node `apps/frontend/scripts/validate-css-vars.mjs` que valida: variables CSS usadas y no definidas, colores `#...`/`rgba(...)` fuera de `00-primitives.css` y `theme.*.css`, y clases globales en `src/styles/*` que no comiencen por `app-` (con excepciones para selectores HTML base). 
- Expuesto el script como `lint:styles` en `apps/frontend/package.json` y encadenado al script `lint` (ahora `ng lint && npm run lint:styles`).
- Introducidas nuevas variables en `apps/frontend/src/styles/00-primitives.css` y reemplazados usos de colores/valores en ficheros no permitidos para usar esas variables; renombradas utilidades globales para usar el prefijo `app-` y actualizados los usos en plantillas y estilos (ej.: `forms.css` -> `app-form`, `form-actions.css` -> `app-form-actions`, `table` -> `app-table`, `header-detail` -> `app-header-detail`, y cambios representativos en HTML bajo `src/app/...`).
- Ajustes menores en CSS (por ejemplo cambiar `text-shadow: 0 1px 0 #000` a `var(--color-black)`), y mensajes de salida del script para agrupar violaciones antes de fallar.

### Testing
- `npm run lint:styles` (ejecutado en `apps/frontend`) — pasó y el script reportó: "Validated 51 CSS files: custom properties, raw colors, and global class prefixes are valid.".
- `npm run build` (ejecutado en `apps/frontend`) — pasó y generó la salida de `ng build` con bundles en `dist/frontend`.
- `npm run lint` (ejecutado en `apps/frontend`) — falla en el paso `ng lint` por errores TypeScript previos no relacionados con la verificación de estilos; los errores detectados incluyen métodos vacíos y variables no usadas en: `autocomplete-textbox.component.ts`, `button.component.spec.ts`, y `toggle-button-field.component.ts` (5 problemas totales).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30720517a4832791efbed267d3d9f7)