### PR TITLE
Make list hover/odd and subtle-surface tokens theme-specific; adjust light theme subtle surfaces

### DIFF
--- a/apps/frontend/src/styles/themes/theme.dark.css
+++ b/apps/frontend/src/styles/themes/theme.dark.css
@@ -37,6 +37,11 @@
 
     --subtle-surface-background-color: var(--color-gray-700);
     --subtle-icon-background-color: var(--color-gray-650);
+    --list-background-color: var(--panel-background-color);
+    --list-text-color: var(--text-primary-color);
+    --list-item-odd-background-color: var(--color-gray-850);
+    --list-item-even-background-color: var(--panel-background-color);
+    --list-item-hover-background-color: var(--color-primary-900);
 
     --control-accent-background-color: linear-gradient(
         180deg,

--- a/apps/frontend/src/styles/themes/theme.light.css
+++ b/apps/frontend/src/styles/themes/theme.light.css
@@ -37,8 +37,13 @@
     --form-control-background-color: var(--color-white);
     --form-control-text-color: var(--text-primary-color);
 
-    --subtle-surface-background-color: var(--color-gray-700);
-    --subtle-icon-background-color: var(--color-gray-650);
+    --subtle-surface-background-color: var(--color-gray-50);
+    --subtle-icon-background-color: var(--color-gray-100);
+    --list-background-color: var(--panel-background-color);
+    --list-text-color: var(--text-primary-color);
+    --list-item-odd-background-color: var(--color-gray-10);
+    --list-item-even-background-color: var(--panel-background-color);
+    --list-item-hover-background-color: var(--color-primary-100);
 
     --control-accent-background-color: linear-gradient(
         180deg,

--- a/apps/frontend/src/styles/tokens/list.tokens.css
+++ b/apps/frontend/src/styles/tokens/list.tokens.css
@@ -1,16 +1,11 @@
 :root {
-    --list-background-color: var(--panel-background-color);
     --list-background-color-odd: var(--list-item-odd-background-color);
     --list-border: var(--panel-border);
     --list-border-radius: var(--panel-border-radius);
-    --list-text-color: var(--text-primary-color);
     --list-shadow: var(--panel-shadow);
     --list-padding-block: var(--size-100);
     --list-padding-inline: 0;
 
     --list-item-padding-block: var(--panel-medium-padding-block);
     --list-item-padding-inline: var(--panel-padding-inline);
-    --list-item-hover-background-color: var(--color-primary-900);
-    --list-item-odd-background-color: var(--color-gray-850);
-    --list-item-even-background-color: var(--list-background-color);
 }


### PR DESCRIPTION
### Motivation
- Expose list row alternation and hover colors as theme-level semantic tokens instead of hardcoding them in the list component tokens so themes can pick appropriate values for dark and light modes. 
- In the light theme, use light subtle surface/icon backgrounds with sufficient contrast versus `--text-primary-color`/`--text-secondary-color`.
- Ensure consumers of `--subtle-surface-background-color` (tables, autocomplete, summary card, section messages) pick up the theme-appropriate values.

### Description
- Added `--list-item-odd-background-color` and `--list-item-hover-background-color` to `apps/frontend/src/styles/themes/theme.dark.css` and `apps/frontend/src/styles/themes/theme.light.css` so themes control odd/hover visuals. 
- Changed the light theme `--subtle-surface-background-color` to `var(--color-gray-50)` and `--subtle-icon-background-color` to `var(--color-gray-100)` in `apps/frontend/src/styles/themes/theme.light.css` (was using the dark gray values before). 
- Removed local definitions of `--list-item-hover-background-color` and `--list-item-odd-background-color` from `apps/frontend/src/styles/tokens/list.tokens.css` so the list tokens now consume the theme-provided semantic tokens.

### Testing
- Ran `npm run lint`; style linting completed and reported "All files pass linting." (style variable validation and CSS lints).  
- Ran `npm run build` in `apps/frontend` and a production build was produced successfully.  
- Ran unit tests with `npm test -- --watch=false`; the run failed due to an existing TypeScript issue in a spec (`TS2322` in `src/app/shared/ui/chip/chip.component.spec.ts`) unrelated to these CSS changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67635efa88832799a2d651ef6e9b7f)