### PR TITLE
Remove duplicate --form-range-focus-ring token

### DIFF
--- a/apps/frontend/src/styles/tokens/semantic/forms.tokens.css
+++ b/apps/frontend/src/styles/tokens/semantic/forms.tokens.css
@@ -36,7 +36,6 @@
     --form-range-text-size: var(--font-size-body);
     --form-range-text-weight: 800;
 
-    --form-range-focus-ring: var(--focus-ring);
     --form-range-height: var(--size-200);
     --form-range-radius: var(--size-100);
     --form-range-background: var(--color-gray-50);


### PR DESCRIPTION
### Motivation
- Remove a duplicated CSS custom property so there is a single canonical `--form-range-focus-ring` declaration in the `/* form-range → slider */` section while keeping its effective value pointing to `var(--focus-ring)`.

### Description
- Deleted the redundant `--form-range-focus-ring: var(--focus-ring);` line from `apps/frontend/src/styles/tokens/semantic/forms.tokens.css`, keeping the single definition inside the slider section.

### Testing
- Verified with `rg -n -e "--form-range-focus-ring: var\(--focus-ring\);" apps/frontend/src/styles/tokens/semantic/forms.tokens.css` and confirmed the occurrence count with `rg -c -e "--form-range-focus-ring" apps/frontend/src/styles/tokens/semantic/forms.tokens.css` which returned `1`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3464a41664832781575222c3c54b58)