### PR TITLE
fix(frontend): add unit to letter spacing token

### DIFF
--- a/apps/frontend/src/styles/primitives.css
+++ b/apps/frontend/src/styles/primitives.css
@@ -100,7 +100,7 @@
     --letter-spacing-000: 0;
     --letter-spacing-200: 0.0625rem;
     --letter-spacing-400: 0.125rem;
-    --letter-spacing-600: 0.1875;
+    --letter-spacing-600: 0.1875rem;
     --letter-spacing-800: 0.25rem;
 
     --line-height-tight: 1.15;


### PR DESCRIPTION
### Motivation
- Añadir la unidad faltante a `--letter-spacing-600` para que sea un valor de longitud válido y preservar la progresión `0.0625rem` entre `--letter-spacing-200/400/600/800`.

### Description
- Cambiado en `apps/frontend/src/styles/primitives.css` la línea `--letter-spacing-600: 0.1875;` por `--letter-spacing-600: 0.1875rem;` y comprobado que no hay consumidores en el repositorio que dependan de la versión sin unidad.

### Testing
- Ejecutados `rg -n --hidden --glob '!node_modules' --glob '!vendor' --glob '!dist' --glob '!build' "var(--letter-spacing-600)|--letter-spacing-600" .` (solo la declaración), `git diff --check` (sin errores), `npm run build` (build completado), y `npm run lint:styles` (reportó violaciones preexistentes de colores que no fueron introducidas por este cambio).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67a0c693c883278d93e95fa631f577)