### PR TITLE
fix(frontend): align typography token references

### DIFF
--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
@@ -60,7 +60,7 @@
     align-items: center;
     justify-content: center;
     color: var(--text-secondary-color);
-    font-size: var(--font-size-large);
+    font-size: var(--type-heading-md-font-size);
     background: transparent;
     border-left: var(--panel-border);
     font-weight: 600;

--- a/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
+++ b/apps/frontend/src/app/features/employees/components/employee-card/employee-card.component.css
@@ -28,7 +28,7 @@
     font-size: var(--type-label-md-font-size);
     line-height: var(--type-label-md-line-height);
 
-    text-transform: var(--type-caps-transform);
+    text-transform: var(--type-caps-text-transform);
     letter-spacing: var(--type-caps-letter-spacing);
     text-shadow: 0 1px 0 var(--color-black);
 }

--- a/apps/frontend/src/app/features/worksites/components/worksite-detail-panel/worksite-detail-panel.component.css
+++ b/apps/frontend/src/app/features/worksites/components/worksite-detail-panel/worksite-detail-panel.component.css
@@ -26,9 +26,9 @@
 
     font-size: var(--type-label-md-font-size);
     font-weight: var(--type-label-md-font-weight);
-    line-height: var(--type-label-md-line-weight);
+    line-height: var(--type-label-md-line-height);
 
-    letter-spacing: var(--type-wide-caps-letter-spacing);
+    letter-spacing: var(--type-caps-wide-letter-spacing);
     text-transform: var(--type-caps-text-transform);
 }
 
@@ -37,11 +37,11 @@
     margin: 0;
     color: var(--text-primary-color);
 
-    font-weight: var(--type-caption-sm-weight);
-    font-size: var(--type-caption-sm-size);
-    line-height: var(--type-caption-sm-line-weight);
+    font-weight: var(--type-caption-sm-font-weight);
+    font-size: var(--type-caption-sm-font-size);
+    line-height: var(--type-caption-sm-line-height);
 
-    letter-spacing: var(--type-wide-caps-letter-spacing);
+    letter-spacing: var(--type-caps-wide-letter-spacing);
     text-transform: var(--type-caps-text-transform);
 
     overflow-wrap: anywhere;

--- a/apps/frontend/src/app/shared/ui/field/field.component.css
+++ b/apps/frontend/src/app/shared/ui/field/field.component.css
@@ -10,7 +10,7 @@
 
     font-size: var(--type-label-md-font-size);
     font-weight: var(--type-label-md-font-weight);
-    line-height: var(--type-label-md-line-weight);
+    line-height: var(--type-label-md-line-height);
 
     color: var(--text-primary-color);
 }
@@ -23,7 +23,7 @@
 .app-field__hint {
     font-size: var(--type-body-sm-font-size);
     font-weight: var(--type-body-sm-font-weight);
-    line-height: var(--type-body-sm-line-weight);
+    line-height: var(--type-body-sm-line-height);
 
     color: var(--text-primary-color);
 }
@@ -31,7 +31,7 @@
 .app-field__error {
     font-size: var(--type-body-sm-font-size);
     font-weight: var(--type-body-sm-font-weight);
-    line-height: var(--type-body-sm-line-weight);
+    line-height: var(--type-body-sm-line-height);
 
     color: var(--color-error-500);
 }

--- a/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
+++ b/apps/frontend/src/app/shared/ui/paginator/paginator.component.css
@@ -39,7 +39,8 @@
 
 .paginator__text {
     color: var(--text-secondary-color);
-    font-size: var(--type-label-sm-size);
-    font-weight: var(--type-label-sm-weight);
-    letter-spacing: var(--type-label-sm-letter-spacing);
+    font-size: var(--type-label-sm-font-size);
+    font-weight: var(--type-label-sm-font-weight);
+    line-height: var(--type-label-sm-line-height);
+    letter-spacing: var(--type-caps-letter-spacing);
 }

