### PR TITLE
fix(frontend): preserve initial autocomplete writes

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts
@@ -2,14 +2,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Observable, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AutocompleteTextboxComponent } from './autocomplete-textbox.component';
 import { MockTranslateService } from '../../../../testing/mock-translate.service';
+
+interface TestOption {
+  code: string;
+  label: string;
+}
+
+@Component({
+  standalone: true,
+  imports: [ReactiveFormsModule, AutocompleteTextboxComponent],
+  template: `
+    <app-autocomplete-textbox
+      [formControl]="control"
+      [searchMethod]="searchMethod"
+      [resolveByValue]="resolveByValue"
+      [displayWith]="displayWith"
+      [valueWith]="valueWith"
+      ariaLabel="Country"
+    />
+  `,
+})
+class InitialValueHostComponent {
+  readonly control = new FormControl<string | null>('es');
+  readonly searchMethod = vi.fn<(query: string) => Observable<TestOption[]>>(() => of([]));
+  readonly resolveByValue = vi.fn<(value: string) => Observable<TestOption | null>>(
+    (value: string) => of(value === 'es' ? { code: 'es', label: 'España' } : null),
+  );
+  readonly displayWith = (option: TestOption): string => option.label;
+  readonly valueWith = (option: TestOption): string => option.code;
+}
 
 describe('AutocompleteTextboxComponent', () => {
   let fixture: ComponentFixture<AutocompleteTextboxComponent<string>>;
@@ -27,7 +58,7 @@ describe('AutocompleteTextboxComponent', () => {
     });
 
     await TestBed.configureTestingModule({
-      imports: [AutocompleteTextboxComponent],
+      imports: [AutocompleteTextboxComponent, InitialValueHostComponent],
       providers: [{ provide: TranslateService, useClass: MockTranslateService }],
     }).compileComponents();
 
@@ -214,6 +245,22 @@ describe('AutocompleteTextboxComponent', () => {
     expect(component.selectedValue).toBeNull();
     expect(component.isOverlayOpen).toBe(false);
     expect(overlayContainerElement.querySelector('.results')).toBeNull();
+  });
+
+  it('should rebuild visible text from a FormControl initial value before first detectChanges', () => {
+    const hostFixture = TestBed.createComponent(InitialValueHostComponent);
+    const hostComponent = hostFixture.componentInstance;
+
+    expect(hostComponent.resolveByValue).not.toHaveBeenCalled();
+
+    hostFixture.detectChanges();
+
+    const input: HTMLInputElement = hostFixture.debugElement.query(By.css('input')).nativeElement;
+
+    expect(hostComponent.resolveByValue).toHaveBeenCalledTimes(1);
+    expect(hostComponent.resolveByValue).toHaveBeenCalledWith('es');
+    expect(input.value).toBe('España');
+    expect(input.readOnly).toBe(true);
   });
 
   it('should resolve external value into a selected option when writeValue is used', async () => {

--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
@@ -28,6 +28,7 @@ import {
 } from '@angular/forms';
 import {
   Observable,
+  ReplaySubject,
   Subject,
   catchError,
   debounceTime,
@@ -273,7 +274,7 @@ export class AutocompleteTextboxComponent<T = unknown>
   /**
    * Internal stream used to serialize external writes received through {@link writeValue}.
    */
-  private readonly writeValueRequests$ = new Subject<string | null>();
+  private readonly writeValueRequests$ = new ReplaySubject<string | null>(1);
 
   /**
    * Stream used to invalidate ongoing asynchronous searches when component state


### PR DESCRIPTION
### Motivation
- External `ControlValueAccessor` writes could be emitted before the internal write pipeline was subscribed, causing initial values from a parent `FormControl` to be lost and visible text not rebuilt via `resolveByValue`.

### Description
- Replace the internal `writeValueRequests$` `Subject<string | null>` with a `ReplaySubject<string | null>(1)` to retain the most recent write until the pipeline subscribes. 
- Import `ReplaySubject` from `rxjs` and update the declaration to `private readonly writeValueRequests$ = new ReplaySubject<string | null>(1);` in `autocomplete-textbox.component.ts`.
- Add a host test component (`InitialValueHostComponent`) and a regression test in `autocomplete-textbox.component.spec.ts` that initializes a `FormControl` before the first `detectChanges()` and verifies `resolveByValue` is invoked and the input displays the reconstructed label in read-only mode.
- Update the test module to include `ReactiveFormsModule` and the host component so the initial-FormControl scenario is exercised.

### Testing
- Ran the focused spec with `npx ng test --watch=false --include=src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.spec.ts` and it completed successfully. 
- Test summary: `Test Files  1 passed (1)` and `Tests  21 passed (21)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330935a2b88327a2099ff0e2e2c098)