### PR TITLE
Refactor autocomplete clear control to use shared InputGroup and Button

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
@@ -4,89 +4,12 @@
     min-width: 0;
 }
 
-.autocomplete {
+.autocomplete,
+.input-wrapper {
     width: 100%;
 }
 
 .autocomplete.disabled {
-    cursor: not-allowed;
-    opacity: var(--form-disabled-opacity);
-}
-
-.input-wrapper {
-    display: flex;
-    width: 100%;
-    overflow: hidden;
-
-    border: var(--form-control-border);
-    border-radius: var(--form-control-border-radius);
-
-    background: var(--form-control-background-color);
-
-    transition: box-shadow 0.2s ease;
-}
-
-.input-wrapper:focus-within {
-    box-shadow: var(--form-control-focus-ring);
-}
-
-.input-wrapper input {
-    flex: 1;
-    min-width: 0;
-
-    padding-inline: var(--form-control-padding-inline);
-    border: 0;
-    outline: 0;
-
-    background: transparent;
-    color: var(--form-control-text-color);
-
-    font-size: var(--form-control-text-size);
-    height: var(--form-control-height);
-}
-
-.input-wrapper input[readonly] {
-    cursor: default;
-}
-
-.input-wrapper input:disabled {
-    cursor: not-allowed;
-    opacity: var(--form-disabled-opacity);
-}
-
-.clear-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-
-    padding: 0 var(--autocomplete-clear-button-padding-inline);
-    border: 0;
-    border-left: var(--form-control-border);
-
-    background: var(--form-control-text-accent-color);
-    color: var(--form-control-background-color);
-
-    font-size: var(--autocomplete-clear-button-font-size);
-    line-height: 1;
-
-    cursor: pointer;
-
-    transition:
-        background-color 0.2s ease,
-        color 0.2s ease;
-}
-
-.clear-button:hover:not(:disabled) {
-    background: var(--form-control-background-color);
-    color: var(--form-control-text-accent-color);
-}
-
-.clear-button:focus-visible {
-    outline: var(--autocomplete-clear-button-focus-outline);
-    outline-offset: var(--autocomplete-clear-button-focus-outline-offset);
-}
-
-.clear-button:disabled {
     cursor: not-allowed;
     opacity: var(--form-disabled-opacity);
 }
@@ -125,10 +48,7 @@
     cursor: pointer;
 }
 
-.results li:hover {
-    background: var(--list-element-hover-background-color);
-}
-
+.results li:hover,
 .results li.active {
     background: var(--list-element-hover-background-color);
 }
@@ -155,23 +75,4 @@
 
     white-space: nowrap;
     border: 0;
-}
-
-.input-wrapper app-input {
-    flex: 1;
-    min-width: 0;
-}
-
-.input-wrapper app-input::ng-deep input {
-    width: 100%;
-    box-sizing: border-box;
-    padding-inline: var(--form-control-padding-inline);
-    border: 0;
-    outline: 0;
-    background: transparent;
-    box-shadow: none;
-}
-
-.input-wrapper app-input::ng-deep input:focus {
-    box-shadow: none;
 }

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.html
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.html
@@ -1,47 +1,49 @@
 <div class="autocomplete" [class.disabled]="disabled">
     <div class="input-wrapper" #inputWrapper cdkOverlayOrigin #trigger="cdkOverlayOrigin">