--- a/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.css
+++ b/apps/frontend/src/app/shared/ui/range-slider/range-slider.component.css
@@ -16,7 +16,7 @@
     border-radius: var(--form-range-value-border-radius);
     background: var(--form-range-value-background-color);
     color: var(--form-range-value-text-color);
-    font-size: var(--form-range-value-text-size);
+    font-size: var(--form-range-value-text-font-size);
     font-weight: var(--form-range-value-text-weight);
 }
 

--- a/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
+++ b/apps/frontend/src/app/shared/ui/summary-card/summary-card.component.css
@@ -34,7 +34,7 @@
 
     font-size: var(--type-label-md-font-size);
     font-weight: var(--type-label-md-font-weight);
-    line-height: var(--type-label-md-line-weight);
+    line-height: var(--type-label-md-line-height);
 
     letter-spacing: var(--type-caps-letter-spacing);
     text-transform: var(--type-caps-text-transform);

--- a/apps/frontend/src/styles/components/section.css
+++ b/apps/frontend/src/styles/components/section.css
@@ -11,10 +11,11 @@
 }
 
 .app-section__title {
-    font-size: var(--type-heading-md-size);
-    font-weight: var(--type-heading-md-weight);
-    text-transform: var(--type-heading-md-transform);
-    letter-spacing: var(--type-heading-md-letter-spacing);
+    font-size: var(--type-heading-md-font-size);
+    font-weight: var(--type-heading-md-font-weight);
+    line-height: var(--type-heading-md-line-height);
+    text-transform: var(--type-caps-text-transform);
+    letter-spacing: var(--type-caps-letter-spacing);
     color: var(--accent-color);
     margin: 0;
 }

--- a/apps/frontend/src/styles/components/table.css
+++ b/apps/frontend/src/styles/components/table.css
@@ -34,10 +34,11 @@
     padding-inline: var(--panel-padding-inline);
     padding-block: var(--panel-padding-block);
     text-align: left;
-    font-size: var(--type-label-sm-size);
-    font-weight: var(--type-label-sm-weight);
-    text-transform: var(--type-label-sm-transform);
-    letter-spacing: var(--type-label-sm-letter-spacing);
+    font-size: var(--type-label-sm-font-size);
+    font-weight: var(--type-label-sm-font-weight);
+    line-height: var(--type-label-sm-line-height);
+    text-transform: var(--type-caps-text-transform);
+    letter-spacing: var(--type-caps-letter-spacing);
     color: var(--text-primary-color);
 }
 

--- a/apps/frontend/src/styles/tokens/forms.tokens.css
+++ b/apps/frontend/src/styles/tokens/forms.tokens.css
@@ -45,7 +45,7 @@
 
     --form-range-value-text-color: var(--color-gray-800);
     --form-range-value-text-font-size: var(--type-body-md-font-size);
-    --form-range-value-text-weight: var(--type-body-md-font-weight);
+    --form-range-value-text-weight: var(--type-label-sm-font-weight);
     --form-range-value-background-color: var(--accent-color);
     --form-range-value-border-radius: var(--size-200);
     --form-range-value-padding: var(--size-100) var(--size-200);

--- a/apps/frontend/src/styles/tokens/forms.tokens.css
+++ b/apps/frontend/src/styles/tokens/forms.tokens.css
@@ -5,12 +5,12 @@
     --form-label-gap: var(--size-300);
 
     --form-hint-text-color: var(--text-secondary-color);
-    --form-hint-font-size: var(--literal-small-font-size);
-    --form-hint-font-weight: var(--font-weight-regular);
+    --form-hint-font-size: var(--type-body-sm-font-size);
+    --form-hint-font-weight: var(--type-body-sm-font-weight);
 
     --form-error-text-color: var(--color-error-500);
-    --form-error-font-size: var(--literal-body-font-size);
-    --form-error-font-weight: var(--font-weight-regular);
+    --form-error-font-size: var(--type-body-sm-font-size);
+    --form-error-font-weight: var(--type-body-sm-font-weight);
 
     /* form-control      → input text / textarea / select */
     --form-control-border: var(--border-width-thin) var(--border-style) var(--border-color-accent);
