### PR TITLE
Add global ESLint ignores for generated frontend files

### DIFF
--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -6,6 +6,9 @@ const angular = require("angular-eslint");
 
 module.exports = defineConfig([
   {
+    ignores: ["dist/**", ".angular/**", "coverage/**", "node_modules/**"],
+  },
+  {
     files: ["**/*.ts"],
     extends: [
       eslint.configs.recommended,


### PR DESCRIPTION
### Motivation
- Prevent ESLint from scanning generated/build/cache directories (e.g. `dist/**`, `.angular/**`) so lint output does not include files produced by the build or Angular cache.

### Description
- Insert a top-level `ignores` block as the first element of `defineConfig([...])` in `apps/frontend/eslint.config.js` with `ignores: ["dist/**", ".angular/**", "coverage/**", "node_modules/**"]`.
- Kept the existing `files` blocks for `**/*.ts` and `**/*.html` unchanged.

### Testing
- Ran `npx eslint` from `apps/frontend` and verified it no longer reports files under `.angular/cache` or `dist/test-out`; the run still fails due to 5 preexisting lint errors in source files unrelated to the ignore patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3185bad848832798f33d16e52ada69)