### PR TITLE
docs(frontend): add conceptual `styles.md` describing frontend style system

### DIFF
--- a/apps/frontend/styles.md
+++ b/apps/frontend/styles.md
@@ -1,112 +1,112 @@
-# Estilos del frontend
+# Frontend styles
 
-Este documento describe cómo se organizan conceptualmente los estilos del frontend y cuándo conviene utilizar cada capa. No pretende ser un inventario de variables CSS, sino una guía para entender el sistema de diseño de la aplicación.
+This document explains how frontend styles are conceptually organized and when each layer should be used. It is not meant to be an inventory of CSS variables, but a guide to understanding the application's design system.
 
-## Punto de entrada global
+## Global entry point
 
-El punto de entrada de estilos globales es `src/styles.css`. Este fichero no define reglas visuales directamente: actúa como manifiesto de carga y fija el orden de importación de las capas del sistema.
+The global style entry point is `src/styles.css`. This file does not define visual rules directly: it works as the loading manifest and sets the import order for the system layers.
 
-El orden es importante porque las capas posteriores dependen de las anteriores:
+The order matters because later layers depend on earlier ones:
 
-1. **Primitivos**: valores base sin semántica de producto.
-2. **Temas**: asignación de colores y superficies por modo visual.
-3. **Tokens semánticos**: nombres orientados al uso dentro de la interfaz.
-4. **Tokens de componentes**: ajustes específicos para piezas reutilizables.
-5. **Estilos base**: reglas generales de documento y utilidades globales.
-6. **Estilos genéricos de componentes**: clases `app-*` compartidas por distintas pantallas.
+1. **Primitives**: base values with no product semantics.
+2. **Themes**: color and surface assignments for each visual mode.
+3. **Semantic tokens**: names oriented around interface usage.
+4. **Component tokens**: specific adjustments for reusable UI pieces.
+5. **Base styles**: general document rules and global utilities.
+6. **Generic component styles**: shared `app-*` classes used across screens.
 
-## Ficheros de variables básicas
+## Basic variable files
 
-Las variables básicas viven bajo `src/styles/tokens/` y se agrupan por nivel de abstracción.
+Basic variables live under `src/styles/tokens/` and are grouped by abstraction level.
 
-### Primitivos
+### Primitives
 
-`src/styles/tokens/00-primitives.css` contiene los valores más básicos del sistema: paleta de colores, escalas de tamaño, radios, grosores y tamaños tipográficos elementales. Estos tokens no deberían usarse para expresar intención de interfaz, sino como materia prima para construir tokens superiores.
+`src/styles/tokens/00-primitives.css` contains the most basic system values: color palette, size scales, radii, stroke widths, and elementary type sizes. These tokens should not be used to express interface intent; they are the raw material used to build higher-level tokens.
 
-Por ejemplo, un color primitivo representa un valor de paleta; no dice si se utiliza para texto, borde, fondo, estado de error o acento.
+For example, a primitive color represents a palette value; it does not say whether it is used for text, borders, backgrounds, error states, or accents.
 
-### Temas
+### Themes
 
-`src/styles/tokens/theme.dark.css` y `src/styles/tokens/theme.light.css` traducen los primitivos a decisiones visuales dependientes del tema. Aquí se definen conceptos como fondo de página, color de texto, acento, bordes, paneles, selección, foco y controles destacados.
+`src/styles/tokens/theme.dark.css` and `src/styles/tokens/theme.light.css` translate primitives into theme-dependent visual decisions. This is where concepts such as page background, text color, accent, borders, panels, selection, focus, and highlighted controls are defined.
 
-La aplicación usa el tema oscuro como base global y permite sobrescribirlo con el atributo `data-theme='light'` para el modo claro. Las reglas de componentes no deberían duplicar decisiones de tema; deben consumir tokens semánticos o de componente.
+The application uses the dark theme as the global base and can override it with the `data-theme='light'` attribute for light mode. Component rules should not duplicate theme decisions; they should consume semantic or component tokens.
 