@@ -35,8 +35,8 @@
     /* form-range        → slider */
     --form-range-text-color: var(--color-gray-800);
     --form-range-focus-ring: var(--focus-ring);
-    --form-range-text-size: var(--literal-body-font-size);
-    --form-range-text-weight: var(--font-weight-bold);
+    --form-range-text-font-size: var(--type-body-md-font-size);
+    --form-range-text-weight: var(--type-body-md-font-weight);
 
     --form-range-height: var(--size-200);
     --form-range-radius: var(--size-100);
@@ -44,8 +44,8 @@
     --form-range-color: var(--accent-color);
 
     --form-range-value-text-color: var(--color-gray-800);
-    --form-range-value-text-size: var(--literal-body-font-size);
-    --form-range-value-text-weight: var(--font-weight-bold);
+    --form-range-value-text-font-size: var(--type-body-md-font-size);
+    --form-range-value-text-weight: var(--type-body-md-font-weight);
     --form-range-value-background-color: var(--accent-color);
     --form-range-value-border-radius: var(--size-200);
     --form-range-value-padding: var(--size-100) var(--size-200);
@@ -93,7 +93,7 @@
     --search-bar-focus-ring: 0 0 0 var(--focus-ring-width) var(--color-primary-focus-alpha-30);
     --search-bar-padding-block: var(--size-225);
     --search-bar-padding-inline: var(--size-250);
-    --search-bar-font-size: var(--literal-body-font-size);
+    --search-bar-font-size: var(--type-body-md-font-size);
 
     /* app-form-actions      → buttons */
 }


### PR DESCRIPTION
### Motivation

- Normalizar el uso de tokens tipográficos en el frontend para usar el contrato canónico definido en `apps/frontend/src/styles/tokens/literals.tokens.css` y eliminar sufijos y referencias heredadas.
- Evitar variables CSS inexistentes y asegurar que cada `var(--...)` esté declarado o tenga un `fallback` explícito.

### Description

- Reemplacé tokens obsoletos y sufijos inconsistentes en componentes y estilos globales (por ejemplo, `-size` → `-font-size`, `-line-weight` → `-line-height`, `-weight` → `-font-weight`) en `section.css`, `table.css`, `paginator.component.css`, `field.component.css`, `summary-card.component.css`, `employee-card.component.css`, `worksite-detail-panel.component.css` y `main-menu.component.css`.
- Sustituí referencias `--type-label-sm-*` y similares por sus homologas con sufijos `-font-size`, `-font-weight`, `-line-height` y adopté los tokens `--type-caps-*` donde aplica (por ejemplo `--type-caps-letter-spacing`, `--type-caps-text-transform`).
- Normalicé tokens de formularios en `apps/frontend/src/styles/tokens/forms.tokens.css`, eliminando referencias `--literal-*` y renombrando los tokens de rango para usar `--form-range-*-font-size` y `--form-range-value-*-font-size`.
- Actualicé el consumidor del slider en `range-slider.component.css` para leer el token renombrado `--form-range-value-text-font-size`.
- Ejecuté una auditoría automática que revisó todas las expresiones `var(--...)` en los CSS del frontend y corregí las referencias no declaradas o sin `fallback` detectadas por dicha auditoría.

### Testing

- Ejecuté `git diff --check` y no arrojó problemas relacionados con los cambios aplicados.
- Ejecuté la auditoría Python (revisión de 52 archivos CSS y 298 declaraciones) que confirmó que cada `var(--...)` está declarada o incluye un `fallback` (resultado: pasado).
- Ejecuté `npm run lint:styles` donde el validador de variables detectó colores en bruto en `src/styles/primitives.css` que vienen de la base del repo y bloquean la ejecución completa del linter (falla preexistente no relacionada con los cambios de tokens).
- Ejecuté `npm test -- --watch=false` y la tarea de tests quedó bloqueada por un error TypeScript preexistente en `chip.component.spec.ts` (falla no relacionada con este cambio de CSS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67510ded748327a5e788c019b59299)