### PR TITLE
Homogenize shared UI Angular 21 patterns

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.ts
@@ -134,7 +134,7 @@ interface ResolvedWriteValue<T> {
     ButtonComponent,
   ],
   templateUrl: './autocomplete-textbox.component.html',
-  styleUrls: ['./autocomplete-textbox.component.css'],
+  styleUrl: './autocomplete-textbox.component.css',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/apps/frontend/src/app/shared/ui/card/card.component.html
+++ b/apps/frontend/src/app/shared/ui/card/card.component.html
@@ -8,8 +8,8 @@
             @if (title()) {
                 <h3 [id]="titleElementId" class="app-card-title">{{ title() }}</h3>
             }
-            @if (headerTpl) {
-                <ng-container [ngTemplateOutlet]="headerTpl"></ng-container>
+            @if (headerTpl()) {
+                <ng-container [ngTemplateOutlet]="headerTpl()"></ng-container>
             }
         </header>
     }
@@ -20,7 +20,7 @@
 
     @if (hasFooter) {
         <footer class="app-card-footer">
-            <ng-container [ngTemplateOutlet]="footerTpl"></ng-container>
+            <ng-container [ngTemplateOutlet]="footerTpl()"></ng-container>
         </footer>
     }
 </section>

--- a/apps/frontend/src/app/shared/ui/card/card.component.ts
+++ b/apps/frontend/src/app/shared/ui/card/card.component.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, ContentChild, TemplateRef, input } from '@angular/core';
+import { Component, TemplateRef, contentChild, input } from '@angular/core';
 import { createUuid } from '../../utils/uuid.utils';
 
 /**
@@ -22,7 +22,7 @@ import { createUuid } from '../../utils/uuid.utils';
   standalone: true,
   imports: [NgTemplateOutlet],
   templateUrl: './card.component.html',
-  styleUrls: ['./card.component.css'],
+  styleUrl: './card.component.css',
 })
 export class CardComponent {
   readonly titleElementId = `card-${createUuid()}-title`;
@@ -51,14 +51,16 @@ export class CardComponent {
   /**
    * Optional projected template rendered inside the header container.
    */
-  @ContentChild('cardHeader', { read: TemplateRef })
-  headerTpl?: TemplateRef<unknown>;
+  readonly headerTpl = contentChild<string, TemplateRef<unknown>>('cardHeader', {
+    read: TemplateRef,
+  });
 
   /**
    * Optional projected template rendered inside the footer container.
    */
-  @ContentChild('cardFooter', { read: TemplateRef })
-  footerTpl?: TemplateRef<unknown>;
+  readonly footerTpl = contentChild<string, TemplateRef<unknown>>('cardFooter', {
+    read: TemplateRef,
+  });
 
   /**
    * Indicates whether the card header should be rendered.
@@ -67,13 +69,13 @@ export class CardComponent {
    * template.</p>
    */
   get hasHeader(): boolean {
-    return !!this.headerTpl || !!this.title();
+    return !!this.headerTpl() || !!this.title();
   }
 
   /**
    * Indicates whether the card footer should be rendered.
    */
   get hasFooter(): boolean {
-    return !!this.footerTpl;
+    return !!this.footerTpl();
   }
 }

--- a/apps/frontend/src/app/shared/ui/clock/clock.component.ts
+++ b/apps/frontend/src/app/shared/ui/clock/clock.component.ts
@@ -15,7 +15,7 @@ import { Component, OnInit, OnDestroy, PLATFORM_ID, inject, input } from '@angul
   selector: 'app-clock',
   standalone: true,
   templateUrl: './clock.component.html',
-  styleUrls: ['./clock.component.css'],
+  styleUrl: './clock.component.css',
 })
 export class ClockComponent implements OnInit, OnDestroy {
   /**

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.html
@@ -1,31 +1,31 @@
 <div class="tabs" role="tablist" aria-label="Tabs navigation">
-  @for (tabItem of tabItems(); track $index; let index = $index) {
-    <button
-      type="button"
-      class="tabs-trigger"
-      role="tab"
-      [id]="triggerId(index)"
-      [attr.aria-controls]="panelId(index)"
-      [attr.aria-selected]="activeIndex() === index"
-      [attr.tabindex]="activeIndex() === index ? 0 : -1"
-      [class.tabs-trigger-active]="activeIndex() === index"
-      (click)="selectTab(index)"
-      (keydown)="onTabKeydown($event, index)"
-    >
-      {{ tabItem.label() }}
-    </button>
-  }
+    @for (tabItem of tabItems(); track $index; let index = $index) {
+        <button
+            type="button"
+            class="tabs-trigger"
+            role="tab"
+            [id]="triggerId(index)"
+            [attr.aria-controls]="panelId(index)"
+            [attr.aria-selected]="activeIndex() === index"
+            [attr.tabindex]="activeIndex() === index ? 0 : -1"
+            [class.tabs-trigger-active]="activeIndex() === index"
+            (click)="selectTab(index)"
+            (keydown)="onTabKeydown($event, index)"
+        >
+            {{ tabItem.label() }}
+        </button>
+    }
 </div>
 
 @for (tabItem of tabItems(); track $index; let index = $index) {
-  @if (isLoaded(index) && activeIndex() === index) {
-    <section
-      class="tabs-panel"
-      role="tabpanel"
-      [id]="panelId(index)"
-      [attr.aria-labelledby]="triggerId(index)"
-    >
-      <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
-    </section>
-  }
+    @if (isLoaded(index) && activeIndex() === index) {
+        <section
+            class="tabs-panel"
+            role="tabpanel"
+            [id]="panelId(index)"
+            [attr.aria-labelledby]="triggerId(index)"
+        >
+            <ng-container [ngTemplateOutlet]="tabItem.template"></ng-container>
+        </section>
+    }
 }

--- a/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
+++ b/apps/frontend/src/app/shared/ui/tabs/tabs.component.ts
@@ -17,7 +17,7 @@ import { TabItemDirective } from './tab-item.directive';
   standalone: true,
   imports: [NgTemplateOutlet],
   templateUrl: './tabs.component.html',
-  styleUrls: ['./tabs.component.css'],
+  styleUrl: './tabs.component.css',
 })
 export class TabsComponent {
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);


### PR DESCRIPTION
### Motivation
- Standardize shared UI components to the Angular 21 authoring patterns used across the codebase for consistency and forward compatibility.
- Move from decorator-based content queries to signal-based APIs where applicable to align with the rest of the code and make template consumption consistent.

### Description
- Replace `styleUrls: [...]` with the Angular 21 `styleUrl: '...` single-string metadata on shared UI components (`autocomplete-textbox`, `clock`, `tabs`, `card`) to match the prevailing project pattern.
- Migrate `CardComponent` content queries from `@ContentChild('...')` to the signal API `contentChild(...)` and adjust the component to read the signal value via `headerTpl()`/`footerTpl()`.
- Update `card.component.html` to call the signal accessors (`headerTpl()` / `footerTpl()`) and ensure conditional checks use the signal results.
- Normalize indentation/formatting in `tabs.component.html` and minor import adjustments in `card.component.ts` to keep templates and authoring style homogeneous.

### Testing
- Ran `npm run lint` and style validation, which completed successfully.
- Ran `npm run build`, which produced a successful application build with generated output in `dist/frontend`.
- Ran unit tests with `npm test -- --watch=false`, and all tests passed (174 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33160132dc8327b3a322b666377779)