-### Tokens semánticos
+### Semantic tokens
 
-Los ficheros de `src/styles/tokens/semantic/` nombran las variables por su función en la interfaz:
+Files under `src/styles/tokens/semantic/` name variables by their role in the interface:
 
-- `base.tokens.css`: tipografía semántica, foco y definiciones comunes de borde.
-- `layout.tokens.css`: estructura de página, secciones, paneles y tarjetas resumen.
-- `forms.tokens.css`: formularios, campos, ayudas, errores, controles, rangos, switches y buscadores.
-- `controls.tokens.css`: controles visuales pequeños como chips y sus variantes de estado.
+- `base.tokens.css`: semantic typography, focus, and common border definitions.
+- `layout.tokens.css`: page structure, sections, panels, and summary cards.
+- `forms.tokens.css`: forms, fields, hints, errors, controls, ranges, switches, and search bars.
+- `controls.tokens.css`: small visual controls such as chips and their state variants.
 
-Esta capa permite que los componentes hablen en términos de intención: texto principal, panel, foco, sección, error, control o acción.
+This layer lets components speak in terms of intent: primary text, panel, focus, section, error, control, or action.
 
-### Tokens de componente
+### Component tokens
 
-Los ficheros de tokens específicos (`avatar.tokens.css`, `brand.tokens.css`, `button.tokens.css`, `header-detail.tokens.css`, `list.tokens.css`, `table.tokens.css`, `autocomplete.tokens.css`, etc.) ajustan piezas concretas de la interfaz.
+Specific token files (`avatar.tokens.css`, `brand.tokens.css`, `button.tokens.css`, `header-detail.tokens.css`, `list.tokens.css`, `table.tokens.css`, `autocomplete.tokens.css`, etc.) tune concrete interface pieces.
 
-Su objetivo es aislar decisiones de una familia de componentes sin llevarlas al CSS estructural. Por ejemplo, las tablas consumen tokens propios que a su vez se apoyan en los tokens de listas y paneles; así se mantiene una apariencia coherente entre listados, tablas y resultados interactivos.
+Their purpose is to isolate decisions for a component family without moving them into structural CSS. For example, tables consume their own tokens, which in turn build on list and panel tokens; this keeps the appearance consistent across lists, tables, and interactive results.
 
-## Estilos base
+## Base styles
 
-`src/styles/base.css` define reglas transversales que afectan al documento y a utilidades globales. Aquí se fija la familia tipográfica, el comportamiento básico de `html` y `body`, el fondo de la aplicación, el contenedor común de página y utilidades de accesibilidad.
+`src/styles/base.css` defines cross-cutting rules that affect the document and global utilities. It sets the type family, basic `html` and `body` behavior, the application background, the common page content container, and accessibility utilities.
 
-Estos estilos deben mantenerse pequeños y genéricos. Si una regla describe una pieza de UI reutilizable, debería vivir en `src/styles/components/`; si describe una pantalla concreta, debería quedarse en el CSS del componente Angular correspondiente.
+These styles should stay small and generic. If a rule describes a reusable UI piece, it should live in `src/styles/components/`; if it describes a specific screen, it should remain in the corresponding Angular component CSS.
 
-## Estilos genéricos
+## Generic styles
 
-Los estilos genéricos viven en `src/styles/components/` y exponen clases globales con prefijo `app-*`. Son bloques reutilizables para patrones de interfaz que aparecen en varias funcionalidades.
+Generic styles live in `src/styles/components/` and expose global classes with the `app-*` prefix. They are reusable blocks for interface patterns that appear in multiple features.
 
