### PR TITLE
refactor(frontend): extract table design tokens

### DIFF
--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -17,6 +17,7 @@
 @import './styles/tokens/button.tokens.css';
 @import './styles/tokens/header-detail.tokens.css';
 @import './styles/tokens/list.tokens.css';
+@import './styles/tokens/table.tokens.css';
 @import './styles/tokens/autocomplete.tokens.css';
 
 /* Base styles */

--- a/apps/frontend/src/styles/tokens/semantic/layout.tokens.css
+++ b/apps/frontend/src/styles/tokens/semantic/layout.tokens.css
@@ -57,19 +57,4 @@
     --summary-card-value-margin-top: 0.8rem;
     --summary-card-value-font-size: var(--font-size-heading-2);
 
-    --table-background-color: var(--panel-background-color);
-    --table-border-radius: var(--list-border-radius);
-    --table-border: var(--list-border);
-    --table-shadow: var(--list-shadow);
-    --table-header-cell-padding-inline: var(--panel-padding-inline);
-    --table-header-cell-padding-block: var(--panel-padding-block);
-    --table-header-cell-letter-spacing: 0.12em;
-    --table-header-cell-font-size: var(--font-size-small);
-    --table-body-cell-padding-inline: var(--list-item-padding-inline);
-    --table-body-cell-padding-block: var(--list-item-padding-block);
-    --table-row-odd-background-color: var(--list-item-odd-background-color);
-    --table-row-even-background-color: var(--list-item-even-background-color);
-    --table-row-hover-background-color: var(--list-item-hover-background-color);
-    --table-compact-cell-padding-block: 0.75rem;
-    --table-compact-cell-padding-inline: var(--size-400);
 }

--- a/apps/frontend/src/styles/tokens/table.tokens.css
+++ b/apps/frontend/src/styles/tokens/table.tokens.css
@@ -1,0 +1,17 @@
+:root {
+    --table-background-color: var(--list-background-color);
+    --table-border: var(--list-border);
+    --table-border-radius: var(--list-border-radius);
+    --table-shadow: var(--list-shadow);
+    --table-header-cell-padding-inline: var(--panel-padding-inline);
+    --table-header-cell-padding-block: var(--panel-padding-block);
+    --table-header-cell-letter-spacing: 0.12em;
+    --table-header-cell-font-size: var(--font-size-small);
+    --table-body-cell-padding-inline: var(--list-item-padding-inline);
+    --table-body-cell-padding-block: var(--list-item-padding-block);
+    --table-row-odd-background-color: var(--list-item-odd-background-color);
+    --table-row-even-background-color: var(--list-item-even-background-color);
+    --table-row-hover-background-color: var(--list-item-hover-background-color);
+    --table-compact-cell-padding-block: 0.75rem;
+    --table-compact-cell-padding-inline: var(--size-400);
+}


### PR DESCRIPTION
### Motivation
- Separate table design tokens from semantic layout tokens to make component-level styling explicit and reduce duplication.
- Make table visuals derive from conceptual `--list-*` tokens for shared properties (background, border, radius, shadow, hover and row variants) so tables inherit list semantics by default.
- Keep only table-specific differences (header/body paddings, header letter-spacing, header font-size and responsive compact padding) in the new token file for clearer overrides.

### Description
- Added `apps/frontend/src/styles/tokens/table.tokens.css` containing the `--table-*` tokens that derive shared properties from `--list-*` and declare table-specific values for paddings, header letter-spacing, header font-size and compact padding.
- Removed the moved `--table-*` token entries from `apps/frontend/src/styles/tokens/semantic/layout.tokens.css` so layout tokens no longer contain component-specific table tokens.
- Updated `apps/frontend/src/styles.css` to import `./styles/tokens/table.tokens.css` alongside the other component token files.
- No changes were made to component styles (`apps/frontend/src/styles/components/table.css`) beyond token indirection.

### Testing
- Ran `npm run lint:styles` which validated CSS custom properties and passed successfully.
- Ran full lint with `npm run lint` (includes `ng lint` and `npm run lint:styles`) and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34648b58908327acdbb8cf5c0a79e0)