### PR TITLE
Agregar tokens compartidos para estilos de listas

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
@@ -26,21 +26,21 @@
     box-sizing: border-box;
 
     margin: 0;
-    padding: var(--autocomplete-results-padding-block) var(--autocomplete-results-padding-inline);
+    padding: var(--list-padding-block) var(--list-padding-inline);
 
     list-style: none;
 
-    border: var(--form-control-border);
-    border-radius: var(--form-control-border-radius);
+    border: var(--list-border);
+    border-radius: var(--list-border-radius);
 
     background: var(--list-background-color);
     color: var(--form-control-text-color);
 
-    box-shadow: var(--autocomplete-results-shadow);
+    box-shadow: var(--list-shadow);
 }
 
 .autocomplete__option {
-    padding: var(--autocomplete-result-padding-block) var(--autocomplete-result-padding-inline);
+    padding: var(--list-item-padding-block) var(--list-item-padding-inline);
 
     white-space: nowrap;
     text-align: left;
@@ -50,7 +50,7 @@
 
 .autocomplete__option:hover,
 .autocomplete__option--active {
-    background: var(--list-element-hover-background-color);
+    background: var(--list-item-hover-background-color);
 }
 
 .autocomplete__message {

--- a/apps/frontend/src/styles/tokens/list.tokens.css
+++ b/apps/frontend/src/styles/tokens/list.tokens.css
@@ -1,5 +1,16 @@
 :root {
     --list-background-color: var(--panel-background-color);
-    --list-background-color-odd: var(--color-gray-850);
-    --list-element-hover-background-color: var(--color-primary-900);
+    --list-border: var(--panel-border);
+    --list-border-radius: var(--panel-border-radius);
+    --list-shadow: var(--panel-shadow);
+    --list-padding-block: var(--size-100);
+    --list-padding-inline: 0;
+    --list-item-padding-block: var(--panel-medium-padding-block);
+    --list-item-padding-inline: var(--panel-padding-inline);
+    --list-item-hover-background-color: var(--color-primary-900);
+    --list-item-odd-background-color: var(--color-gray-850);
+    --list-item-even-background-color: var(--list-background-color);
+
+    --list-background-color-odd: var(--list-item-odd-background-color);
+    --list-element-hover-background-color: var(--list-item-hover-background-color);
 }

--- a/apps/frontend/src/styles/tokens/semantic/layout.tokens.css
+++ b/apps/frontend/src/styles/tokens/semantic/layout.tokens.css
@@ -58,18 +58,18 @@
     --summary-card-value-font-size: var(--font-size-heading-2);
 
     --table-background-color: var(--panel-background-color);
-    --table-border-radius: var(--panel-border-radius);
-    --table-border: var(--panel-border);
-    --table-shadow: var(--panel-shadow);
+    --table-border-radius: var(--list-border-radius);
+    --table-border: var(--list-border);
+    --table-shadow: var(--list-shadow);
     --table-header-cell-padding-inline: var(--panel-padding-inline);
     --table-header-cell-padding-block: var(--panel-padding-block);
     --table-header-cell-letter-spacing: 0.12em;
     --table-header-cell-font-size: var(--font-size-small);
-    --table-body-cell-padding-inline: var(--panel-padding-inline);
-    --table-body-cell-padding-block: var(--panel-medium-padding-block);
-    --table-row-odd-background-color: var(--list-background-color-odd);
-    --table-row-even-background-color: var(--list-background-color);
-    --table-row-hover-background-color: var(--list-element-hover-background-color);
+    --table-body-cell-padding-inline: var(--list-item-padding-inline);
+    --table-body-cell-padding-block: var(--list-item-padding-block);
+    --table-row-odd-background-color: var(--list-item-odd-background-color);
+    --table-row-even-background-color: var(--list-item-even-background-color);
+    --table-row-hover-background-color: var(--list-item-hover-background-color);
     --table-compact-cell-padding-block: 0.75rem;
     --table-compact-cell-padding-inline: var(--size-400);
 }


### PR DESCRIPTION
### Motivation

- Centralizar los estilos y comportamiento genérico de listas para evitar mezcla de tokens específicos de componentes y facilitar la consistencia visual en tablas y listados.
- Hacer que componentes genéricos como tablas y el listado de resultados del autocomplete deriven de un set conceptual común de tokens `--list-*`.

### Description

- Añadidos nuevos tokens en `apps/frontend/src/styles/tokens/list.tokens.css`: `--list-border`, `--list-border-radius`, `--list-shadow`, `--list-padding-block`, `--list-padding-inline`, `--list-item-padding-block`, `--list-item-padding-inline`, `--list-item-hover-background-color`, `--list-item-odd-background-color` y `--list-item-even-background-color`, manteniendo aliases de compatibilidad (`--list-background-color-odd`, `--list-element-hover-background-color`).
- Actualizados los tokens semánticos en `apps/frontend/src/styles/tokens/semantic/layout.tokens.css` para que los valores genéricos de tabla (como `--table-border`, `--table-border-radius`, `--table-shadow`, `--table-body-cell-padding-*`, `--table-row-*-background-color`, `--table-row-hover-background-color`) deriven de los nuevos `--list-*`.
- Reemplazados los estilos estructurales del listado de resultados en `apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css` para usar los tokens conceptuales `--list-*` en lugar de una mezcla de `--autocomplete-results-*`, `--form-control-*` y tokens dispersos.

### Testing

- Ejecutado `npm run lint:styles` y la validación de variables CSS completó correctamente con `Validated 53 CSS files` sin errores.
- Ejecutado `git diff --check` y no se detectaron problemas de formato o conflictos en los cambios aplicados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a345ef93cd883279086d73b578ccb62)