-La idea es evitar que cada feature recree estructura, espaciado, bordes, sombras o estados vacíos por su cuenta. Cada pantalla puede añadir clases propias de feature para composición local, pero debería apoyarse en estos estilos comunes cuando el patrón ya existe.
+The goal is to avoid each feature recreating structure, spacing, borders, shadows, or empty states on its own. Each screen can add feature-specific classes for local composition, but it should rely on these shared styles when the pattern already exists.
 
-## Relación con los estilos de componentes Angular
+## Relationship with Angular component styles
 
-Los componentes Angular mantienen sus estilos específicos junto al propio componente (`*.component.css`). Esa capa debe encargarse de composición local, variantes de una pantalla concreta o ajustes que no sean reutilizables.
+Angular components keep their specific styles next to the component itself (`*.component.css`). This layer should handle local composition, variants for a concrete screen, or adjustments that are not reusable.
 
-Como criterio general:
+As a general rule:
 
-- Si el estilo expresa una decisión global de diseño, debe ser un token.
-- Si el estilo define un patrón reutilizable entre pantallas, debe ser un estilo genérico `app-*`.
-- Si el estilo solo tiene sentido para una feature o componente concreto, debe quedarse en su CSS local.
+- If the style expresses a global design decision, it should be a token.
+- If the style defines a reusable pattern across screens, it should be a generic `app-*` style.
+- If the style only makes sense for one feature or concrete component, it should stay in its local CSS file.
 
-## Esquema de estilos genéricos de la app
+## Generic application style schema
 
-- **Base de aplicación** (`src/styles/base.css`)
-  - `app-page-content`: contenedor flexible común para el contenido principal de las páginas.
-  - `app-visually-hidden`: utilidad de accesibilidad para ocultar contenido visualmente manteniéndolo disponible para lectores de pantalla.
+- **Application base** (`src/styles/base.css`)
+  - `app-page-content`: common flexible container for the main content of pages.
+  - `app-visually-hidden`: accessibility utility that visually hides content while keeping it available to screen readers.
 
-- **Tarjetas y paneles** (`src/styles/components/card.css`)
-  - `app-card`: contenedor principal para paneles de contenido, formularios, widgets y bloques destacados.
-  - `app-card__header`: zona superior de una tarjeta, normalmente para título o acciones contextuales.
-  - `app-card__title`: título visual de una tarjeta.
-  - `app-card__body`: zona de contenido principal con gestión de crecimiento y scroll interno.
-  - `app-card__footer`: zona inferior para acciones, totales o contenido secundario.
+- **Cards and panels** (`src/styles/components/card.css`)
+  - `app-card`: main container for content panels, forms, widgets, and highlighted blocks.
+  - `app-card__header`: top area of a card, usually for a title or contextual actions.
+  - `app-card__title`: visual title of a card.
+  - `app-card__body`: main content area with growth and internal scroll handling.
+  - `app-card__footer`: bottom area for actions, totals, or secondary content.
 
-- **Formularios** (`src/styles/components/forms.css`)
-  - `app-form`: estructura vertical común para formularios de creación, edición y preferencias.
+- **Forms** (`src/styles/components/forms.css`)
+  - `app-form`: common vertical structure for creation, editing, and preferences forms.
 
-- **Acciones de formulario** (`src/styles/components/form-actions.css`)
-  - `app-form-actions`: agrupación alineada de botones de envío, cancelación u otras acciones al final de un formulario.
+- **Form actions** (`src/styles/components/form-actions.css`)
+  - `app-form-actions`: aligned group of submit, cancel, or other action buttons at the end of a form.
 
