### PR TITLE
fix(frontend): coerce button boolean attributes

### DIFF
--- a/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/button/button.component.spec.ts
@@ -35,6 +35,27 @@ class TestHostComponent {
     void _event;
   }
 }
+@Component({
+  standalone: true,
+  imports: [ButtonComponent],
+  template: `
+    <app-button disabled>
+      Save
+    </app-button>
+  `,
+})
+class DisabledAttributeHostComponent {}
+
+@Component({
+  standalone: true,
+  imports: [ButtonComponent],
+  template: `
+    <app-button icon>
+      Save
+    </app-button>
+  `,
+})
+class IconAttributeHostComponent {}
 
 describe('ButtonComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
@@ -42,7 +63,7 @@ describe('ButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
+      imports: [TestHostComponent, DisabledAttributeHostComponent, IconAttributeHostComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -73,6 +94,22 @@ describe('ButtonComponent', () => {
 
     const buttonEl = getButton();
     expect(buttonEl.disabled).toBe(true);
+  });
+
+  it('should disable the button when disabled is provided as an attribute', () => {
+    const attributeFixture = TestBed.createComponent(DisabledAttributeHostComponent);
+    attributeFixture.detectChanges();
+
+    const buttonEl: HTMLButtonElement = attributeFixture.nativeElement.querySelector('button');
+    expect(buttonEl.disabled).toBe(true);
+  });
+
+  it('should render the icon class when icon is provided as an attribute', () => {
+    const attributeFixture = TestBed.createComponent(IconAttributeHostComponent);
+    attributeFixture.detectChanges();
+
+    const buttonEl: HTMLButtonElement = attributeFixture.nativeElement.querySelector('button');
+    expect(buttonEl.classList).toContain('app-button--icon');
   });
 
   it('should expose aria-label when provided', () => {

--- a/apps/frontend/src/app/shared/ui/button/button.component.ts
+++ b/apps/frontend/src/app/shared/ui/button/button.component.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Component, input, output } from '@angular/core';
+import { booleanAttribute, Component, input, output } from '@angular/core';
 
 /**
  * Visual intent styles that can be applied to the button.
@@ -34,14 +34,14 @@ export class ButtonComponent {
   /**
    * Whether user interaction is disabled.
    */
-  readonly disabled = input<boolean>(false);
+  readonly disabled = input(false, { transform: booleanAttribute });
 
   /**
    * Whether the button is rendered as an icon-only button.
    *
    * Icon buttons are square, centered and require an accessible label.
    */
-  readonly icon = input<boolean>(false);
+  readonly icon = input(false, { transform: booleanAttribute });
 
   /**
    * Extra CSS classes appended to the root button element.


### PR DESCRIPTION
### Motivation
- Ensure attribute-only usage like `<app-button disabled>` and `<app-button icon>` is coerced to boolean values so the component behaves the same for attribute and bound inputs.
- Add coverage verifying attribute syntax works in the component tests.

### Description
- Import `booleanAttribute` from `@angular/core` and apply it as a transform for the boolean inputs.
- Change `readonly disabled = input<boolean>(false);` to `readonly disabled = input(false, { transform: booleanAttribute });`.
- Change `readonly icon = input<boolean>(false);` to `readonly icon = input(false, { transform: booleanAttribute });`.
- Add `DisabledAttributeHostComponent` and `IconAttributeHostComponent` and new specs that assert attribute-style `disabled` disables the native button and attribute-style `icon` adds the `app-button--icon` class.

### Testing
- Ran `cd apps/frontend && npm test -- --watch=false` (Angular test runner) and the full test suite passed with all tests green (`169 passed`).
- Ran `cd apps/frontend && npm run lint` and linting completed successfully with no errors.
- Running the spec directly with `npx vitest run src/app/shared/ui/button/button.component.spec.ts` reported a component resource resolution error when invoked in isolation, but the project test runner (`npm test`) succeeded for the full suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330ad363688327a064655f05877386)