### PR TITLE
test(frontend): remove unused click event parameter

### DIFF
--- a/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
@@ -31,7 +31,7 @@ class TestHostComponent {
   styleClass = '';
   ariaLabel: string | undefined = undefined;
 
-  onClicked(_event: MouseEvent): void {
+  onClicked(): void {
     // Intentionally empty.
   }
 }


### PR DESCRIPTION
### Motivation
- Eliminar el parámetro `MouseEvent` no usado del handler de prueba para evitar declaraciones innecesarias y mantener clara la intención del test.

### Description
- Cambiado `onClicked(_event: MouseEvent): void` a `onClicked(): void` en `apps/frontend/src/app/shared/ui/button/button.component.spec.ts` y se mantuvo el binding del template `(clicked)="onClicked($event)"`.

### Testing
- `npm run build` (desde `apps/frontend`) pasó; `npx vitest run src/app/shared/ui/button/button.component.spec.ts` falló por recursos externos de `ButtonComponent` sin resolver; `npm test -- --run apps/frontend/src/app/shared/ui/button/button.component.spec.ts` falló debido a que la CLI de Angular rechazó el argumento desconocido `--run`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318d979c908327bea7f7529bf25299)