-- **Cabeceras de detalle** (`src/styles/components/header-detail.css`)
-  - `app-header-detail`: cabecera destacada para páginas de detalle de entidad.
-  - `app-header-detail__identity`: bloque de identidad que agrupa icono, título e información principal.
-  - `app-header-detail__icon`: contenedor visual del icono o avatar de la entidad.
-  - `app-header-detail__title`: título principal de la entidad mostrada.
-  - `app-header-detail__info`: línea de metadatos o información secundaria.
-  - `app-header-detail__status`: zona reservada para estado, etiqueta o chip asociado al detalle.
+- **Detail headers** (`src/styles/components/header-detail.css`)
+  - `app-header-detail`: highlighted header for entity detail pages.
+  - `app-header-detail__identity`: identity block that groups icon, title, and main information.
+  - `app-header-detail__icon`: visual container for the entity icon or avatar.
+  - `app-header-detail__title`: main title of the displayed entity.
+  - `app-header-detail__info`: metadata line or secondary information.
+  - `app-header-detail__status`: reserved area for status, label, or chip associated with the detail view.
 
-- **Secciones** (`src/styles/components/section.css`)
-  - `app-section`: bloque vertical reutilizable para agrupar contenido relacionado dentro de una página o tarjeta.
-  - `app-section__header`: cabecera de sección con título y posibles acciones.
-  - `app-section__title`: título de sección con tratamiento visual uniforme.
-  - `app-section__message`: mensaje informativo, estado vacío o aviso asociado a una sección.
-  - `app-section__message--error`: variante de mensaje para errores dentro de una sección.
+- **Sections** (`src/styles/components/section.css`)
+  - `app-section`: reusable vertical block that groups related content inside a page or card.
+  - `app-section__header`: section header with title and optional actions.
+  - `app-section__title`: section title with consistent visual treatment.
+  - `app-section__message`: informational message, empty state, or notice associated with a section.
+  - `app-section__message--error`: message variant for errors inside a section.
 
-- **Tablas y listados tabulares** (`src/styles/components/table.css`)
-  - `app-table`: tabla genérica para listados de resultados, registros, horarios, centros de trabajo y fichajes.
-  - `app-table thead`: cabecera visual de la tabla.
-  - `app-table th`: celdas de encabezado con estilo compacto y texto destacado.
-  - `app-table td`: celdas de datos del cuerpo.
-  - `app-table tbody tr`: filas de resultados con alternancia visual y estado hover.
+- **Tables and tabular lists** (`src/styles/components/table.css`)
+  - `app-table`: generic table for result lists, records, schedules, worksites, and time logs.
+  - `app-table thead`: visual table header.
+  - `app-table th`: compact, highlighted header cells.
+  - `app-table td`: body data cells.
+  - `app-table tbody tr`: result rows with visual alternation and hover state.

