### PR TITLE
fix(frontend): replace inline empty form callbacks

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
@@ -46,6 +46,14 @@ import {
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { SearchMethod } from '../../types/search.types';
 
+const noopAutocompleteChange = (value: string | null): void => {
+  void value;
+};
+
+const noopTouched = (): void => {
+  void undefined;
+};
+
 /**
  * Visual state of the autocomplete panel.
  *
@@ -389,12 +397,12 @@ export class AutocompleteTextboxComponent<T = unknown>
   /**
    * Callback registered by Angular Forms to propagate value changes.
    */
-  private onChange: (value: string | null) => void = () => {};
+  private onChange: (value: string | null) => void = noopAutocompleteChange;
 
   /**
    * Callback registered by Angular Forms to mark the control as touched.
    */
-  private onTouched: () => void = () => {};
+  private onTouched: () => void = noopTouched;
 
   /**
    * Creates the component and registers cleanup logic for global listeners.

--- a/apps/frontend/src/app/shared/ui/toggle-button-field/toggle-button-field.component.ts
+++ b/apps/frontend/src/app/shared/ui/toggle-button-field/toggle-button-field.component.ts
@@ -6,6 +6,14 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { FieldComponent } from '../field/field.component';
 import { createUuid } from '../../utils/uuid.utils';
 
+const noopToggleChange = (value: boolean): void => {
+  void value;
+};
+
+const noopTouched = (): void => {
+  void undefined;
+};
+
 @Component({
   selector: 'app-toggle-button-field',
   standalone: true,
@@ -58,12 +66,12 @@ export class ToggleButtonFieldComponent implements ControlValueAccessor {
   /**
    * Callback invoked by Angular forms when the control value changes.
    */
-  private onChange: (value: boolean) => void = () => {};
+  private onChange: (value: boolean) => void = noopToggleChange;
 
   /**
    * Callback invoked by Angular forms when the control is marked as touched.
    */
-  private onTouched: () => void = () => {};
+  private onTouched: () => void = noopTouched;
 
   /**
    * Receives a value from the form model and normalizes it to a boolean.


### PR DESCRIPTION
### Motivation

- Evitar cuerpos vacíos inline en los callbacks de `ControlValueAccessor` para cumplir con reglas de lint y mejorar claridad del código. 
- Mantener las firmas esperadas por Angular Forms mientras se usa una estrategia noop compatible con ESLint.

### Description

- Añadí funciones noop tipadas en `apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts` y en `apps/frontend/src/app/shared/ui/toggle-button-field/toggle-button-field.component.ts` para reemplazar cuerpos vacíos inline. 
- Reemplacé las inicializaciones privadas `onChange` y `onTouched` para que apunten a los noops reutilizables en ambos componentes. 
- Conservé exactamente las firmas esperadas por `ControlValueAccessor` (`(value: string | null) => void` y `() => void` para el autocomplete, y `(value: boolean) => void` y `() => void` para el toggle). 
- Dejé `registerOnChange` y `registerOnTouched` sin cambios para que Angular Forms continúe sobrescribiendo los callbacks proporcionados.

### Testing

- Ejecuté `npx eslint src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts src/app/shared/ui/toggle-button-field/toggle-button-field.component.ts`, el cual completó sin errores en los archivos modificados. 
- Ejecuté `npm run lint` en el paquete `apps/frontend` y la comprobación global de lint falló por un error preexistente fuera de este cambio en `apps/frontend/src/app/shared/ui/button/button.component.spec.ts` relacionado con una variable `_event` no usada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3189772ca083279ce8146969888696)