### PR TITLE
fix(frontend): preserve main menu user separator

### DIFF
--- a/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
+++ b/apps/frontend/src/app/core/layout/main-menu/main-menu.component.css
@@ -49,9 +49,9 @@
 
     white-space: nowrap;
     overflow: hidden;
+    border: 0;
     border-right: var(--panel-border);
     background: transparent;
-    border: 0;
 }
 
 .main-menu__icon-button {


### PR DESCRIPTION
### Motivation
- Asegurar que el botón del nombre de usuario en la barra principal no tenga bordes generales que reescriban su separador derecho y que el separador permanezca en los estados normal, hover y focus.

### Description
- Reordenar las declaraciones en `.main-menu__user-name` para aplicar primero `border: 0` y después `border-right: var(--panel-border)` con lo que se elimina cualquier borde residual y se conserva únicamente el separador derecho.
- Verificar que no existen reglas posteriores en el mismo componente que sobrescriban el separador en `:hover` o `:focus`.
- Incluir el cambio como commit con mensaje `fix(frontend): preserve main menu user separator`.

### Testing
- Ejecutado `npx ng lint` y la comprobación de ESLint de Angular pasó correctamente, aunque el validador de estilos reportó colores crudos preexistentes en `src/styles/primitives.css` (no relacionados con este cambio). 
- Ejecutado `npm run build` y la compilación produjo la salida de producción sin errores. 
- Ejecutado `npx prettier --check` que mostró advertencias de estilo previas; se aplicó formato donde fue necesario durante el flujo de trabajo. 
- Ejecutado `git diff --check` y una aserción estática en Python que confirmó que `border: 0` aparece antes de `border-right` y que no hay reglas `:hover`/`:focus` en el componente que sobrescriban el separador.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a679f845a148327bba5db1f7d2758b5)