--- a/apps/frontend/styles.md
+++ b/apps/frontend/styles.md
@@ -1,0 +1,112 @@
+# Estilos del frontend
+
+Este documento describe cómo se organizan conceptualmente los estilos del frontend y cuándo conviene utilizar cada capa. No pretende ser un inventario de variables CSS, sino una guía para entender el sistema de diseño de la aplicación.
+
+## Punto de entrada global
+
+El punto de entrada de estilos globales es `src/styles.css`. Este fichero no define reglas visuales directamente: actúa como manifiesto de carga y fija el orden de importación de las capas del sistema.
+
+El orden es importante porque las capas posteriores dependen de las anteriores:
+
+1. **Primitivos**: valores base sin semántica de producto.
+2. **Temas**: asignación de colores y superficies por modo visual.
+3. **Tokens semánticos**: nombres orientados al uso dentro de la interfaz.
+4. **Tokens de componentes**: ajustes específicos para piezas reutilizables.
+5. **Estilos base**: reglas generales de documento y utilidades globales.
+6. **Estilos genéricos de componentes**: clases `app-*` compartidas por distintas pantallas.
+
+## Ficheros de variables básicas
+
+Las variables básicas viven bajo `src/styles/tokens/` y se agrupan por nivel de abstracción.
+
+### Primitivos
+
+`src/styles/tokens/00-primitives.css` contiene los valores más básicos del sistema: paleta de colores, escalas de tamaño, radios, grosores y tamaños tipográficos elementales. Estos tokens no deberían usarse para expresar intención de interfaz, sino como materia prima para construir tokens superiores.
+
+Por ejemplo, un color primitivo representa un valor de paleta; no dice si se utiliza para texto, borde, fondo, estado de error o acento.
+
+### Temas
+
+`src/styles/tokens/theme.dark.css` y `src/styles/tokens/theme.light.css` traducen los primitivos a decisiones visuales dependientes del tema. Aquí se definen conceptos como fondo de página, color de texto, acento, bordes, paneles, selección, foco y controles destacados.
+
+La aplicación usa el tema oscuro como base global y permite sobrescribirlo con el atributo `data-theme='light'` para el modo claro. Las reglas de componentes no deberían duplicar decisiones de tema; deben consumir tokens semánticos o de componente.
+
+### Tokens semánticos
+
+Los ficheros de `src/styles/tokens/semantic/` nombran las variables por su función en la interfaz:
+
+- `base.tokens.css`: tipografía semántica, foco y definiciones comunes de borde.
+- `layout.tokens.css`: estructura de página, secciones, paneles y tarjetas resumen.
+- `forms.tokens.css`: formularios, campos, ayudas, errores, controles, rangos, switches y buscadores.
+- `controls.tokens.css`: controles visuales pequeños como chips y sus variantes de estado.
+
+Esta capa permite que los componentes hablen en términos de intención: texto principal, panel, foco, sección, error, control o acción.
+
+### Tokens de componente
+
+Los ficheros de tokens específicos (`avatar.tokens.css`, `brand.tokens.css`, `button.tokens.css`, `header-detail.tokens.css`, `list.tokens.css`, `table.tokens.css`, `autocomplete.tokens.css`, etc.) ajustan piezas concretas de la interfaz.
+
+Su objetivo es aislar decisiones de una familia de componentes sin llevarlas al CSS estructural. Por ejemplo, las tablas consumen tokens propios que a su vez se apoyan en los tokens de listas y paneles; así se mantiene una apariencia coherente entre listados, tablas y resultados interactivos.
+
+## Estilos base
+
+`src/styles/base.css` define reglas transversales que afectan al documento y a utilidades globales. Aquí se fija la familia tipográfica, el comportamiento básico de `html` y `body`, el fondo de la aplicación, el contenedor común de página y utilidades de accesibilidad.
+
+Estos estilos deben mantenerse pequeños y genéricos. Si una regla describe una pieza de UI reutilizable, debería vivir en `src/styles/components/`; si describe una pantalla concreta, debería quedarse en el CSS del componente Angular correspondiente.
+
+## Estilos genéricos
+
+Los estilos genéricos viven en `src/styles/components/` y exponen clases globales con prefijo `app-*`. Son bloques reutilizables para patrones de interfaz que aparecen en varias funcionalidades.
+
+La idea es evitar que cada feature recree estructura, espaciado, bordes, sombras o estados vacíos por su cuenta. Cada pantalla puede añadir clases propias de feature para composición local, pero debería apoyarse en estos estilos comunes cuando el patrón ya existe.
+
+## Relación con los estilos de componentes Angular
+
+Los componentes Angular mantienen sus estilos específicos junto al propio componente (`*.component.css`). Esa capa debe encargarse de composición local, variantes de una pantalla concreta o ajustes que no sean reutilizables.
+
+Como criterio general:
+
+- Si el estilo expresa una decisión global de diseño, debe ser un token.
+- Si el estilo define un patrón reutilizable entre pantallas, debe ser un estilo genérico `app-*`.
+- Si el estilo solo tiene sentido para una feature o componente concreto, debe quedarse en su CSS local.
+
+## Esquema de estilos genéricos de la app
+
+- **Base de aplicación** (`src/styles/base.css`)
+  - `app-page-content`: contenedor flexible común para el contenido principal de las páginas.
+  - `app-visually-hidden`: utilidad de accesibilidad para ocultar contenido visualmente manteniéndolo disponible para lectores de pantalla.
+
+- **Tarjetas y paneles** (`src/styles/components/card.css`)
+  - `app-card`: contenedor principal para paneles de contenido, formularios, widgets y bloques destacados.
+  - `app-card__header`: zona superior de una tarjeta, normalmente para título o acciones contextuales.
+  - `app-card__title`: título visual de una tarjeta.
+  - `app-card__body`: zona de contenido principal con gestión de crecimiento y scroll interno.
+  - `app-card__footer`: zona inferior para acciones, totales o contenido secundario.
+
+- **Formularios** (`src/styles/components/forms.css`)
+  - `app-form`: estructura vertical común para formularios de creación, edición y preferencias.
+
+- **Acciones de formulario** (`src/styles/components/form-actions.css`)
+  - `app-form-actions`: agrupación alineada de botones de envío, cancelación u otras acciones al final de un formulario.
+
+- **Cabeceras de detalle** (`src/styles/components/header-detail.css`)
+  - `app-header-detail`: cabecera destacada para páginas de detalle de entidad.
+  - `app-header-detail__identity`: bloque de identidad que agrupa icono, título e información principal.
+  - `app-header-detail__icon`: contenedor visual del icono o avatar de la entidad.
+  - `app-header-detail__title`: título principal de la entidad mostrada.
+  - `app-header-detail__info`: línea de metadatos o información secundaria.
+  - `app-header-detail__status`: zona reservada para estado, etiqueta o chip asociado al detalle.
+
+- **Secciones** (`src/styles/components/section.css`)
+  - `app-section`: bloque vertical reutilizable para agrupar contenido relacionado dentro de una página o tarjeta.
+  - `app-section__header`: cabecera de sección con título y posibles acciones.
+  - `app-section__title`: título de sección con tratamiento visual uniforme.
+  - `app-section__message`: mensaje informativo, estado vacío o aviso asociado a una sección.
+  - `app-section__message--error`: variante de mensaje para errores dentro de una sección.
+
+- **Tablas y listados tabulares** (`src/styles/components/table.css`)
+  - `app-table`: tabla genérica para listados de resultados, registros, horarios, centros de trabajo y fichajes.
+  - `app-table thead`: cabecera visual de la tabla.
+  - `app-table th`: celdas de encabezado con estilo compacto y texto destacado.
+  - `app-table td`: celdas de datos del cuerpo.
+  - `app-table tbody tr`: filas de resultados con alternancia visual y estado hover.


