### PR TITLE
fix(frontend): guard clock browser APIs

### DIFF
--- a/apps/frontend/src/app/shared/ui/clock/clock.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.spec.ts
@@ -1,6 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
+import { PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -85,6 +86,29 @@ describe('ClockComponent', () => {
     vi.advanceTimersByTime(1000);
 
     expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should not start a browser interval when rendered on the server', async () => {
+    fixture.destroy();
+    TestBed.resetTestingModule();
+
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+    const fmtSpy = vi.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('10:15:30');
+
+    await TestBed.configureTestingModule({
+      imports: [ClockComponent],
+      providers: [{ provide: PLATFORM_ID, useValue: 'server' }],
+    }).compileComponents();
+
+    const serverFixture = TestBed.createComponent(ClockComponent);
+    serverFixture.componentRef.setInput('locale', 'en-US');
+    serverFixture.detectChanges();
+
+    expect(fmtSpy).toHaveBeenCalledWith('en-US', expect.objectContaining({ hour12: false }));
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+
+    expect(() => serverFixture.componentInstance.ngOnDestroy()).not.toThrow();
+    serverFixture.destroy();
   });
 
   it('should clear the interval on destroy', () => {

--- a/apps/frontend/src/app/shared/ui/clock/clock.component.ts
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.ts
@@ -1,7 +1,8 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Component, OnInit, OnDestroy, input } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, OnInit, OnDestroy, PLATFORM_ID, inject, input } from '@angular/core';
 
 /**
  * Displays the current local time and refreshes it every second.
@@ -19,7 +20,7 @@ import { Component, OnInit, OnDestroy, input } from '@angular/core';
 export class ClockComponent implements OnInit, OnDestroy {
   /**
    * Preferred BCP 47 locale used to format the visual time string.
-   * If not provided, the component falls back to `navigator.language`.
+   * If not provided, the component falls back to the browser locale or `en-US`.
    */
   readonly locale = input<string>();
 
@@ -46,28 +47,40 @@ export class ClockComponent implements OnInit, OnDestroy {
   /**
    * Internal interval handle used to stop periodic updates on destroy.
    */
-  private timerId?: number;
+  private readonly platformId = inject(PLATFORM_ID);
+
+  /**
+   * Whether browser-only APIs can be used safely.
+   */
+  private readonly isBrowser = isPlatformBrowser(this.platformId);
+
+  private timerId?: ReturnType<typeof setInterval>;
 
   /**
    * Initializes the clock and starts a one-second refresh interval.
    */
   ngOnInit(): void {
     this.updateTime();
-    this.timerId = window.setInterval(() => this.updateTime(), 1000);
+
+    if (this.isBrowser) {
+      this.timerId = window.setInterval(() => this.updateTime(), 1000);
+    }
   }
 
   /**
    * Stops the internal timer when the component is destroyed.
    */
   ngOnDestroy(): void {
-    if (this.timerId) clearInterval(this.timerId);
+    if (this.timerId !== undefined) {
+      clearInterval(this.timerId);
+    }
   }
 
   /**
    * Recomputes the formatted and machine-readable current time values.
    */
   private updateTime(): void {
-    const currentLocale = this.locale() ?? navigator.language;
+    const currentLocale = this.locale() ?? globalThis.navigator?.language ?? 'en-US';
     const now = new Date();
 
     this.time = now.toLocaleTimeString(currentLocale, {


### PR DESCRIPTION
### Motivation
- Evitar fallos en entornos sin APIs de navegador (SSR) y asegurar que el componente no use `window`/`navigator` cuando no estén disponibles.
- Asegurar que el temporizador se inicia solo en navegador y que `ngOnDestroy()` limpia el intervalo de forma segura.

### Description
- Inyecta `PLATFORM_ID` con `inject(PLATFORM_ID)` y calcula `isPlatformBrowser(this.platformId)` para detectar el entorno de ejecución.
- Si no es navegador, evita llamar a `window.setInterval` y mantiene el temporizador no inicializado; el tipo de `timerId` cambia a `ReturnType<typeof setInterval>`.
- Reemplaza acceso directo a `navigator.language` por `globalThis.navigator?.language ?? 'en-US'` para un fallback seguro.
- Actualiza `ngOnDestroy()` para llamar a `clearInterval` solo cuando `timerId` exista y añade un test que simula ejecución en servidor para verificar que no se inicia el intervalo.

### Testing
- Ejecutadas las pruebas unitarias con `npm test -- --include src/app/shared/ui/clock/clock.component.spec.ts --watch=false` y la suite correspondiente pasó: 1 fichero, 9 tests OK.
- Se verificó el formato con `npx prettier --check` y se aplicó `npx prettier --write` para corregir el estilo, y la comprobación final fue satisfactoria.
- Se ejecutó `npx ng lint` y no se encontraron problemas de linting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330e86cd708327b04b0018ca2b8a44)