### PR TITLE
Add keyboard navigation for tabs

### DIFF
--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
@@ -1,29 +1,31 @@
 <div class="tabs" role="tablist" aria-label="Tabs navigation">
-    @for (tabItem of tabItems(); track $index; let index = $index) {
-        <button
-            type="button"
-            class="tabs-trigger"
-            role="tab"
-            [id]="triggerId(index)"
-            [attr.aria-controls]="panelId(index)"
-            [attr.aria-selected]="activeIndex() === index"
-            [class.tabs-trigger-active]="activeIndex() === index"
-            (click)="selectTab(index)"
-        >
-            {{ tabItem.label() }}
-        </button>
-    }
+  @for (tabItem of tabItems(); track $index; let index = $index) {
+    <button
+      type="button"
+      class="tabs-trigger"
+      role="tab"
+      [id]="triggerId(index)"
+      [attr.aria-controls]="panelId(index)"
+      [attr.aria-selected]="activeIndex() === index"
+      [attr.tabindex]="activeIndex() === index ? 0 : -1"
+      [class.tabs-trigger-active]="activeIndex() === index"
+      (click)="selectTab(index)"
+      (keydown)="onTabKeydown($event, index)"
+    >
+      {{ tabItem.label() }}
+    </button>
+  }
 </div>
 
 @for (tabItem of tabItems(); track $index; let index = $index) {
-    @if (isLoaded(index) && activeIndex() === index) {
-        <section
-            class="tabs-panel"
-            role="tabpanel"
-            [id]="panelId(index)"
-            [attr.aria-labelledby]="triggerId(index)"
-        >
-            <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
-        </section>
-    }
+  @if (isLoaded(index) && activeIndex() === index) {
+    <section
+      class="tabs-panel"
+      role="tabpanel"
+      [id]="panelId(index)"
+      [attr.aria-labelledby]="triggerId(index)"
+    >
+      <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
+    </section>
+  }
 }

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.spec.ts
@@ -66,7 +66,8 @@ describe('TabsComponent', () => {
 
   it('should lazy-load a panel only when its tab is clicked', () => {
     const firstTabs = fixture.nativeElement.querySelector('#tabs-a');
-    const tabButtons: NodeListOf<HTMLButtonElement> = firstTabs.querySelectorAll('button[role="tab"]');
+    const tabButtons: NodeListOf<HTMLButtonElement> =
+      firstTabs.querySelectorAll('button[role="tab"]');
 
     tabButtons[1].click();
     fixture.detectChanges();
@@ -76,8 +77,10 @@ describe('TabsComponent', () => {
   });
 
   it('should generate unique ids across different app-tabs instances', () => {
-    const tabElements: NodeListOf<HTMLElement> = fixture.nativeElement.querySelectorAll('[role="tab"]');
-    const panelElements: NodeListOf<HTMLElement> = fixture.nativeElement.querySelectorAll('[role="tabpanel"]');
+    const tabElements: NodeListOf<HTMLElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    const panelElements: NodeListOf<HTMLElement> =
+      fixture.nativeElement.querySelectorAll('[role="tabpanel"]');
 
     const tabIds = Array.from(tabElements, (tab) => tab.id);
     const panelIds = Array.from(panelElements, (panel) => panel.id);
@@ -99,5 +102,64 @@ describe('TabsComponent', () => {
       expect(labelledById).toBeTruthy();
       expect(fixture.nativeElement.querySelector(`#${labelledById}`)).toBeTruthy();
     });
+  });
+
+  it('should navigate tabs with ArrowRight and ArrowLeft', () => {
+    const firstTabs = fixture.nativeElement.querySelector('#tabs-a');
+    const tabButtons: NodeListOf<HTMLButtonElement> =
+      firstTabs.querySelectorAll('button[role="tab"]');
+
+    tabButtons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(tabButtons[1].getAttribute('aria-selected')).toBe('true');
+    expect(tabButtons[1].getAttribute('tabindex')).toBe('0');
+    expect(firstTabs.querySelector('.details-content')).toBeTruthy();
+    expect(document.activeElement).toBe(tabButtons[1]);
+
+    tabButtons[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(tabButtons[0].getAttribute('aria-selected')).toBe('true');
+    expect(tabButtons[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(tabButtons[0]);
+  });
+
+  it('should wrap arrow key navigation between first and last tabs', () => {
+    const firstTabs = fixture.nativeElement.querySelector('#tabs-a');
+    const tabButtons: NodeListOf<HTMLButtonElement> =
+      firstTabs.querySelectorAll('button[role="tab"]');
+
+    tabButtons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(tabButtons[1].getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(tabButtons[1]);
+
+    tabButtons[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(tabButtons[0].getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(tabButtons[0]);
+  });
+
+  it('should navigate to first and last tabs with Home and End', () => {
+    const firstTabs = fixture.nativeElement.querySelector('#tabs-a');
+    const tabButtons: NodeListOf<HTMLButtonElement> =
+      firstTabs.querySelectorAll('button[role="tab"]');
+
+    tabButtons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(tabButtons[1].getAttribute('aria-selected')).toBe('true');
+    expect(tabButtons[1].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(tabButtons[1]);
+
+    tabButtons[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(tabButtons[0].getAttribute('aria-selected')).toBe('true');
+    expect(tabButtons[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(tabButtons[0]);
   });
 });

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, contentChildren, signal } from '@angular/core';
+import { Component, ElementRef, contentChildren, inject, signal } from '@angular/core';
 import { createUuid } from '../../utils/uuid.utils';
 import { TabItemDirective } from './tab-item.directive';
 
@@ -20,6 +20,8 @@ import { TabItemDirective } from './tab-item.directive';
   styleUrls: ['./tabs.component.css'],
 })
 export class TabsComponent {
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
   readonly tabItems = contentChildren(TabItemDirective);
 
   readonly activeIndex = signal(0);
@@ -29,12 +31,55 @@ export class TabsComponent {
   private readonly loadedIndices = signal<Set<number>>(new Set([0]));
 
   selectTab(index: number): void {
+    this.activateTab(index);
+  }
+
+  onTabKeydown(event: KeyboardEvent, index: number): void {
+    // Currently tabs are horizontal. If configurable orientation is added,
+    // route vertical tablists through ArrowUp/ArrowDown and keep Home/End.
+    const tabCount = this.tabItems().length;
+
+    if (tabCount === 0) {
+      return;
+    }
+
+    let nextIndex: number;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = (index + 1) % tabCount;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (index - 1 + tabCount) % tabCount;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = tabCount - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    this.activateTab(nextIndex);
+    this.focusTab(nextIndex);
+  }
+
+  private activateTab(index: number): void {
     this.activeIndex.set(index);
     this.loadedIndices.update((loaded) => {
       const next = new Set(loaded);
       next.add(index);
       return next;
     });
+  }
+
+  private focusTab(index: number): void {
+    const tabs =
+      this.elementRef.nativeElement.querySelectorAll<HTMLButtonElement>('button[role="tab"]');
+    tabs.item(index)?.focus();
   }
 
   isLoaded(index: number): boolean {


### PR DESCRIPTION
### Motivation
- Hacer que los componentes de pestañas sean accesibles mediante teclado y cumplir con las expectativas de usuarios que navegan con flechas, `Home` y `End`.
- Evitar que múltiples pestañas sean enfocables por tabulación usando un roving `tabindex` para que solo la pestaña activa reciba foco por defecto.

### Description
- Añadido ` [attr.tabindex]="activeIndex() === index ? 0 : -1"` y `(keydown)="onTabKeydown($event, index)"` a cada botón con `role="tab"` en `tabs.component.html` para controlar el foco y capturar eventos de teclado.
- Implementado `onTabKeydown` en `tabs.component.ts` que soporta `ArrowRight`, `ArrowLeft`, `Home` y `End`, calcula el índice siguiente (incluyendo wrapping), previene el comportamiento por defecto, actualiza `activeIndex` y marca el índice como cargado.
- Agregada inyección de `ElementRef` y la función `focusTab` para mover el foco al botón activo tras la navegación por teclado.
- Añadidos tests en `tabs.component.spec.ts` que verifican navegación con `ArrowRight`/`ArrowLeft`, wrapping entre primeros/últimos y navegación con `Home`/`End`, además de comprobar `aria-selected`, `tabindex`, lazy-load y gestión de foco.

### Testing
- Ejecutado `npm test -- --include='**/tabs.component.spec.ts' --watch=false`, que pasó con 1 fichero de pruebas y 7 tests exitosos.
- Ejecutado `npm run lint`, que completó satisfactoriamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3310d5b0948327b3f21a9f6085fc46)