### PR DESCRIPTION
### Motivation
- Documentar de forma clara y centralizada cómo está organizado el sistema de estilos del frontend para facilitar decisiones de diseño y consistencia entre componentes. 
- Evitar duplicidad entre temas, tokens y estilos locales dejando pautas sobre qué debería ser token, estilo genérico `app-*` o CSS de componente. 
- Facilitar la incorporación de nuevas pantallas y componentes usando las capas existentes (primitivos → temas → tokens semánticos → tokens de componente → estilos base → estilos genéricos).

### Description
- Añadido el fichero `apps/frontend/styles.md` que explica el punto de entrada `src/styles.css` y el orden de carga de las capas de estilos. 
- Descritas las capas de variables: `00-primitives.css`, `theme.dark.css`/`theme.light.css`, `semantic/*` y tokens específicos de componentes, con su propósito y relación. 
- Documentada la separación entre `src/styles/base.css`, los estilos genéricos en `src/styles/components/` (prefijo `app-*`) y los CSS locales de componentes Angular, incluyendo un esquema final de las clases genéricas y su uso previsto.

### Testing
- Ejecutado `git diff --cached --check` para validar la diff en el índice y no se detectaron problemas (comprobación pasada). 
- Verificada la presencia del nuevo fichero con `git status` y la ruta `apps/frontend/styles.md` incluida en el commit (creación del archivo confirmada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3466ee5c8c832794141323608d50f0)