### PR TITLE
Split header detail CSS tokens

### DIFF
--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -9,6 +9,7 @@
 @import './styles/tokens/brand.css';
 @import './styles/tokens/button.css';
 @import './styles/tokens/list.css';
+@import './styles/tokens/header-detail.tokens.css';
 
 @import './styles/base.css';
 @import './styles/components/form-actions.css';

--- a/apps/frontend/src/styles/components/header-detail.css
+++ b/apps/frontend/src/styles/components/header-detail.css
@@ -1,20 +1,3 @@
-:root {
-    --app-header-detail-gap: var(--panel-gap);
-    --app-header-detail-padding-inline: var(--panel-padding-inline);
-    --app-header-detail-padding-block: var(--panel-padding-block);
-    --app-header-detail-background-color: var(--panel-background-color);
-    --app-header-detail-border: var(--panel-border);
-    --app-header-detail-border-radius: var(--panel-border-radius);
-    --app-header-detail-icon-size: 6rem;
-    --app-header-detail-icon-border: var(--stroke-400) solid var(--color-white-alpha-12);
-    --app-header-detail-icon-border-radius: var(--radius-400);
-    --app-header-detail-icon-color: var(--accent-color);
-    --app-header-detail-icon-font-size: var(--font-size-700);
-    --app-header-detail-info-gap: var(--size-300);
-    --app-header-detail-info-font-size: var(--font-size-350);
-    --app-header-detail-compact-padding-inline-end: 1.85rem;
-}
-
 .app-header-detail {
     display: flex;
     align-items: center;
@@ -73,9 +56,5 @@
     .app-header-detail__icon {
         --app-header-detail-icon-size: 4.8rem;
         --app-header-detail-icon-font-size: var(--font-size-500);
-    }
-
-    .app-header-detail__status {
-        width: 100%;
     }
 }

--- a/apps/frontend/src/styles/tokens/header-detail.tokens.css
+++ b/apps/frontend/src/styles/tokens/header-detail.tokens.css
@@ -1,0 +1,16 @@
+:root {
+    --app-header-detail-gap: var(--panel-gap);
+    --app-header-detail-padding-inline: var(--panel-padding-inline);
+    --app-header-detail-padding-block: var(--panel-padding-block);
+    --app-header-detail-background-color: var(--panel-background-color);
+    --app-header-detail-border: var(--panel-border);
+    --app-header-detail-border-radius: var(--panel-border-radius);
+    --app-header-detail-icon-size: 6rem;
+    --app-header-detail-icon-border: var(--stroke-400) solid var(--color-white-alpha-12);
+    --app-header-detail-icon-border-radius: var(--radius-400);
+    --app-header-detail-icon-color: var(--accent-color);
+    --app-header-detail-icon-font-size: var(--font-size-700);
+    --app-header-detail-info-gap: var(--size-300);
+    --app-header-detail-info-font-size: var(--font-size-350);
+    --app-header-detail-compact-padding-inline-end: 1.85rem;
+}


### PR DESCRIPTION
### Motivation
- Separate component-specific custom properties into a tokens file so variables are reusable and can be imported before component styles.
- Keep the component stylesheet focused on selectors and layout rules for easier maintenance and clarity.

### Description
- Added `apps/frontend/src/styles/tokens/header-detail.tokens.css` containing the `:root` block with all `--app-header-detail-*` custom properties.
- Removed the `:root` variables block from `apps/frontend/src/styles/components/header-detail.css` so the file only contains the component selectors and `@media` rules.
- Removed the `.app-header-detail__status { width: 100%; }` rule from the component stylesheet to match the requested selector set.
- Updated `apps/frontend/src/styles.css` to import `./styles/tokens/header-detail.tokens.css` before `./styles/components/header-detail.css`.

### Testing
- Ran `npm run lint:styles` (which executes `node scripts/validate-css-vars.mjs`) and it completed successfully, reporting validated CSS files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3453ea279083279f99fb4d6907e358)