### PR TITLE
Refactor summary card markup for semantic metrics

### DIFF
--- a/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
+++ b/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
@@ -22,6 +22,10 @@
     font-size: var(--summary-card-icon-font-size);
 }
 
+.summary-card__metric {
+    margin: 0;
+}
+
 .summary-card__label {
     color: var(--text-secondary-color);
 
@@ -34,6 +38,7 @@
 }
 
 .summary-card__value {
+    margin: 0;
     color: var(--text-secondary-color);
 
     font-size: var(--type-heading-lg-font-size);

--- a/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
+++ b/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
@@ -38,7 +38,7 @@
 }
 
 .summary-card__value {
-    margin: 0;
+    margin: var(--summary-card-value-margin-top) 0 0;
     color: var(--text-secondary-color);
 
     font-size: var(--type-heading-lg-font-size);

--- a/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.html
+++ b/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.html
@@ -1,7 +1,9 @@
-<article [class]="summaryCardClass">
+<div [class]="summaryCardClass">
     <span class="summary-card__icon" aria-hidden="true">
         <fa-icon [icon]="icon()"></fa-icon>
     </span>
-    <span class="summary-card__label">{{ label() }}</span>
-    <p class="summary-card__value">{{ value() }}</p>
-</article>
+    <dl class="summary-card__metric">
+        <dt class="summary-card__label">{{ label() }}</dt>
+        <dd class="summary-card__value">{{ value() }}</dd>
+    </dl>
+</div>

--- a/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.spec.ts
@@ -49,10 +49,14 @@ describe('SummaryCardComponent', () => {
   });
 
   it('should render the label and value', () => {
+    const cardElement = fixture.nativeElement.querySelector('.summary-card');
     const labelElement = fixture.nativeElement.querySelector('.summary-card__label');
     const valueElement = fixture.nativeElement.querySelector('.summary-card__value');
 
+    expect(cardElement.tagName).not.toBe('ARTICLE');
+    expect(labelElement.tagName).toBe('DT');
     expect(labelElement.textContent.trim()).toBe('Employees');
+    expect(valueElement.tagName).toBe('DD');
     expect(valueElement.textContent.trim()).toBe('24');
   });
 


### PR DESCRIPTION
### Motivation
- Mejorar la semántica del componente de resumen para exponer la pareja etiqueta-valor como una relación semántica (etiqueta/valor) en lugar de texto plano, sin alterar la presentación visual.

### Description
- Reemplazado el elemento raíz `<article>` por un `<div>` en `apps/frontend/src/app/shared/ui/summary-card/summary-card.component.html` y representada la pareja etiqueta-valor con `<dl>`, `<dt>` y `<dd>` manteniendo la clase del icono y `aria-hidden="true"` para que siga siendo decorativo.
- Añadido un reset de márgenes `margin: 0` para `.summary-card__metric` y `.summary-card__value` en `apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css` para neutralizar los márgenes por defecto de `<dl>`/`<dd>` sin cambiar las clases BEM existentes.
- Ampliada la prueba de renderizado en `apps/frontend/src/app/shared/ui/summary-card/summary-card.component.spec.ts` para verificar que el contenedor raíz ya no es un `ARTICLE`, que la etiqueta se renderiza como `DT` y el valor como `DD`.

### Testing
- Ejecutado `npm test -- --watch=false --include='src/app/shared/ui/summary-card/summary-card.component.spec.ts'`, que falló por una incidencia TypeScript preexistente en `src/app/shared/ui/chip/chip.component.spec.ts` y no está relacionado con estos cambios. (falla)
- Ejecutado `npm run lint:styles` para validación de variables CSS y `npx eslint src/app/shared/ui/summary-card/summary-card.component.spec.ts`, ambos completados correctamente. (éxito)
- Ejecutado `git diff --check` para comprobaciones de diff y formato después de aplicar cambios, sin errores reportados. (éxito)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65f476d2f88327aab6b6773819f508)