### PR TITLE
Use list tokens for autocomplete results

### DIFF
--- a/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
+++ b/apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css
@@ -34,7 +34,7 @@
     border-radius: var(--list-border-radius);
 
     background: var(--list-background-color);
-    color: var(--form-control-text-color);
+    color: var(--list-text-color);
 
     box-shadow: var(--list-shadow);
 }

--- a/apps/frontend/src/styles/tokens/list.tokens.css
+++ b/apps/frontend/src/styles/tokens/list.tokens.css
@@ -2,6 +2,7 @@
     --list-background-color: var(--panel-background-color);
     --list-border: var(--panel-border);
     --list-border-radius: var(--panel-border-radius);
+    --list-text-color: var(--text-primary-color);
     --list-shadow: var(--panel-shadow);
     --list-padding-block: var(--size-100);
     --list-padding-inline: 0;


### PR DESCRIPTION
### Motivation
- Align autocomplete result styling with the list token set so list containers use dedicated tokens for border, radius, background, text color, and shadow to enable consistent theming and future reuse.

### Description
- Updated `apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css` to use `--list-text-color` for `.autocomplete__results` and added `--list-text-color` to `apps/frontend/src/styles/tokens/list.tokens.css` derived from `--text-primary-color`, while keeping existing `--list-*` and `--form-control-*` tokens unchanged.

### Testing
- Ran `npm run lint:styles` in `apps/frontend` which succeeded (`Validated 53 CSS files`) and ran `git diff --check` which passed; a root-level `npm run lint:styles` attempt failed due to missing root `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3462319be483279484a5f170898f90)