-        <app-input
-            [inputId]="controlId()"
-            type="text"
-            role="combobox"
-            autocomplete="off"
-            autocapitalize="off"
-            autocorrect="off"
-            [spellcheck]="false"
-            [placeholder]="hasSelection ? '' : emptyHint() || placeholder() || ''"
-            [formControl]="textControl"
-            [readonly]="hasSelection"
-            [ariaLabel]="ariaLabelledBy() ? null : ariaLabel() || null"
-            [ariaLabelledBy]="ariaLabelledBy() || null"
-            [ariaDescribedBy]="ariaDescribedBy() || null"
-            [ariaInvalid]="ariaInvalid()"
-            [ariaReadonly]="hasSelection ? true : null"
-            [attr.aria-disabled]="disabled ? 'true' : null"
-            [ariaExpanded]="isOverlayOpen"
-            ariaHaspopup="listbox"
-            [ariaControls]="isOverlayOpen ? resultsListId : null"
-            [ariaActiveDescendant]="
-                isOverlayOpen && activeIndex >= 0 && results.length > 0
-                    ? getOptionId(activeIndex)
-                    : null
-            "
-            [ariaBusy]="isLoading"
-            [ariaAutocomplete]="hasSelection ? null : 'list'"
-            (blur)="handleBlur()"
-            (keydown)="onInputKeydown($event)"
-        />
+        <app-input-group [disabled]="disabled">
+            <app-input
+                [inputId]="controlId()"
+                type="text"
+                role="combobox"
+                autocomplete="off"
+                autocapitalize="off"
+                autocorrect="off"
+                [spellcheck]="false"
+                [placeholder]="hasSelection ? '' : emptyHint() || placeholder() || ''"
+                [formControl]="textControl"
+                [readonly]="hasSelection"
+                [ariaLabel]="ariaLabelledBy() ? null : ariaLabel() || null"
+                [ariaLabelledBy]="ariaLabelledBy() || null"
+                [ariaDescribedBy]="ariaDescribedBy() || null"
+                [ariaInvalid]="ariaInvalid()"
+                [ariaReadonly]="hasSelection ? true : null"
+                [attr.aria-disabled]="disabled ? 'true' : null"
+                [ariaExpanded]="isOverlayOpen"
+                ariaHaspopup="listbox"
+                [ariaControls]="isOverlayOpen ? resultsListId : null"
+                [ariaActiveDescendant]="
+                    isOverlayOpen && activeIndex >= 0 && results.length > 0
+                        ? getOptionId(activeIndex)
+                        : null
+                "
+                [ariaBusy]="isLoading"
+                [ariaAutocomplete]="hasSelection ? null : 'list'"
+                (blur)="handleBlur()"
+                (keydown)="onInputKeydown($event)"
+            />
 
