### PR TITLE
Deprecate legacy list hover token alias (`--list-element-hover-background-color`)

### DIFF
--- a/apps/frontend/src/styles/tokens/list.tokens.css
+++ b/apps/frontend/src/styles/tokens/list.tokens.css
@@ -13,5 +13,6 @@
     --list-item-even-background-color: var(--list-background-color);
 
     --list-background-color-odd: var(--list-item-odd-background-color);
+    /* Deprecated: use --list-item-hover-background-color instead. */
     --list-element-hover-background-color: var(--list-item-hover-background-color);
 }


### PR DESCRIPTION
### Motivation
- Ensure `--list-item-hover-background-color` is the canonical hover token while preserving `--list-element-hover-background-color` as a temporary deprecated alias to avoid breaking external references.

### Description
- Added a deprecation comment and kept the alias mapping in `apps/frontend/src/styles/tokens/list.tokens.css` so `--list-element-hover-background-color` still points to `--list-item-hover-background-color` and no consumer changes were required.

### Testing
- Ran `rg "list-element-hover-background-color" apps/frontend/src` and ran `rg "--table-row-hover-background-color: var(--list-item-hover-background-color)" apps/frontend/src/styles/tokens` plus `rg "background: var(--list-item-hover-background-color)" apps/frontend/src/app/shared/ui/autocomplete-textbox/autocomplete-textbox.component.css`, and the searches confirmed the legacy alias and that consumers reference the new token.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346593afc08327a6e342867ab65bea)