### PR TITLE
Mover tokens de autocomplete a archivo de tokens de componente

### DIFF
--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -17,6 +17,7 @@
 @import './styles/tokens/button.tokens.css';
 @import './styles/tokens/header-detail.tokens.css';
 @import './styles/tokens/list.tokens.css';
+@import './styles/tokens/autocomplete.tokens.css';
 
 /* Base styles */
 @import './styles/base.css';

--- a/apps/frontend/src/styles/tokens/autocomplete.tokens.css
+++ b/apps/frontend/src/styles/tokens/autocomplete.tokens.css
@@ -1,0 +1,14 @@
+:root {
+    --autocomplete-clear-button-padding-inline: 0.66rem;
+    --autocomplete-clear-button-font-size: 1.66rem;
+    --autocomplete-clear-button-focus-outline: var(--focus-ring-width) var(--border-style) var(--form-control-background-color);
+    --autocomplete-clear-button-focus-outline-offset: calc(var(--focus-ring-width) * -1);
+
+    --autocomplete-results-max-width: min(30rem, calc(100vw - var(--size-600)));
+    --autocomplete-results-max-height: 14rem;
+    --autocomplete-results-padding-block: var(--list-padding-block);
+    --autocomplete-results-padding-inline: var(--list-padding-inline);
+    --autocomplete-results-shadow: var(--list-shadow);
+    --autocomplete-result-padding-block: var(--list-item-padding-block);
+    --autocomplete-result-padding-inline: var(--list-item-padding-inline);
+}

--- a/apps/frontend/src/styles/tokens/semantic/forms.tokens.css
+++ b/apps/frontend/src/styles/tokens/semantic/forms.tokens.css
@@ -94,17 +94,6 @@
     --search-bar-padding-inline: 0.75rem;
     --search-bar-font-size: 0.95rem;
 
-    --autocomplete-clear-button-padding-inline: 0.66rem;
-    --autocomplete-clear-button-font-size: 1.66rem;
-    --autocomplete-clear-button-focus-outline: var(--focus-ring-width) var(--border-style) var(--form-control-background-color);
-    --autocomplete-clear-button-focus-outline-offset: calc(var(--focus-ring-width) * -1);
-    --autocomplete-results-max-width: min(30rem, calc(100vw - var(--size-600)));
-    --autocomplete-results-max-height: 14rem;
-    --autocomplete-results-padding-block: var(--size-100);
-    --autocomplete-results-padding-inline: 0;
-    --autocomplete-results-shadow: 0 1rem 2rem var(--color-black-alpha-35);
-    --autocomplete-result-padding-block: var(--size-200);
-    --autocomplete-result-padding-inline: 0.75rem;
 
     /* app-form-actions      → buttons */
 }


### PR DESCRIPTION
### Motivation
- Separar los tokens específicos de `autocomplete` en su propio archivo de tokens de componente para mantener los tokens semánticos de formulario más limpios y modulares. 
- Hacer que los tokens de resultados de autocomplete reutilicen las definiciones conceptuales de `list` para asegurar consistencia visual y evitar duplicación.

### Description
- Se creó `apps/frontend/src/styles/tokens/autocomplete.tokens.css` con los tokens `--autocomplete-*` relevantes. 
- Se eliminaron las definiciones `--autocomplete-*` de `apps/frontend/src/styles/tokens/semantic/forms.tokens.css`. 
- Se importó `./styles/tokens/autocomplete.tokens.css` en `apps/frontend/src/styles.css` junto a los demás tokens de componente, colocándolo después de `list.tokens.css`. 
- Se actualizaron los tokens de resultados para derivar de tokens de lista cuando aplica, por ejemplo `--autocomplete-results-shadow: var(--list-shadow)` y `--autocomplete-result-padding-block: var(--list-item-padding-block)`.

### Testing
- Se ejecutó `npm run lint:styles` (ejecuta `node scripts/validate-css-vars.mjs`) y la validación de variables CSS en 54 archivos fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34632118008327a66d5265ec596816)