-        @if (hasSelection) {
-            <button
-                type="button"
-                class="clear-button"
-                [attr.aria-label]="clearButtonAriaLabel() || ('actions.clearSelection' | translate)"
-                [disabled]="disabled"
-                (click)="clearSelection()"
-            >
-                ✕
-            </button>
-        }
+            @if (hasSelection) {
+                <app-button
+                    type="button"
+                    [icon]="true"
+                    [disabled]="disabled"
+                    [ariaLabel]="clearButtonAriaLabel() || ('actions.clearSelection' | translate)"
+                    (clicked)="clearSelection()"
+                >
+                    ✕
+                </app-button>
+            }
+        </app-input-group>
     </div>
 
     <div class="sr-only" [id]="statusMessageId" role="status" aria-live="polite" aria-atomic="true">

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
@@ -162,7 +162,7 @@ describe('AutocompleteTextboxComponent', () => {
     expect(input.readOnly).toBe(true);
     expect(input.value).toBe('madr-1');
     expect(component.isOverlayOpen).toBe(false);
-    expect(fixture.debugElement.query(By.css('.clear-button'))).not.toBeNull();
+    expect(fixture.debugElement.query(By.css('app-button button'))).not.toBeNull();
     expect(onChangeSpy).toHaveBeenCalledTimes(1);
     expect(onChangeSpy).toHaveBeenCalledWith('madr-1');
     expect(selectedChangeSpy).toHaveBeenCalledTimes(1);
@@ -229,7 +229,7 @@ describe('AutocompleteTextboxComponent', () => {
     expect(component.selectedValue).toBe('valor fijo');
     expect(input.value).toBe('valor fijo');
     expect(input.readOnly).toBe(true);
-    expect(fixture.debugElement.query(By.css('.clear-button'))).not.toBeNull();
+    expect(fixture.debugElement.query(By.css('app-button button'))).not.toBeNull();
   });
 
   it('should keep fallback text without selection when resolveByValue returns null', async () => {
@@ -245,7 +245,7 @@ describe('AutocompleteTextboxComponent', () => {
     expect(component.selectedValue).toBeNull();
     expect(input.value).toBe('texto externo');
     expect(input.readOnly).toBe(false);
-    expect(fixture.debugElement.query(By.css('.clear-button'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('app-button button'))).toBeNull();
   });
 
   it('should clear selection, hide clear button and make input editable again', async () => {
@@ -257,7 +257,7 @@ describe('AutocompleteTextboxComponent', () => {
     fixture.detectChanges();
 
     const clearButton: HTMLButtonElement = fixture.debugElement.query(
-      By.css('.clear-button'),
+      By.css('app-button button'),
     ).nativeElement;
 
     clearButton.click();
@@ -269,7 +269,7 @@ describe('AutocompleteTextboxComponent', () => {
     expect(input.readOnly).toBe(false);
     expect(input.value).toBe('');
     expect(component.textControl.value).toBe('');
-    expect(fixture.debugElement.query(By.css('.clear-button'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('app-button button'))).toBeNull();
   });
 
   it('should show empty hint when no value is selected', () => {

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
@@ -45,7 +45,9 @@ import {
 } from 'rxjs';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { SearchMethod } from '../../types/search.types';
+import { ButtonComponent } from '../button/button.component';
 import { InputComponent } from '../input/input.component';
+import { InputGroupComponent } from '../input-group/input-group.component';
 
 const noopAutocompleteChange = (value: string | null): void => {
   void value;
@@ -121,7 +123,15 @@ interface ResolvedWriteValue<T> {
 @Component({
   selector: 'app-autocomplete-textbox',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, OverlayModule, TranslatePipe, InputComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    OverlayModule,
+    TranslatePipe,
+    InputComponent,
+    InputGroupComponent,
+    ButtonComponent,
+  ],
   templateUrl: './autocomplete-textbox.component.html',
   styleUrls: ['./autocomplete-textbox.component.css'],
   providers: [


### PR DESCRIPTION
### Motivation

- Replace a native, component-specific clear button with the shared `app-button` and `app-input-group` to ensure consistent visuals and behavior across the UI library.
- Keep a stable overlay origin element for correct `overlayWidth` calculation (the overlay width is derived from `inputWrapper.nativeElement`).
- Remove duplicated layout/focus/border CSS and `::ng-deep` hacks that are already provided by `InputGroupComponent` to centralize styling and reduce maintenance.

### Description

- Added imports for the shared components by including `InputGroupComponent` and `ButtonComponent` in the component `imports` array of `AutocompleteTextboxComponent` and imported them at the top of the file.
- Updated the template to wrap the existing `app-input` in an `app-input-group [disabled]="disabled"` while preserving the outer `.input-wrapper` element with `#inputWrapper cdkOverlayOrigin #trigger="cdkOverlayOrigin"` so overlay sizing remains stable.
- Replaced the native `<button class="clear-button">` with `<app-button type="button" [icon]="true" (clicked)="clearSelection()" [disabled]="disabled" [ariaLabel]="clearButtonAriaLabel() || ('actions.clearSelection' | translate)">✕</app-button>` and kept the same clear behavior and ARIA label.
- Simplified `autocomplete-textbox.component.css` by removing duplicated group/input/button rules and `::ng-deep` overrides, leaving only autocomplete-specific rules (host width, overlay/list/messages, disabled state and minimal hover/active behavior).
- Updated tests in `autocomplete-textbox.component.spec.ts` to locate the clear control via `app-button button` (or by accessible label) instead of the removed `.clear-button` selector.

### Testing

- Ran the component unit tests with `npm test -- --watch=false --include src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts`, which built and executed the spec bundle and reported the single spec file with all tests passing (1 test file, 20 tests passed).
- An initial `npm test` attempt using the `apps/frontend`-prefixed `--include` pattern reported no matching tests due to include path mismatch, so the corrected include path above was used to run the tests successfully.
- Ran linting with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32fb9c1db88327ac076574504309e8)