### PR TITLE
Add shared input group component

### DIFF
--- a/apps/frontend/src/app/shared/ui/input-group/input-group.component.css
+++ b/apps/frontend/src/app/shared/ui/input-group/input-group.component.css
@@ -1,0 +1,87 @@
+:host {
+    display: flex;
+    width: 100%;
+}
+
+.input-group {
+    display: inline-flex;
+    align-items: stretch;
+    width: 100%;
+}
+
+:host ::ng-deep app-input {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+:host ::ng-deep app-input input,
+:host ::ng-deep app-button .app-button,
+:host ::ng-deep [inputGroupAddon] {
+    position: relative;
+    border-radius: 0;
+}
+
+:host ::ng-deep app-input:not(:first-child) input,
+:host ::ng-deep app-button:not(:first-child) .app-button,
+:host ::ng-deep [inputGroupAddon]:not(:first-child) {
+    margin-left: calc(var(--border-width-thin) * -1);
+}
+
+:host ::ng-deep app-input:first-child input,
+:host ::ng-deep app-button:first-child .app-button,
+:host ::ng-deep [inputGroupAddon]:first-child {
+    border-top-left-radius: var(--form-control-border-radius);
+    border-bottom-left-radius: var(--form-control-border-radius);
+}
+
+:host ::ng-deep app-input:last-child input,
+:host ::ng-deep app-button:last-child .app-button,
+:host ::ng-deep [inputGroupAddon]:last-child {
+    border-top-right-radius: var(--form-control-border-radius);
+    border-bottom-right-radius: var(--form-control-border-radius);
+}
+
+:host ::ng-deep app-input:focus-within,
+:host ::ng-deep app-button:focus-within,
+:host ::ng-deep [inputGroupAddon]:focus-within {
+    z-index: 1;
+}
+
+:host ::ng-deep [inputGroupAddon] {
+    box-sizing: border-box;
+    min-width: var(--form-control-height);
+    min-height: var(--form-control-height);
+    padding-block: var(--form-control-padding-block);
+    padding-inline: var(--form-control-padding-inline);
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+
+    border: var(--form-control-border);
+    background: var(--input-group-addon-background-color, var(--form-control-background-color));
+    color: var(--input-group-addon-text-color, var(--text-secondary-color));
+    font-size: var(--form-control-text-size);
+    line-height: 1;
+    white-space: nowrap;
+}
+
+:host ::ng-deep app-button {
+    --button-height: var(--form-control-height);
+    --button-min-width: var(--form-control-height);
+    --button-padding-inline: var(--form-control-padding-inline);
+    --button-border-radius: 0;
+}
+
+:host ::ng-deep app-button .app-button {
+    box-shadow: none;
+}
+
+:host ::ng-deep app-button:not(:first-child) .app-button {
+    border-left: var(--button-border);
+}
+
+:host(.input-group--disabled) ::ng-deep [inputGroupAddon] {
+    opacity: var(--form-disabled-opacity);
+}

--- a/apps/frontend/src/app/shared/ui/input-group/input-group.component.html
+++ b/apps/frontend/src/app/shared/ui/input-group/input-group.component.html
@@ -1,0 +1,8 @@
+<div
+    class="input-group"
+    role="group"
+    [attr.aria-label]="ariaLabel()"
+    [attr.aria-labelledby]="ariaLabelledBy()"
+>
+    <ng-content></ng-content>
+</div>

--- a/apps/frontend/src/app/shared/ui/input-group/input-group.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/input-group/input-group.component.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { ButtonComponent } from '../button/button.component';
+import { InputComponent } from '../input/input.component';
+import { InputGroupComponent } from './input-group.component';
+
+@Component({
+  standalone: true,
+  imports: [InputComponent, InputGroupComponent],
+  template: `
+    <app-input-group ariaLabel="Price filter">
+      <span inputGroupAddon>$</span>
+      <app-input placeholder="Price" />
+      <span inputGroupAddon>.00</span>
+    </app-input-group>
+  `,
+})
+class TextAddonHostComponent {}
+
+@Component({
+  standalone: true,
+  imports: [ButtonComponent, InputComponent, InputGroupComponent],
+  template: `
+    <app-input-group ariaLabel="Search keyword">
+      <app-button type="submit">Search</app-button>
+      <app-input placeholder="Keyword" />
+    </app-input-group>
+  `,
+})
+class ButtonAddonHostComponent {}
+
+describe('InputGroupComponent', () => {
+  it('should group text addons with the shared input component', async () => {
+    const fixture = await createFixture(TextAddonHostComponent);
+
+    const group = fixture.debugElement.query(By.css('[role="group"]'));
+    const addons = fixture.debugElement.queryAll(By.css('[inputGroupAddon]'));
+    const input = fixture.debugElement.query(By.directive(InputComponent));
+
+    expect(group.attributes['aria-label']).toBe('Price filter');
+    expect(addons.map((addon) => addon.nativeElement.textContent.trim())).toEqual(['$', '.00']);
+    expect(input).toBeTruthy();
+  });
+
+  it('should allow the shared button component as an addon', async () => {
+    const fixture = await createFixture(ButtonAddonHostComponent);
+
+    const button = fixture.debugElement.query(By.directive(ButtonComponent));
+    const input = fixture.debugElement.query(By.directive(InputComponent));
+
+    expect(button).toBeTruthy();
+    expect(input).toBeTruthy();
+  });
+});
+
+async function createFixture<T>(component: new () => T): Promise<ComponentFixture<T>> {
+  await TestBed.configureTestingModule({ imports: [component] }).compileComponents();
+  const fixture = TestBed.createComponent(component);
+  fixture.detectChanges();
+  return fixture;
+}

--- a/apps/frontend/src/app/shared/ui/input-group/input-group.component.ts
+++ b/apps/frontend/src/app/shared/ui/input-group/input-group.component.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { booleanAttribute, Component, input } from '@angular/core';
+
+/**
+ * Horizontal group for text inputs and addons.
+ *
+ * Project addons, InputComponent and ButtonComponent instances as children to
+ * compose prefixed, suffixed, multiple-addon or button-addon fields.
+ */
+@Component({
+  selector: 'app-input-group',
+  standalone: true,
+  templateUrl: './input-group.component.html',
+  styleUrl: './input-group.component.css',
+  host: {
+    '[class.input-group--disabled]': 'disabled()',
+  },
+})
+export class InputGroupComponent {
+  /** Accessible label for the grouped input controls. */
+  readonly ariaLabel = input<string>();
+
+  /** References visible labelling text when an external label is used. */
+  readonly ariaLabelledBy = input<string>();
+
+  /** Applies a disabled visual treatment to non-form addon content. */
+  readonly disabled = input(false, { transform: booleanAttribute });
+}

--- a/apps/frontend/src/app/shared/ui/input/input.component.html
+++ b/apps/frontend/src/app/shared/ui/input/input.component.html
@@ -5,6 +5,7 @@
     [disabled]="disabled"
     [required]="required()"
     [attr.autocomplete]="autocomplete()"
+    [attr.placeholder]="placeholder()"
     [attr.aria-describedby]="ariaDescribedBy()"
     [attr.aria-labelledby]="ariaLabelledBy()"
     [attr.aria-invalid]="ariaInvalid() ? 'true' : null"

--- a/apps/frontend/src/app/shared/ui/input/input.component.ts
+++ b/apps/frontend/src/app/shared/ui/input/input.component.ts
@@ -24,6 +24,7 @@ import { createUuid } from '../../utils/uuid.utils';
 })
 export class InputComponent implements ControlValueAccessor {
   readonly autocomplete = input<string>('off');
+  readonly placeholder = input<string>('');
   readonly required = input(false, { transform: booleanAttribute });
   readonly inputId = input<string>();
   readonly ariaDescribedBy = input<string | null>(null);

--- a/apps/frontend/src/styles/03-semantics.forms.css
+++ b/apps/frontend/src/styles/03-semantics.forms.css
@@ -27,6 +27,9 @@
     --form-control-focus-ring: 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
     --form-control-height: var(--size-800);
 
+    --input-group-addon-background-color: var(--form-control-background-color);
+    --input-group-addon-text-color: var(--text-secondary-color);
+
     /* form-range        → slider */
     --form-range-text-color: var(--color-gray-800);
     --form-range-focus-ring: var(--focus-ring);


### PR DESCRIPTION
### Motivation
- Provide a reusable input group wrapper to reproduce the three first rows of the reference (text addons and buttons) while excluding check/radio controls. 
- Reuse existing `app-input` and `app-button` components so addons and button addons compose visually and semantically.

### Description
- Add a standalone `app-input-group` component with `input-group.component.ts`, template and styles to project `app-input`, `app-button` and addon nodes via `ng-content` and `inputGroupAddon`.
- Add unit tests in `input-group.component.spec.ts` to cover text addons and button addons compositions.
- Extend `app-input` to accept a `placeholder` input and propagate it in the template (`input.component.ts` / `input.component.html`).
- Add semantic CSS tokens `--input-group-addon-background-color` and `--input-group-addon-text-color` to `03-semantics.forms.css` and styles to align buttons/inputs for contiguous addon appearance.

### Testing
- Ran linter with `npm --prefix apps/frontend run lint` and it passed successfully. 
- Ran unit tests with `npm --prefix apps/frontend test -- --watch=false` and all tests passed (`161 passed`).
- Built the frontend with `npm --prefix apps/frontend run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e182ba448327a3369738f5c6818d)