### PR TITLE
Ensure search bar IDs are unique per instance

### DIFF
--- a/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.spec.ts
@@ -107,6 +107,24 @@ describe('SearchBarComponent', () => {
     expect(component).toBeTruthy();
   });
 
+
+  it('should generate unique input and help text IDs for each component instance', async () => {
+    const firstFixture = await createComponent();
+    const secondFixture = await createComponent();
+
+    const firstInput = getInput(firstFixture);
+    const secondInput = getInput(secondFixture);
+    const firstHelpTextId = firstInput.getAttribute('aria-describedby');
+    const secondHelpTextId = secondInput.getAttribute('aria-describedby');
+
+    expect(firstInput.id).toMatch(/^search-bar-.+-input$/);
+    expect(secondInput.id).toMatch(/^search-bar-.+-input$/);
+    expect(firstHelpTextId).toMatch(/^search-bar-.+-help$/);
+    expect(secondHelpTextId).toMatch(/^search-bar-.+-help$/);
+    expect(firstInput.id).not.toBe(secondInput.id);
+    expect(firstHelpTextId).not.toBe(secondHelpTextId);
+  });
+
   it('should render the shared button component as a submit button', async () => {
     fixture = await createComponent();
 

--- a/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.ts
+++ b/apps/frontend/src/app/shared/ui/search-bar/search-bar.component.ts
@@ -11,6 +11,7 @@ import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
 import { ButtonComponent } from '../button/button.component';
 import { InputComponent } from '../input/input.component';
+import { createUuid } from '../../utils/uuid.utils';
 import { InputGroupComponent } from '../input-group/input-group.component';
 
 /**
@@ -32,6 +33,7 @@ import { InputGroupComponent } from '../input-group/input-group.component';
 })
 export class SearchBarComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
+  private readonly instanceId = createUuid();
 
   /**
    * Debounce time, in milliseconds, applied to user typing.
@@ -56,12 +58,12 @@ export class SearchBarComponent implements OnInit {
   /**
    * DOM identifier of the main input element.
    */
-  protected readonly inputId = 'search-bar-input';
+  protected readonly inputId = `search-bar-${this.instanceId}-input`;
 
   /**
    * DOM identifier of the hidden helper text associated with the input.
    */
-  protected readonly helpTextId = 'search-bar-help';
+  protected readonly helpTextId = `search-bar-${this.instanceId}-help`;
 
   /**
    * Reactive control bound to the visible search input.


### PR DESCRIPTION
### Motivation
- Prevent DOM ID collisions and improve accessibility when multiple `SearchBarComponent` instances are rendered on the same page by generating per-instance IDs instead of using fixed IDs.

### Description
- Import `createUuid` and add a private `instanceId = createUuid()` to `SearchBarComponent`.
- Replace the fixed `inputId = 'search-bar-input'` with ``inputId = `search-bar-${this.instanceId}-input` `` and replace `helpTextId = 'search-bar-help'` with ``helpTextId = `search-bar-${this.instanceId}-help` `` in `apps/frontend/src/app/shared/ui/search-bar/search-bar.component.ts`.
- Add a unit test in `apps/frontend/src/app/shared/ui/search-bar/search-bar.component.spec.ts` that creates two component instances and asserts their input IDs and `aria-describedby` help-text IDs match the expected pattern and are distinct.

### Testing
- Ran the unit test file with `cd apps/frontend && npm test -- --watch=false --include=src/app/shared/ui/search-bar/search-bar.component.spec.ts` and all tests passed (`Test Files 1 passed`, `Tests 15 passed`).
- Ran linting with `cd apps/frontend && npm run lint -- --fix=false` and the linter passed (`All files pass linting`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330c85addc8327a97a2e5a85719c19)