### PR TITLE
feat(frontend): centralize application messages

### DIFF
--- a/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
+++ b/apps/frontend/src/app/core/user/pages/user-preferences-page.component.html
@@ -1,88 +1,84 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.userPreferences">
-    <div pageContent class="app-page-content user-preferences">
-        <section class="app-card preferences-card">
-            <div class="app-card__body preferences-card__body">
-                <form class="app-form" [formGroup]="form" (ngSubmit)="save()">
-                    <app-field
-                        controlId="preferences-locale"
-                        [label]="'userPreferences.fields.locale' | translate"
-                        required
-                    >
-                        <app-select
-                            inputId="preferences-locale"
-                            formControlName="locale"
-                            [options]="localeOptions"
-                            required
-                        />
-                    </app-field>
+  <div pageContent class="app-page-content user-preferences">
+    <section class="app-card preferences-card">
+      <div class="app-card__body preferences-card__body">
+        <form class="app-form" [formGroup]="form" (ngSubmit)="save()">
+          <app-field
+            controlId="preferences-locale"
+            [label]="'userPreferences.fields.locale' | translate"
+            required
+          >
+            <app-select
+              inputId="preferences-locale"
+              formControlName="locale"
+              [options]="localeOptions"
+              required
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="preferences-time-format"
-                        [label]="'userPreferences.fields.timeFormat' | translate"
-                        required
-                    >
-                        <app-select
-                            inputId="preferences-time-format"
-                            formControlName="timeFormat"
-                            [options]="timeFormatOptions"
-                            required
-                        />
-                    </app-field>
+          <app-field
+            controlId="preferences-time-format"
+            [label]="'userPreferences.fields.timeFormat' | translate"
+            required
+          >
+            <app-select
+              inputId="preferences-time-format"
+              formControlName="timeFormat"
+              [options]="timeFormatOptions"
+              required
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="preferences-timezone"
-                        [label]="'userPreferences.fields.defaultTimezone' | translate"
-                        [error]="
-                            form.controls.defaultTimezone.touched &&
-                            form.controls.defaultTimezone.invalid
-                                ? ('userPreferences.errors.invalidTimezone' | translate)
-                                : ''
-                        "
-                        [invalid]="
-                            form.controls.defaultTimezone.touched &&
-                            form.controls.defaultTimezone.invalid
-                        "
-                        required
-                    >
-                        <app-autocomplete-textbox
-                            inputId="preferences-timezone"
-                            formControlName="defaultTimezone"
-                            [searchMethod]="searchMethod"
-                            [displayWith]="timezoneDisplayWith"
-                            [valueWith]="timezoneValueWith"
-                            [resolveByValue]="resolveTimezoneByValue"
-                            [emptyHint]="'userPreferences.fields.defaultTimezoneHint' | translate"
-                            ariaLabelledBy="preferences-timezone-label"
-                            [ariaDescribedBy]="
-                                form.controls.defaultTimezone.touched &&
-                                form.controls.defaultTimezone.invalid
-                                    ? 'preferences-timezone-error'
-                                    : null
-                            "
-                            [ariaInvalid]="
-                                form.controls.defaultTimezone.touched &&
-                                form.controls.defaultTimezone.invalid
-                            "
-                        />
-                    </app-field>
+          <app-field
+            controlId="preferences-timezone"
+            [label]="'userPreferences.fields.defaultTimezone' | translate"
+            [error]="
+              form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+                ? ('userPreferences.errors.invalidTimezone' | translate)
+                : ''
+            "
+            [invalid]="
+              form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+            "
+            required
+          >
+            <app-autocomplete-textbox
+              inputId="preferences-timezone"
+              formControlName="defaultTimezone"
+              [searchMethod]="searchMethod"
+              [displayWith]="timezoneDisplayWith"
+              [valueWith]="timezoneValueWith"
+              [resolveByValue]="resolveTimezoneByValue"
+              [emptyHint]="'userPreferences.fields.defaultTimezoneHint' | translate"
+              ariaLabelledBy="preferences-timezone-label"
+              [ariaDescribedBy]="
+                form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+                  ? 'preferences-timezone-error'
+                  : null
+              "
+              [ariaInvalid]="
+                form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+              "
+            />
+          </app-field>
 
-                    @if (errorMessage) {
-                        <p class="app-message app-message--error">
-                            {{ errorMessage | translate }}
-                        </p>
-                    }
+          @if (errorMessage) {
+            <app-message type="error" presentation="inline">
+              {{ errorMessage | translate }}
+            </app-message>
+          }
 
-                    <div class="app-form-actions">
-                        <app-button type="button" variant="secondary" (clicked)="cancel()">
-                            {{ 'actions.cancel' | translate }}
-                        </app-button>
+          <div class="app-form-actions">
+            <app-button type="button" variant="secondary" (clicked)="cancel()">
+              {{ 'actions.cancel' | translate }}
+            </app-button>
 
-                        <app-button type="submit" variant="main">
-                            {{ 'actions.save' | translate }}
-                        </app-button>
-                    </div>
-                </form>
-            </div>
-        </section>
-    </div>
+            <app-button type="submit" variant="main">
+              {{ 'actions.save' | translate }}
+            </app-button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
 </app-page-template>

--- a/apps/frontend/src/app/core/user/pages/user-preferences-page.component.ts
+++ b/apps/frontend/src/app/core/user/pages/user-preferences-page.component.ts
@@ -39,10 +39,13 @@ import { TimeFormat } from '../services/user-profile-api.service';
  *
  * Those responsibilities belong to CurrentUserFacade and lower layers.
  */
+import { MessageComponent } from '../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-user-preferences-page',
   standalone: true,
   imports: [
+    MessageComponent,
     ReactiveFormsModule,
     TranslatePipe,
     AutocompleteTextboxComponent,

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.css
@@ -1,11 +1,3 @@
 .application-settings__content {
-    display: flex;
-}
-
-.application-settings__message {
-    margin: 0;
-}
-
-.application-settings__message--error {
-    color: var(--color-error-soft);
+  display: flex;
 }

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.html
@@ -1,127 +1,108 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="navigation.applicationSettings">
-    <div pageContent class="app-page-content application-settings__content">
-        <section class="app-card settings-card">
-            <div class="app-card__body settings-card__body">
-                <form class="app-form" [formGroup]="form" (ngSubmit)="save()">
-                    <app-field
-                        controlId="daysUntilLocked"
-                        [label]="'applicationSettings.fields.daysUntilLocked' | translate"
-                        required
-                    >
-                        <app-range-slider
-                            inputId="daysUntilLocked"
-                            formControlName="daysUntilLocked"
-                            [min]="0"
-                            [max]="daysUntilLockedSliderMax"
-                            [step]="1"
-                            required
-                        />
-                    </app-field>
+  <div pageContent class="app-page-content application-settings__content">
+    <section class="app-card settings-card">
+      <div class="app-card__body settings-card__body">
+        <form class="app-form" [formGroup]="form" (ngSubmit)="save()">
+          <app-field
+            controlId="daysUntilLocked"
+            [label]="'applicationSettings.fields.daysUntilLocked' | translate"
+            required
+          >
+            <app-range-slider
+              inputId="daysUntilLocked"
+              formControlName="daysUntilLocked"
+              [min]="0"
+              [max]="daysUntilLockedSliderMax"
+              [step]="1"
+              required
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="employeeWorkplaceCreationAllowed"
-                        [label]="
-                            'applicationSettings.fields.employeeWorkplaceCreationAllowed'
-                                | translate
-                        "
-                    >
-                        <app-toggle-button
-                            inputId="employeeWorkplaceCreationAllowed"
-                            formControlName="employeeWorkplaceCreationAllowed"
-                            ariaLabelledBy="employeeWorkplaceCreationAllowed-label"
-                        />
-                    </app-field>
+          <app-field
+            controlId="employeeWorkplaceCreationAllowed"
+            [label]="'applicationSettings.fields.employeeWorkplaceCreationAllowed' | translate"
+          >
+            <app-toggle-button
+              inputId="employeeWorkplaceCreationAllowed"
+              formControlName="employeeWorkplaceCreationAllowed"
+              ariaLabelledBy="employeeWorkplaceCreationAllowed-label"
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="worksiteChangeDuringShiftAllowed"
-                        [label]="
-                            'applicationSettings.fields.worksiteChangeDuringShiftAllowed'
-                                | translate
-                        "
-                    >
-                        <app-toggle-button
-                            inputId="worksiteChangeDuringShiftAllowed"
-                            formControlName="worksiteChangeDuringShiftAllowed"
-                            ariaLabelledBy="worksiteChangeDuringShiftAllowed-label"
-                        />
-                    </app-field>
+          <app-field
+            controlId="worksiteChangeDuringShiftAllowed"
+            [label]="'applicationSettings.fields.worksiteChangeDuringShiftAllowed' | translate"
+          >
+            <app-toggle-button
+              inputId="worksiteChangeDuringShiftAllowed"
+              formControlName="worksiteChangeDuringShiftAllowed"
+              ariaLabelledBy="worksiteChangeDuringShiftAllowed-label"
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="employeeManualTimelogEntryAllowed"
-                        [label]="
-                            'applicationSettings.fields.employeeManualTimelogEntryAllowed'
-                                | translate
-                        "
-                    >
-                        <app-toggle-button
-                            inputId="employeeManualTimelogEntryAllowed"
-                            formControlName="employeeManualTimelogEntryAllowed"
-                            ariaLabelledBy="employeeManualTimelogEntryAllowed-label"
-                        />
-                    </app-field>
+          <app-field
+            controlId="employeeManualTimelogEntryAllowed"
+            [label]="'applicationSettings.fields.employeeManualTimelogEntryAllowed' | translate"
+          >
+            <app-toggle-button
+              inputId="employeeManualTimelogEntryAllowed"
+              formControlName="employeeManualTimelogEntryAllowed"
+              ariaLabelledBy="employeeManualTimelogEntryAllowed-label"
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="default-timezone"
-                        [label]="'applicationSettings.fields.defaultTimezone' | translate"
-                        [error]="
-                            form.controls.defaultTimezone.touched &&
-                            form.controls.defaultTimezone.invalid
-                                ? ('applicationSettings.errors.invalidTimezone' | translate)
-                                : ''
-                        "
-                        [invalid]="
-                            form.controls.defaultTimezone.touched &&
-                            form.controls.defaultTimezone.invalid
-                        "
-                        required
-                    >
-                        <app-autocomplete-textbox
-                            inputId="default-timezone"
-                            formControlName="defaultTimezone"
-                            [searchMethod]="searchMethod"
-                            [displayWith]="timezoneDisplayWith"
-                            [valueWith]="timezoneValueWith"
-                            [resolveByValue]="resolveTimezoneByValue"
-                            [emptyHint]="
-                                'applicationSettings.fields.defaultTimezoneHint' | translate
-                            "
-                            ariaLabelledBy="default-timezone-label"
-                            [ariaDescribedBy]="
-                                form.controls.defaultTimezone.touched &&
-                                form.controls.defaultTimezone.invalid
-                                    ? 'default-timezone-error'
-                                    : null
-                            "
-                            [ariaInvalid]="
-                                form.controls.defaultTimezone.touched &&
-                                form.controls.defaultTimezone.invalid
-                            "
-                        />
-                    </app-field>
+          <app-field
+            controlId="default-timezone"
+            [label]="'applicationSettings.fields.defaultTimezone' | translate"
+            [error]="
+              form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+                ? ('applicationSettings.errors.invalidTimezone' | translate)
+                : ''
+            "
+            [invalid]="
+              form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+            "
+            required
+          >
+            <app-autocomplete-textbox
+              inputId="default-timezone"
+              formControlName="defaultTimezone"
+              [searchMethod]="searchMethod"
+              [displayWith]="timezoneDisplayWith"
+              [valueWith]="timezoneValueWith"
+              [resolveByValue]="resolveTimezoneByValue"
+              [emptyHint]="'applicationSettings.fields.defaultTimezoneHint' | translate"
+              ariaLabelledBy="default-timezone-label"
+              [ariaDescribedBy]="
+                form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+                  ? 'default-timezone-error'
+                  : null
+              "
+              [ariaInvalid]="
+                form.controls.defaultTimezone.touched && form.controls.defaultTimezone.invalid
+              "
+            />
+          </app-field>
 
-                    @if (errorMessage) {
-                        <p class="application-settings__message application-settings__message--error">
-                            {{ errorMessage | translate }}
-                        </p>
-                    }
+          @if (errorMessage) {
+            <app-message type="error" presentation="inline">
+              {{ errorMessage | translate }}
+            </app-message>
+          }
 
-                    <div class="app-form-actions">
-                        <app-button type="button" variant="secondary" (clicked)="cancel()">
-                            {{ 'actions.cancel' | translate }}
-                        </app-button>
+          <div class="app-form-actions">
+            <app-button type="button" variant="secondary" (clicked)="cancel()">
+              {{ 'actions.cancel' | translate }}
+            </app-button>
 
-                        @if (isAdmin) {
-                            <app-button
-                                type="submit"
-                                [disabled]="form.invalid || saving"
-                                variant="main"
-                            >
-                                {{ 'actions.save' | translate }}
-                            </app-button>
-                        }
-                    </div>
-                </form>
-            </div>
-        </section>
-    </div>
+            @if (isAdmin) {
+              <app-button type="submit" [disabled]="form.invalid || saving" variant="main">
+                {{ 'actions.save' | translate }}
+              </app-button>
+            }
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
 </app-page-template>

--- a/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
+++ b/apps/frontend/src/app/features/applicationsettings/pages/application-settings-page.component.ts
@@ -21,10 +21,13 @@ import { ApplicationSettings } from '../models/application-settings';
 import { ApplicationSettingsApiService } from '../services/application-settings-api.service';
 import { retryTransientHttpErrors } from '../../../shared/utils/http-retry.util';
 
+import { MessageComponent } from '../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-application-settings-page',
   standalone: true,
   imports: [
+    MessageComponent,
     ReactiveFormsModule,
     TranslatePipe,
     AutocompleteTextboxComponent,

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
@@ -1,59 +1,50 @@
 <section class="app-section schedule-table" aria-labelledby="schedule-table-title">
-    <header class="app-section__header schedule-table__header">
-        <h2 id="schedule-table-title" class="app-section__title schedule-table__title">
-            {{ 'schedule.schedules' | translate }}
-        </h2>
-        @if (totalItems() > 0) {
-            <app-paginator
-                [totalItems]="totalItems()"
-                [pageSize]="pageSize"
-                [currentPage]="currentPage()"
-                [betweenLabel]="'paginator.of' | translate"
-                [previousLabel]="'paginator.previousPage' | translate"
-                [nextLabel]="'paginator.nextPage' | translate"
-                [ariaLabel]="'paginator.ariaLabel' | translate"
-                (pageRequested)="onPageChange($event)"
-            />
+  <header class="app-section__header schedule-table__header">
+    <h2 id="schedule-table-title" class="app-section__title schedule-table__title">
+      {{ 'schedule.schedules' | translate }}
+    </h2>
+    @if (totalItems() > 0) {
+      <app-paginator
+        [totalItems]="totalItems()"
+        [pageSize]="pageSize"
+        [currentPage]="currentPage()"
+        [betweenLabel]="'paginator.of' | translate"
+        [previousLabel]="'paginator.previousPage' | translate"
+        [nextLabel]="'paginator.nextPage' | translate"
+        [ariaLabel]="'paginator.ariaLabel' | translate"
+        (pageRequested)="onPageChange($event)"
+      />
+    }
+  </header>
+
+  @if (schedulesResource.error() !== undefined) {
+    <app-message type="error">{{ 'schedule.loadError' | translate }}</app-message>
+  }
+
+  @if (schedulesResource.isLoading()) {
+    <app-message type="info">{{ 'schedule.loading' | translate }}</app-message>
+  }
+
+  @if (!schedulesResource.isLoading() && schedules().length > 0) {
+    <table class="app-table schedule-table__table">
+      <thead>
+        <tr>
+          <th scope="col">{{ 'schedule.code' | translate }}</th>
+          <th scope="col">{{ 'schedule.name' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (schedule of schedules(); track schedule.code) {
+          <tr>
+            <td>{{ schedule.code }}</td>
+            <td>{{ schedule.name }}</td>
+          </tr>
         }
-    </header>
+      </tbody>
+    </table>
+  }
 
-    @if (schedulesResource.error() !== undefined) {
-        <div
-            class="app-section__message app-section__message--error schedule-table__message schedule-table__message--error"
-            role="alert"
-        >
-            {{ 'schedule.loadError' | translate }}
-        </div>
-    }
-
-    @if (schedulesResource.isLoading()) {
-        <div class="app-section__message schedule-table__message" aria-live="polite">
-            {{ 'schedule.loading' | translate }}
-        </div>
-    }
-
-    @if (!schedulesResource.isLoading() && schedules().length > 0) {
-        <table class="app-table schedule-table__table">
-            <thead>
-                <tr>
-                    <th scope="col">{{ 'schedule.code' | translate }}</th>
-                    <th scope="col">{{ 'schedule.name' | translate }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                @for (schedule of schedules(); track schedule.code) {
-                    <tr>
-                        <td>{{ schedule.code }}</td>
-                        <td>{{ schedule.name }}</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    }
-
-    @if (isEmpty()) {
-        <div class="app-section__message schedule-table__message" aria-live="polite">
-            {{ 'schedule.empty' | translate }}
-        </div>
-    }
+  @if (isEmpty()) {
+    <app-message type="info">{{ 'schedule.empty' | translate }}</app-message>
+  }
 </section>

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.ts
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.ts
@@ -17,10 +17,12 @@ import { ScheduleApiService, SchedulePage } from '../../services/schedule-api.se
 import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
 import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
+import { MessageComponent } from '../../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-schedule-table',
   standalone: true,
-  imports: [TranslatePipe, PaginatorComponent],
+  imports: [MessageComponent, TranslatePipe, PaginatorComponent],
   templateUrl: './schedule-table.component.html',
   styleUrl: './schedule-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -1,82 +1,67 @@
 <section class="app-section timelog-table" aria-labelledby="timelog-table-title">
-    <header class="app-section__header timelog-table__header">
-        <h2 id="timelog-table-title" class="app-section__title timelog-table__title">
-            {{ 'timelog.timelogs' | translate }}
-        </h2>
-        @if (totalItems() > 0) {
-            <app-paginator
-                [totalItems]="totalItems()"
-                [pageSize]="pageSize"
-                [currentPage]="currentPage()"
-                [betweenLabel]="'paginator.of' | translate"
-                [previousLabel]="'paginator.previousPage' | translate"
-                [nextLabel]="'paginator.nextPage' | translate"
-                [ariaLabel]="'paginator.ariaLabel' | translate"
-                (pageRequested)="onPageChange($event)"
-            />
+  <header class="app-section__header timelog-table__header">
+    <h2 id="timelog-table-title" class="app-section__title timelog-table__title">
+      {{ 'timelog.timelogs' | translate }}
+    </h2>
+    @if (totalItems() > 0) {
+      <app-paginator
+        [totalItems]="totalItems()"
+        [pageSize]="pageSize"
+        [currentPage]="currentPage()"
+        [betweenLabel]="'paginator.of' | translate"
+        [previousLabel]="'paginator.previousPage' | translate"
+        [nextLabel]="'paginator.nextPage' | translate"
+        [ariaLabel]="'paginator.ariaLabel' | translate"
+        (pageRequested)="onPageChange($event)"
+      />
+    }
+  </header>
+
+  @if (timelogsResource.error() !== undefined) {
+    <app-message type="error">{{ 'timelog.loadError' | translate }}</app-message>
+  }
+
+  @if (timelogsResource.isLoading()) {
+    <app-message type="info">{{ 'timelog.loading' | translate }}</app-message>
+  }
+
+  @if (!timelogsResource.isLoading() && timelogs().length > 0) {
+    <table class="app-table timelog-table__table">
+      <thead>
+        <tr>
+          <th scope="col">{{ 'timelog.date' | translate }}</th>
+          <th scope="col">{{ 'timelog.clockin' | translate }}</th>
+          <th scope="col">{{ 'timelog.clockout' | translate }}</th>
+          <th scope="col">{{ 'timelog.duration' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (
+          timelog of pagedTimelogs();
+          track timelog.entryTime + '-' + (timelog.exitTime ?? 'open')
+        ) {
+          <tr>
+            <td>
+              {{ timelog.entryTime | date: 'shortDate' : userTimezone() : userLocale() }}
+            </td>
+            <td>
+              {{ timelog.entryTime | date: timeFormat() : userTimezone() : userLocale() }}
+            </td>
+            <td>
+              @if (timelog.exitTime) {
+                {{ timelog.exitTime | date: timeFormat() : userTimezone() : userLocale() }}
+              } @else {
+                —
+              }
+            </td>
+            <td>{{ timelog.workTime | duration }}</td>
+          </tr>
         }
-    </header>
+      </tbody>
+    </table>
+  }
 
-    @if (timelogsResource.error() !== undefined) {
-        <div class="app-section__message app-section__message--error timelog-table__message timelog-table__message--error" role="alert">
-            {{ 'timelog.loadError' | translate }}
-        </div>
-    }
-
-    @if (timelogsResource.isLoading()) {
-        <div class="app-section__message timelog-table__message" aria-live="polite">
-            {{ 'timelog.loading' | translate }}
-        </div>
-    }
-
-    @if (!timelogsResource.isLoading() && timelogs().length > 0) {
-        <table class="app-table timelog-table__table">
-            <thead>
-                <tr>
-                    <th scope="col">{{ 'timelog.date' | translate }}</th>
-                    <th scope="col">{{ 'timelog.clockin' | translate }}</th>
-                    <th scope="col">{{ 'timelog.clockout' | translate }}</th>
-                    <th scope="col">{{ 'timelog.duration' | translate }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                @for (
-                    timelog of pagedTimelogs();
-                    track timelog.entryTime + '-' + (timelog.exitTime ?? 'open')
-                ) {
-                    <tr>
-                        <td>
-                            {{
-                                timelog.entryTime
-                                    | date: 'shortDate' : userTimezone() : userLocale()
-                            }}
-                        </td>
-                        <td>
-                            {{
-                                timelog.entryTime
-                                    | date: timeFormat() : userTimezone() : userLocale()
-                            }}
-                        </td>
-                        <td>
-                            @if (timelog.exitTime) {
-                                {{
-                                    timelog.exitTime
-                                        | date: timeFormat() : userTimezone() : userLocale()
-                                }}
-                            } @else {
-                                —
-                            }
-                        </td>
-                        <td>{{ timelog.workTime | duration }}</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    }
-
-    @if (isEmpty()) {
-        <div class="app-section__message timelog-table__message" aria-live="polite">
-            {{ 'timelog.empty' | translate }}
-        </div>
-    }
+  @if (isEmpty()) {
+    <app-message type="info">{{ 'timelog.empty' | translate }}</app-message>
+  }
 </section>

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
@@ -20,10 +20,12 @@ import { FALLBACK_LANGUAGE } from '../../../../core/i18n/language.util';
 import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
 import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
+import { MessageComponent } from '../../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-timelog-table',
   standalone: true,
-  imports: [TranslatePipe, DatePipe, DurationPipe, PaginatorComponent],
+  imports: [MessageComponent, TranslatePipe, DatePipe, DurationPipe, PaginatorComponent],
   templateUrl: './timelog-table.component.html',
   styleUrl: './timelog-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
@@ -1,76 +1,65 @@
 <section class="app-section worksite-table" aria-labelledby="worksite-table-title">
-    <header class="app-section__header worksite-table__header">
-        <h2 id="worksite-table-title" class="app-section__title worksite-table__title">
-            {{ 'worksite.worksites' | translate }}
-        </h2>
-        @if (totalItems() > 0) {
-            <app-paginator
-                [totalItems]="totalItems()"
-                [pageSize]="pageSize"
-                [currentPage]="currentPage()"
-                [betweenLabel]="'paginator.of' | translate"
-                [previousLabel]="'paginator.previousPage' | translate"
-                [nextLabel]="'paginator.nextPage' | translate"
-                [ariaLabel]="'paginator.ariaLabel' | translate"
-                (pageRequested)="onPageChange($event)"
-            />
+  <header class="app-section__header worksite-table__header">
+    <h2 id="worksite-table-title" class="app-section__title worksite-table__title">
+      {{ 'worksite.worksites' | translate }}
+    </h2>
+    @if (totalItems() > 0) {
+      <app-paginator
+        [totalItems]="totalItems()"
+        [pageSize]="pageSize"
+        [currentPage]="currentPage()"
+        [betweenLabel]="'paginator.of' | translate"
+        [previousLabel]="'paginator.previousPage' | translate"
+        [nextLabel]="'paginator.nextPage' | translate"
+        [ariaLabel]="'paginator.ariaLabel' | translate"
+        (pageRequested)="onPageChange($event)"
+      />
+    }
+  </header>
+
+  @if (worksitesResource.error() !== undefined) {
+    <app-message type="error">{{ 'worksite.loadError' | translate }}</app-message>
+  }
+
+  @if (worksitesResource.isLoading()) {
+    <app-message type="info">{{ 'worksite.loading' | translate }}</app-message>
+  }
+
+  @if (!worksitesResource.isLoading() && worksites().length > 0) {
+    <table class="app-table worksite-table__table">
+      <thead>
+        <tr>
+          <th scope="col">{{ 'worksite.code' | translate }}</th>
+          <th scope="col">{{ 'worksite.name' | translate }}</th>
+          <th scope="col">{{ 'worksite.scope' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (worksite of pagedWorksites(); track worksite.code) {
+          <tr
+            class="worksite-table__row"
+            role="button"
+            tabindex="0"
+            [attr.aria-label]="'worksite.openDetail' | translate: { name: worksite.name }"
+            (click)="openWorksite(worksite)"
+            (keydown.enter)="openWorksite(worksite)"
+            (keydown.space)="$event.preventDefault(); openWorksite(worksite)"
+          >
+            <td>{{ worksite.code }}</td>
+            <td>{{ worksite.name }}</td>
+            <td>
+              <app-chip
+                [label]="'worksite.scopes.' + worksite.scope | translate"
+                [type]="worksite.scope === 'ASSIGNED' ? 'primary' : 'default'"
+              ></app-chip>
+            </td>
+          </tr>
         }
-    </header>
+      </tbody>
+    </table>
+  }
 
-    @if (worksitesResource.error() !== undefined) {
-        <div
-            class="app-section__message app-section__message--error worksite-table__message worksite-table__message--error"
-            role="alert"
-        >
-            {{ 'worksite.loadError' | translate }}
-        </div>
-    }
-
-    @if (worksitesResource.isLoading()) {
-        <div class="app-section__message worksite-table__message" aria-live="polite">
-            {{ 'worksite.loading' | translate }}
-        </div>
-    }
-
-    @if (!worksitesResource.isLoading() && worksites().length > 0) {
-        <table class="app-table worksite-table__table">
-            <thead>
-                <tr>
-                    <th scope="col">{{ 'worksite.code' | translate }}</th>
-                    <th scope="col">{{ 'worksite.name' | translate }}</th>
-                    <th scope="col">{{ 'worksite.scope' | translate }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                @for (worksite of pagedWorksites(); track worksite.code) {
-                    <tr
-                        class="worksite-table__row"
-                        role="button"
-                        tabindex="0"
-                        [attr.aria-label]="
-                            'worksite.openDetail' | translate: { name: worksite.name }
-                        "
-                        (click)="openWorksite(worksite)"
-                        (keydown.enter)="openWorksite(worksite)"
-                        (keydown.space)="$event.preventDefault(); openWorksite(worksite)"
-                    >
-                        <td>{{ worksite.code }}</td>
-                        <td>{{ worksite.name }}</td>
-                        <td>
-                            <app-chip
-                                [label]="'worksite.scopes.' + worksite.scope | translate"
-                                [type]="worksite.scope === 'ASSIGNED' ? 'primary' : 'default'"
-                            ></app-chip>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    }
-
-    @if (isEmpty()) {
-        <div class="app-section__message worksite-table__message" aria-live="polite">
-            {{ 'worksite.empty' | translate }}
-        </div>
-    }
+  @if (isEmpty()) {
+    <app-message type="info">{{ 'worksite.empty' | translate }}</app-message>
+  }
 </section>

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
@@ -20,10 +20,12 @@ import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.co
 import { ChipComponent } from '../../../../shared/ui/chip/chip.component';
 import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
+import { MessageComponent } from '../../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-worksite-table',
   standalone: true,
-  imports: [TranslatePipe, PaginatorComponent, ChipComponent],
+  imports: [MessageComponent, TranslatePipe, PaginatorComponent, ChipComponent],
   templateUrl: './worksite-table.component.html',
   styleUrl: './worksite-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.css
@@ -1,20 +1,12 @@
 form {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  flex-grow: 1;
 }
 
 .worksite-form__field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.7rem;
-}
-
-.worksite-form__message {
-    margin: 0;
-}
-
-.worksite-form__message--error {
-    color: var(--color-error-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
 }

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.html
@@ -1,217 +1,200 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.new">
-    <div pageContent class="app-page-content worksite-create-content">
-        <section class="app-card worksites-card">
-            <div class="app-card__body worksites-card__body">
-                    <form class="app-form worksite-form" [formGroup]="form" (ngSubmit)="save()">
-                    <app-field
-                        controlId="worksite-code"
-                        [label]="'worksite.code' | translate"
-                        [hint]="
-                            form.controls.code.pending
-                                ? ('worksite.messages.codeChecking' | translate)
-                                : ''
-                        "
-                        [error]="
-                            form.controls.code.touched && form.controls.code.invalid
-                                ? form.controls.code.hasError('duplicatedCode')
-                                    ? ('worksite.errors.duplicatedCode' | translate)
-                                    : form.controls.code.hasError('codeLookupFailed')
-                                      ? ('worksite.errors.codeLookupFailed' | translate)
-                                      : ('worksite.errors.invalidCode' | translate)
-                                : ''
-                        "
-                        [invalid]="form.controls.code.touched && form.controls.code.invalid"
-                        [disabled]="form.controls.code.disabled"
-                        required
-                    >
-                        <app-input
-                            inputId="worksite-code"
-                            formControlName="code"
-                            autocomplete="off"
-                            ariaLabelledBy="worksite-code-label"
-                            [ariaDescribedBy]="
-                                form.controls.code.touched && form.controls.code.invalid
-                                    ? 'worksite-code-error'
-                                    : form.controls.code.pending
-                                      ? 'worksite-code-hint'
-                                      : null
-                            "
-                            [ariaInvalid]="form.controls.code.touched && form.controls.code.invalid"
-                            [ariaErrorMessage]="
-                                form.controls.code.touched && form.controls.code.invalid
-                                    ? 'worksite-code-error'
-                                    : null
-                            "
-                            required
-                        />
-                    </app-field>
+  <div pageContent class="app-page-content worksite-create-content">
+    <section class="app-card worksites-card">
+      <div class="app-card__body worksites-card__body">
+        <form class="app-form worksite-form" [formGroup]="form" (ngSubmit)="save()">
+          <app-field
+            controlId="worksite-code"
+            [label]="'worksite.code' | translate"
+            [hint]="
+              form.controls.code.pending ? ('worksite.messages.codeChecking' | translate) : ''
+            "
+            [error]="
+              form.controls.code.touched && form.controls.code.invalid
+                ? form.controls.code.hasError('duplicatedCode')
+                  ? ('worksite.errors.duplicatedCode' | translate)
+                  : form.controls.code.hasError('codeLookupFailed')
+                    ? ('worksite.errors.codeLookupFailed' | translate)
+                    : ('worksite.errors.invalidCode' | translate)
+                : ''
+            "
+            [invalid]="form.controls.code.touched && form.controls.code.invalid"
+            [disabled]="form.controls.code.disabled"
+            required
+          >
+            <app-input
+              inputId="worksite-code"
+              formControlName="code"
+              autocomplete="off"
+              ariaLabelledBy="worksite-code-label"
+              [ariaDescribedBy]="
+                form.controls.code.touched && form.controls.code.invalid
+                  ? 'worksite-code-error'
+                  : form.controls.code.pending
+                    ? 'worksite-code-hint'
+                    : null
+              "
+              [ariaInvalid]="form.controls.code.touched && form.controls.code.invalid"
+              [ariaErrorMessage]="
+                form.controls.code.touched && form.controls.code.invalid
+                  ? 'worksite-code-error'
+                  : null
+              "
+              required
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="worksite-name"
-                        [label]="'worksite.name' | translate"
-                        [error]="
-                            form.controls.name.touched && form.controls.name.invalid
-                                ? ('worksite.errors.invalidName' | translate)
-                                : ''
-                        "
-                        [invalid]="form.controls.name.touched && form.controls.name.invalid"
-                        [disabled]="form.controls.name.disabled"
-                        required
-                    >
-                        <app-input
-                            inputId="worksite-name"
-                            formControlName="name"
-                            autocomplete="off"
-                            ariaLabelledBy="worksite-name-label"
-                            [ariaDescribedBy]="
-                                form.controls.name.touched && form.controls.name.invalid
-                                    ? 'worksite-name-error'
-                                    : null
-                            "
-                            [ariaInvalid]="form.controls.name.touched && form.controls.name.invalid"
-                            [ariaErrorMessage]="
-                                form.controls.name.touched && form.controls.name.invalid
-                                    ? 'worksite-name-error'
-                                    : null
-                            "
-                            required
-                        />
-                    </app-field>
+          <app-field
+            controlId="worksite-name"
+            [label]="'worksite.name' | translate"
+            [error]="
+              form.controls.name.touched && form.controls.name.invalid
+                ? ('worksite.errors.invalidName' | translate)
+                : ''
+            "
+            [invalid]="form.controls.name.touched && form.controls.name.invalid"
+            [disabled]="form.controls.name.disabled"
+            required
+          >
+            <app-input
+              inputId="worksite-name"
+              formControlName="name"
+              autocomplete="off"
+              ariaLabelledBy="worksite-name-label"
+              [ariaDescribedBy]="
+                form.controls.name.touched && form.controls.name.invalid
+                  ? 'worksite-name-error'
+                  : null
+              "
+              [ariaInvalid]="form.controls.name.touched && form.controls.name.invalid"
+              [ariaErrorMessage]="
+                form.controls.name.touched && form.controls.name.invalid
+                  ? 'worksite-name-error'
+                  : null
+              "
+              required
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="worksite-scope"
-                        [label]="'worksite.scope' | translate"
-                        required
-                    >
-                        <app-select
-                            inputId="worksite-scope"
-                            formControlName="scope"
-                            [options]="scopeOptions"
-                            required
-                        />
-                    </app-field>
+          <app-field controlId="worksite-scope" [label]="'worksite.scope' | translate" required>
+            <app-select
+              inputId="worksite-scope"
+              formControlName="scope"
+              [options]="scopeOptions"
+              required
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="worksite-timezone"
-                        [label]="'worksite.timeZone' | translate"
-                        [error]="
-                            form.controls.timeZone.touched && form.controls.timeZone.invalid
-                                ? ('worksite.errors.invalidTimezone' | translate)
-                                : ''
-                        "
-                        [invalid]="form.controls.timeZone.touched && form.controls.timeZone.invalid"
-                        required
-                    >
-                        <app-autocomplete-textbox
-                            inputId="worksite-timezone"
-                            formControlName="timeZone"
-                            [searchMethod]="searchMethod"
-                            [displayWith]="timezoneDisplayWith"
-                            [valueWith]="timezoneValueWith"
-                            [resolveByValue]="resolveTimezoneByValue"
-                            [emptyHint]="'worksite.fields.timeZoneHint' | translate"
-                            ariaLabelledBy="worksite-timezone-label"
-                            [ariaDescribedBy]="
-                                form.controls.timeZone.touched && form.controls.timeZone.invalid
-                                    ? 'worksite-timezone-error'
-                                    : null
-                            "
-                            [ariaInvalid]="
-                                form.controls.timeZone.touched && form.controls.timeZone.invalid
-                            "
-                        />
-                    </app-field>
+          <app-field
+            controlId="worksite-timezone"
+            [label]="'worksite.timeZone' | translate"
+            [error]="
+              form.controls.timeZone.touched && form.controls.timeZone.invalid
+                ? ('worksite.errors.invalidTimezone' | translate)
+                : ''
+            "
+            [invalid]="form.controls.timeZone.touched && form.controls.timeZone.invalid"
+            required
+          >
+            <app-autocomplete-textbox
+              inputId="worksite-timezone"
+              formControlName="timeZone"
+              [searchMethod]="searchMethod"
+              [displayWith]="timezoneDisplayWith"
+              [valueWith]="timezoneValueWith"
+              [resolveByValue]="resolveTimezoneByValue"
+              [emptyHint]="'worksite.fields.timeZoneHint' | translate"
+              ariaLabelledBy="worksite-timezone-label"
+              [ariaDescribedBy]="
+                form.controls.timeZone.touched && form.controls.timeZone.invalid
+                  ? 'worksite-timezone-error'
+                  : null
+              "
+              [ariaInvalid]="form.controls.timeZone.touched && form.controls.timeZone.invalid"
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="worksite-address"
-                        [label]="'worksite.address' | translate"
-                        [error]="
-                            form.controls.address.touched && form.controls.address.invalid
-                                ? ('worksite.errors.invalidAddress' | translate)
-                                : ''
-                        "
-                        [invalid]="form.controls.address.touched && form.controls.address.invalid"
-                        [disabled]="form.controls.address.disabled"
-                    >
-                        <app-input
-                            inputId="worksite-address"
-                            formControlName="address"
-                            autocomplete="street-address"
-                            ariaLabelledBy="worksite-address-label"
-                            [ariaDescribedBy]="
-                                form.controls.address.touched && form.controls.address.invalid
-                                    ? 'worksite-address-error'
-                                    : null
-                            "
-                            [ariaInvalid]="
-                                form.controls.address.touched && form.controls.address.invalid
-                            "
-                            [ariaErrorMessage]="
-                                form.controls.address.touched && form.controls.address.invalid
-                                    ? 'worksite-address-error'
-                                    : null
-                            "
-                        />
-                    </app-field>
+          <app-field
+            controlId="worksite-address"
+            [label]="'worksite.address' | translate"
+            [error]="
+              form.controls.address.touched && form.controls.address.invalid
+                ? ('worksite.errors.invalidAddress' | translate)
+                : ''
+            "
+            [invalid]="form.controls.address.touched && form.controls.address.invalid"
+            [disabled]="form.controls.address.disabled"
+          >
+            <app-input
+              inputId="worksite-address"
+              formControlName="address"
+              autocomplete="street-address"
+              ariaLabelledBy="worksite-address-label"
+              [ariaDescribedBy]="
+                form.controls.address.touched && form.controls.address.invalid
+                  ? 'worksite-address-error'
+                  : null
+              "
+              [ariaInvalid]="form.controls.address.touched && form.controls.address.invalid"
+              [ariaErrorMessage]="
+                form.controls.address.touched && form.controls.address.invalid
+                  ? 'worksite-address-error'
+                  : null
+              "
+            />
+          </app-field>
 
-                    <app-field
-                        controlId="worksite-description"
-                        [label]="'worksite.description' | translate"
-                        [error]="
-                            form.controls.description.touched && form.controls.description.invalid
-                                ? ('worksite.errors.invalidDescription' | translate)
-                                : ''
-                        "
-                        [invalid]="
-                            form.controls.description.touched && form.controls.description.invalid
-                        "
-                        [disabled]="form.controls.description.disabled"
-                    >
-                        <app-input
-                            inputId="worksite-description"
-                            formControlName="description"
-                            autocomplete="off"
-                            ariaLabelledBy="worksite-description-label"
-                            [ariaDescribedBy]="
-                                form.controls.description.touched &&
-                                form.controls.description.invalid
-                                    ? 'worksite-description-error'
-                                    : null
-                            "
-                            [ariaInvalid]="
-                                form.controls.description.touched &&
-                                form.controls.description.invalid
-                            "
-                            [ariaErrorMessage]="
-                                form.controls.description.touched &&
-                                form.controls.description.invalid
-                                    ? 'worksite-description-error'
-                                    : null
-                            "
-                        />
-                    </app-field>
+          <app-field
+            controlId="worksite-description"
+            [label]="'worksite.description' | translate"
+            [error]="
+              form.controls.description.touched && form.controls.description.invalid
+                ? ('worksite.errors.invalidDescription' | translate)
+                : ''
+            "
+            [invalid]="form.controls.description.touched && form.controls.description.invalid"
+            [disabled]="form.controls.description.disabled"
+          >
+            <app-input
+              inputId="worksite-description"
+              formControlName="description"
+              autocomplete="off"
+              ariaLabelledBy="worksite-description-label"
+              [ariaDescribedBy]="
+                form.controls.description.touched && form.controls.description.invalid
+                  ? 'worksite-description-error'
+                  : null
+              "
+              [ariaInvalid]="form.controls.description.touched && form.controls.description.invalid"
+              [ariaErrorMessage]="
+                form.controls.description.touched && form.controls.description.invalid
+                  ? 'worksite-description-error'
+                  : null
+              "
+            />
+          </app-field>
 
-                    @if (errorMessage) {
-                        <p class="worksite-form__message worksite-form__message--error">
-                            {{ errorMessage | translate }}
-                        </p>
-                    }
+          @if (errorMessage) {
+            <app-message type="error" presentation="inline">
+              {{ errorMessage | translate }}
+            </app-message>
+          }
 
-                    <div class="app-form-actions">
-                        <app-button type="button" variant="secondary" (clicked)="cancel()">
-                            {{ 'actions.cancel' | translate }}
-                        </app-button>
+          <div class="app-form-actions">
+            <app-button type="button" variant="secondary" (clicked)="cancel()">
+              {{ 'actions.cancel' | translate }}
+            </app-button>
 
-                        <app-button
-                            type="submit"
-                            variant="main"
-                            [disabled]="form.invalid || form.pending || saving"
-                        >
-                            {{ 'actions.save' | translate }}
-                        </app-button>
-                    </div>
-                </form>
-            </div>
-        </section>
-    </div>
+            <app-button
+              type="submit"
+              variant="main"
+              [disabled]="form.invalid || form.pending || saving"
+            >
+              {{ 'actions.save' | translate }}
+            </app-button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
 </app-page-template>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-create-page.component.ts
@@ -22,10 +22,13 @@ import { WorksiteScope } from '../models/worksite';
 import { WorksiteApiService } from '../services/worksite-api.service';
 import { UniqueWorksiteCodeValidator } from '../validators/unique-worksite-code.validator';
 
+import { MessageComponent } from '../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-worksite-create-page',
   standalone: true,
   imports: [
+    MessageComponent,
     ReactiveFormsModule,
     TranslatePipe,
     AutocompleteTextboxComponent,

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.css
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.css
@@ -1,67 +1,55 @@
 .worksite-detail__content {
-    flex-direction: column;
+  flex-direction: column;
 }
 
 .worksite-detail__grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    gap: var(--layout-main-gap);
-    grid-template-areas:
-        'header header'
-        'general summary';
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--layout-main-gap);
+  grid-template-areas:
+    'header header'
+    'general summary';
 }
 
 #header {
-    grid-area: header;
+  grid-area: header;
 }
 
 #general {
-    grid-area: general;
+  grid-area: general;
 }
 
 #summary {
-    grid-area: summary;
+  grid-area: summary;
 }
 
 .worksite-detail__actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 1rem;
-    margin-top: 1.55rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1.55rem;
 }
 
 :host ::ng-deep .worksite-detail__panel--empty .app-card__body {
-    min-height: 24rem;
-}
-
-.worksite-detail__message {
-    padding: 1rem 1.5rem;
-    border-radius: 0.5rem;
-    background: var(--color-white-alpha-06);
-}
-
-.worksite-detail__message--error {
-    background: var(--color-error-soft-alpha-12);
-    color: var(--color-error-soft);
+  min-height: 24rem;
 }
 
 @media (max-width: 900px) {
-    .worksite-detail__grid {
-        grid-template-columns: 1fr;
-        grid-template-areas:
-            'header'
-            'general'
-            'summary';
-    }
+  .worksite-detail__grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'header'
+      'general'
+      'summary';
+  }
 }
 
 @media (max-width: 640px) {
-    .worksite-detail__actions {
-        flex-direction: column;
-    }
+  .worksite-detail__actions {
+    flex-direction: column;
+  }
 
-    .worksite-detail__actions app-button {
-        width: 100%;
-    }
-
+  .worksite-detail__actions app-button {
+    width: 100%;
+  }
 }

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.html
@@ -1,58 +1,46 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.detail">
-    <section pageContent class="app-page-content worksite-detail__content">
-        @if (worksiteResource.error() !== undefined) {
-            <div class="worksite-detail__message worksite-detail__message--error" role="alert">
-                {{ 'worksite.detailLoadError' | translate }}
-            </div>
-        } @else if (worksiteResource.isLoading()) {
-            <div class="worksite-detail__message" aria-live="polite">
-                {{ 'worksite.detailLoading' | translate }}
-            </div>
-        } @else if (worksite(); as worksite) {
-            <app-tabs>
-                <ng-template [appTabItem]="'worksite.tabs.general' | translate">
-                    <div class="worksite-detail__grid">
-                        <app-worksite-detail-header
-                            id="header"
-                            [worksite]="worksite"
-                        ></app-worksite-detail-header>
+  <section pageContent class="app-page-content worksite-detail__content">
+    @if (worksiteResource.error() !== undefined) {
+      <app-message type="error">{{ 'worksite.detailLoadError' | translate }}</app-message>
+    } @else if (worksiteResource.isLoading()) {
+      <app-message type="info">{{ 'worksite.detailLoading' | translate }}</app-message>
+    } @else if (worksite(); as worksite) {
+      <app-tabs>
+        <ng-template [appTabItem]="'worksite.tabs.general' | translate">
+          <div class="worksite-detail__grid">
+            <app-worksite-detail-header
+              id="header"
+              [worksite]="worksite"
+            ></app-worksite-detail-header>
 
-                        <app-worksite-detail-panel
-                            id="general"
-                            [worksite]="worksite"
-                        ></app-worksite-detail-panel>
+            <app-worksite-detail-panel
+              id="general"
+              [worksite]="worksite"
+            ></app-worksite-detail-panel>
 
-                        <app-worksite-summary-panel id="summary"></app-worksite-summary-panel>
-                    </div>
+            <app-worksite-summary-panel id="summary"></app-worksite-summary-panel>
+          </div>
 
-                    <div class="worksite-detail__actions">
-                        <app-button type="button" variant="secondary" (clicked)="goBack()">
-                            {{ 'actions.cancel' | translate }}
-                        </app-button>
-                        @if (isAdmin | async) {
-                            <app-button
-                                type="button"
-                                variant="main"
-                                (clicked)="editWorksite(worksite)"
-                            >
-                                {{ 'actions.edit' | translate }}
-                            </app-button>
-                        }
-                    </div>
-                </ng-template>
+          <div class="worksite-detail__actions">
+            <app-button type="button" variant="secondary" (clicked)="goBack()">
+              {{ 'actions.cancel' | translate }}
+            </app-button>
+            @if (isAdmin | async) {
+              <app-button type="button" variant="main" (clicked)="editWorksite(worksite)">
+                {{ 'actions.edit' | translate }}
+              </app-button>
+            }
+          </div>
+        </ng-template>
 
-                <ng-template [appTabItem]="'worksite.tabs.employees' | translate">
-                    <app-card
-                        styleClass="worksite-detail__panel worksite-detail__panel--empty"
-                    ></app-card>
-                </ng-template>
+        <ng-template [appTabItem]="'worksite.tabs.employees' | translate">
+          <app-card styleClass="worksite-detail__panel worksite-detail__panel--empty"></app-card>
+        </ng-template>
 
-                <ng-template [appTabItem]="'worksite.tabs.schedules' | translate">
-                    <app-card
-                        styleClass="worksite-detail__panel worksite-detail__panel--empty"
-                    ></app-card>
-                </ng-template>
-            </app-tabs>
-        }
-    </section>
+        <ng-template [appTabItem]="'worksite.tabs.schedules' | translate">
+          <app-card styleClass="worksite-detail__panel worksite-detail__panel--empty"></app-card>
+        </ng-template>
+      </app-tabs>
+    }
+  </section>
 </app-page-template>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-detail-page.component.ts
@@ -21,10 +21,13 @@ import { CurrentUserFacade } from '../../../core/user/services/current-user.faca
 import { WorksiteDetailPanelComponent } from '../components/worksite-detail-panel/worksite-detail-panel.component';
 import { WorksiteSummaryPanelComponent } from '../components/worksite-summary-panel/worksite-summary-panel.component';
 
+import { MessageComponent } from '../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-worksite-detail-page',
   standalone: true,
   imports: [
+    MessageComponent,
     ButtonComponent,
     CardComponent,
     PageTemplateComponent,

--- a/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.html
@@ -1,195 +1,174 @@
 <app-page-template appNameKey="navigation.janus" pageNameKey="worksite.edit">
-    <div pageContent class="app-page-content worksite-create-content">
-        <section class="app-card worksites-card">
-            <div class="app-card__body worksites-card__body">
-                @if (loading) {
-                    <p class="worksite-form__message">{{ 'worksite.detailLoading' | translate }}</p>
-                } @else {
-                    <form class="app-form worksite-form" [formGroup]="form" (ngSubmit)="save()">
-                        <app-field
-                            controlId="worksite-code"
-                            [label]="'worksite.code' | translate"
-                            [disabled]="form.controls.code.disabled"
-                        >
-                            <app-input
-                                inputId="worksite-code"
-                                formControlName="code"
-                                autocomplete="off"
-                                ariaLabelledBy="worksite-code-label"
-                            />
-                        </app-field>
+  <div pageContent class="app-page-content worksite-create-content">
+    <section class="app-card worksites-card">
+      <div class="app-card__body worksites-card__body">
+        @if (loading) {
+          <app-message type="info">{{ 'worksite.detailLoading' | translate }}</app-message>
+        } @else {
+          <form class="app-form worksite-form" [formGroup]="form" (ngSubmit)="save()">
+            <app-field
+              controlId="worksite-code"
+              [label]="'worksite.code' | translate"
+              [disabled]="form.controls.code.disabled"
+            >
+              <app-input
+                inputId="worksite-code"
+                formControlName="code"
+                autocomplete="off"
+                ariaLabelledBy="worksite-code-label"
+              />
+            </app-field>
 
-                        <app-field
-                            controlId="worksite-name"
-                            [label]="'worksite.name' | translate"
-                            [error]="
-                                form.controls.name.touched && form.controls.name.invalid
-                                    ? ('worksite.errors.invalidName' | translate)
-                                    : ''
-                            "
-                            [invalid]="form.controls.name.touched && form.controls.name.invalid"
-                            [disabled]="form.controls.name.disabled"
-                            required
-                        >
-                            <app-input
-                                inputId="worksite-name"
-                                formControlName="name"
-                                autocomplete="off"
-                                ariaLabelledBy="worksite-name-label"
-                                [ariaDescribedBy]="
-                                    form.controls.name.touched && form.controls.name.invalid
-                                        ? 'worksite-name-error'
-                                        : null
-                                "
-                                [ariaInvalid]="form.controls.name.touched && form.controls.name.invalid"
-                                [ariaErrorMessage]="
-                                    form.controls.name.touched && form.controls.name.invalid
-                                        ? 'worksite-name-error'
-                                        : null
-                                "
-                                required
-                            />
-                        </app-field>
+            <app-field
+              controlId="worksite-name"
+              [label]="'worksite.name' | translate"
+              [error]="
+                form.controls.name.touched && form.controls.name.invalid
+                  ? ('worksite.errors.invalidName' | translate)
+                  : ''
+              "
+              [invalid]="form.controls.name.touched && form.controls.name.invalid"
+              [disabled]="form.controls.name.disabled"
+              required
+            >
+              <app-input
+                inputId="worksite-name"
+                formControlName="name"
+                autocomplete="off"
+                ariaLabelledBy="worksite-name-label"
+                [ariaDescribedBy]="
+                  form.controls.name.touched && form.controls.name.invalid
+                    ? 'worksite-name-error'
+                    : null
+                "
+                [ariaInvalid]="form.controls.name.touched && form.controls.name.invalid"
+                [ariaErrorMessage]="
+                  form.controls.name.touched && form.controls.name.invalid
+                    ? 'worksite-name-error'
+                    : null
+                "
+                required
+              />
+            </app-field>
 
-                        <app-field
-                            controlId="worksite-scope"
-                            [label]="'worksite.scope' | translate"
-                            required
-                        >
-                            <app-select
-                                inputId="worksite-scope"
-                                formControlName="scope"
-                                [options]="scopeOptions"
-                                required
-                            />
-                        </app-field>
+            <app-field controlId="worksite-scope" [label]="'worksite.scope' | translate" required>
+              <app-select
+                inputId="worksite-scope"
+                formControlName="scope"
+                [options]="scopeOptions"
+                required
+              />
+            </app-field>
 
-                        <app-field
-                            controlId="worksite-timezone"
-                            [label]="'worksite.timeZone' | translate"
-                            [error]="
-                                form.controls.timeZone.touched && form.controls.timeZone.invalid
-                                    ? ('worksite.errors.invalidTimezone' | translate)
-                                    : ''
-                            "
-                            [invalid]="
-                                form.controls.timeZone.touched && form.controls.timeZone.invalid
-                            "
-                            required
-                        >
-                            <app-autocomplete-textbox
-                                inputId="worksite-timezone"
-                                formControlName="timeZone"
-                                [searchMethod]="searchMethod"
-                                [displayWith]="timezoneDisplayWith"
-                                [valueWith]="timezoneValueWith"
-                                [resolveByValue]="resolveTimezoneByValue"
-                                [emptyHint]="'worksite.fields.timeZoneHint' | translate"
-                                ariaLabelledBy="worksite-timezone-label"
-                                [ariaDescribedBy]="
-                                    form.controls.timeZone.touched && form.controls.timeZone.invalid
-                                        ? 'worksite-timezone-error'
-                                        : null
-                                "
-                                [ariaInvalid]="
-                                    form.controls.timeZone.touched && form.controls.timeZone.invalid
-                                "
-                            />
-                        </app-field>
+            <app-field
+              controlId="worksite-timezone"
+              [label]="'worksite.timeZone' | translate"
+              [error]="
+                form.controls.timeZone.touched && form.controls.timeZone.invalid
+                  ? ('worksite.errors.invalidTimezone' | translate)
+                  : ''
+              "
+              [invalid]="form.controls.timeZone.touched && form.controls.timeZone.invalid"
+              required
+            >
+              <app-autocomplete-textbox
+                inputId="worksite-timezone"
+                formControlName="timeZone"
+                [searchMethod]="searchMethod"
+                [displayWith]="timezoneDisplayWith"
+                [valueWith]="timezoneValueWith"
+                [resolveByValue]="resolveTimezoneByValue"
+                [emptyHint]="'worksite.fields.timeZoneHint' | translate"
+                ariaLabelledBy="worksite-timezone-label"
+                [ariaDescribedBy]="
+                  form.controls.timeZone.touched && form.controls.timeZone.invalid
+                    ? 'worksite-timezone-error'
+                    : null
+                "
+                [ariaInvalid]="form.controls.timeZone.touched && form.controls.timeZone.invalid"
+              />
+            </app-field>
 
-                        <app-field
-                            controlId="worksite-address"
-                            [label]="'worksite.address' | translate"
-                            [error]="
-                                form.controls.address.touched && form.controls.address.invalid
-                                    ? ('worksite.errors.invalidAddress' | translate)
-                                    : ''
-                            "
-                            [invalid]="form.controls.address.touched && form.controls.address.invalid"
-                            [disabled]="form.controls.address.disabled"
-                        >
-                            <app-input
-                                inputId="worksite-address"
-                                formControlName="address"
-                                autocomplete="street-address"
-                                ariaLabelledBy="worksite-address-label"
-                                [ariaDescribedBy]="
-                                    form.controls.address.touched && form.controls.address.invalid
-                                        ? 'worksite-address-error'
-                                        : null
-                                "
-                                [ariaInvalid]="
-                                    form.controls.address.touched && form.controls.address.invalid
-                                "
-                                [ariaErrorMessage]="
-                                    form.controls.address.touched && form.controls.address.invalid
-                                        ? 'worksite-address-error'
-                                        : null
-                                "
-                            />
-                        </app-field>
+            <app-field
+              controlId="worksite-address"
+              [label]="'worksite.address' | translate"
+              [error]="
+                form.controls.address.touched && form.controls.address.invalid
+                  ? ('worksite.errors.invalidAddress' | translate)
+                  : ''
+              "
+              [invalid]="form.controls.address.touched && form.controls.address.invalid"
+              [disabled]="form.controls.address.disabled"
+            >
+              <app-input
+                inputId="worksite-address"
+                formControlName="address"
+                autocomplete="street-address"
+                ariaLabelledBy="worksite-address-label"
+                [ariaDescribedBy]="
+                  form.controls.address.touched && form.controls.address.invalid
+                    ? 'worksite-address-error'
+                    : null
+                "
+                [ariaInvalid]="form.controls.address.touched && form.controls.address.invalid"
+                [ariaErrorMessage]="
+                  form.controls.address.touched && form.controls.address.invalid
+                    ? 'worksite-address-error'
+                    : null
+                "
+              />
+            </app-field>
 
-                        <app-field
-                            controlId="worksite-description"
-                            [label]="'worksite.description' | translate"
-                            [error]="
-                                form.controls.description.touched &&
-                                form.controls.description.invalid
-                                    ? ('worksite.errors.invalidDescription' | translate)
-                                    : ''
-                            "
-                            [invalid]="
-                                form.controls.description.touched &&
-                                form.controls.description.invalid
-                            "
-                            [disabled]="form.controls.description.disabled"
-                        >
-                            <app-input
-                                inputId="worksite-description"
-                                formControlName="description"
-                                autocomplete="off"
-                                ariaLabelledBy="worksite-description-label"
-                                [ariaDescribedBy]="
-                                    form.controls.description.touched &&
-                                    form.controls.description.invalid
-                                        ? 'worksite-description-error'
-                                        : null
-                                "
-                                [ariaInvalid]="
-                                    form.controls.description.touched &&
-                                    form.controls.description.invalid
-                                "
-                                [ariaErrorMessage]="
-                                    form.controls.description.touched &&
-                                    form.controls.description.invalid
-                                        ? 'worksite-description-error'
-                                        : null
-                                "
-                            />
-                        </app-field>
+            <app-field
+              controlId="worksite-description"
+              [label]="'worksite.description' | translate"
+              [error]="
+                form.controls.description.touched && form.controls.description.invalid
+                  ? ('worksite.errors.invalidDescription' | translate)
+                  : ''
+              "
+              [invalid]="form.controls.description.touched && form.controls.description.invalid"
+              [disabled]="form.controls.description.disabled"
+            >
+              <app-input
+                inputId="worksite-description"
+                formControlName="description"
+                autocomplete="off"
+                ariaLabelledBy="worksite-description-label"
+                [ariaDescribedBy]="
+                  form.controls.description.touched && form.controls.description.invalid
+                    ? 'worksite-description-error'
+                    : null
+                "
+                [ariaInvalid]="
+                  form.controls.description.touched && form.controls.description.invalid
+                "
+                [ariaErrorMessage]="
+                  form.controls.description.touched && form.controls.description.invalid
+                    ? 'worksite-description-error'
+                    : null
+                "
+              />
+            </app-field>
 
-                        @if (errorMessage) {
-                            <p class="worksite-form__message worksite-form__message--error">
-                                {{ errorMessage | translate }}
-                            </p>
-                        }
+            @if (errorMessage) {
+              <app-message type="error" presentation="inline">
+                {{ errorMessage | translate }}
+              </app-message>
+            }
 
-                        <div class="app-form-actions">
-                            <app-button type="button" variant="secondary" (clicked)="cancel()">
-                                {{ 'actions.cancel' | translate }}
-                            </app-button>
+            <div class="app-form-actions">
+              <app-button type="button" variant="secondary" (clicked)="cancel()">
+                {{ 'actions.cancel' | translate }}
+              </app-button>
 
-                            <app-button
-                                type="submit"
-                                variant="main"
-                                [disabled]="form.invalid || saving"
-                            >
-                                {{ 'actions.save' | translate }}
-                            </app-button>
-                        </div>
-                    </form>
-                }
+              <app-button type="submit" variant="main" [disabled]="form.invalid || saving">
+                {{ 'actions.save' | translate }}
+              </app-button>
             </div>
-        </section>
-    </div>
+          </form>
+        }
+      </div>
+    </section>
+  </div>
 </app-page-template>

--- a/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.ts
+++ b/apps/frontend/src/app/features/worksites/pages/worksite-edit-page.component.ts
@@ -22,10 +22,13 @@ import {
 import { Worksite, WorksiteScope } from '../models/worksite';
 import { WorksiteApiService } from '../services/worksite-api.service';
 
+import { MessageComponent } from '../../../shared/ui/message/message.component';
+
 @Component({
   selector: 'app-worksite-edit-page',
   standalone: true,
   imports: [
+    MessageComponent,
     ReactiveFormsModule,
     TranslatePipe,
     AutocompleteTextboxComponent,

--- a/apps/frontend/src/app/shared/ui/message/message.component.css
+++ b/apps/frontend/src/app/shared/ui/message/message.component.css
@@ -1,0 +1,46 @@
+:host {
+  display: block;
+}
+
+.message {
+  margin: 0;
+  color: var(--text-primary-color);
+}
+
+.message--panel {
+  padding-block: var(--section-message-padding-block);
+  padding-inline: var(--section-message-padding-inline);
+  border: 1px solid transparent;
+  border-radius: var(--section-message-border-radius);
+  background-color: var(--section-message-background-color);
+}
+
+.message--inline {
+  padding: 0;
+  background: transparent;
+}
+
+.message--error {
+  color: var(--color-error-soft);
+}
+
+.message--error.message--panel {
+  border-color: var(--color-error-soft);
+  background-color: var(--color-error-soft-alpha-12);
+}
+
+.message--success {
+  color: var(--color-success-500);
+}
+
+.message--success.message--panel {
+  background-color: var(--color-success-muted-alpha-16);
+}
+
+.message--warning {
+  color: var(--color-warning-500);
+}
+
+.message--info {
+  color: var(--color-info-500);
+}

--- a/apps/frontend/src/app/shared/ui/message/message.component.html
+++ b/apps/frontend/src/app/shared/ui/message/message.component.html
@@ -1,0 +1,3 @@
+<div [class]="classes()" [attr.role]="role()" [attr.aria-live]="ariaLive()">
+  <ng-content></ng-content>
+</div>

--- a/apps/frontend/src/app/shared/ui/message/message.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/message/message.component.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MessageComponent, MessagePresentation, MessageType } from './message.component';
+
+@Component({
+  standalone: true,
+  imports: [MessageComponent],
+  template: `<app-message [type]="type" [presentation]="presentation"
+    >Translated text</app-message
+  >`,
+})
+class TestHostComponent {
+  type: MessageType = 'info';
+  presentation: MessagePresentation = 'panel';
+}
+
+describe('MessageComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [TestHostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it.each(['error', 'success', 'warning', 'info'] as const)('applies the %s variant', (type) => {
+    fixture.componentInstance.type = type;
+    fixture.detectChanges();
+    expect(message().classList).toContain(`message--${type}`);
+  });
+
+  it.each(['inline', 'panel'] as const)('applies the %s presentation', (presentation) => {
+    fixture.componentInstance.presentation = presentation;
+    fixture.detectChanges();
+    expect(message().classList).toContain(`message--${presentation}`);
+  });
+
+  it('projects content and exposes errors as alerts', () => {
+    fixture.componentInstance.type = 'error';
+    fixture.detectChanges();
+    expect(message().textContent?.trim()).toBe('Translated text');
+    expect(message().getAttribute('role')).toBe('alert');
+    expect(message().getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('politely announces informational states', () => {
+    expect(message().hasAttribute('role')).toBe(false);
+    expect(message().getAttribute('aria-live')).toBe('polite');
+  });
+
+  function message(): HTMLElement {
+    return fixture.nativeElement.querySelector('.message');
+  }
+});

--- a/apps/frontend/src/app/shared/ui/message/message.component.ts
+++ b/apps/frontend/src/app/shared/ui/message/message.component.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+export type MessageType = 'error' | 'success' | 'warning' | 'info';
+export type MessagePresentation = 'inline' | 'panel';
+
+@Component({
+  selector: 'app-message',
+  standalone: true,
+  templateUrl: './message.component.html',
+  styleUrl: './message.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MessageComponent {
+  readonly type = input<MessageType>('info');
+  readonly presentation = input<MessagePresentation>('panel');
+
+  protected readonly classes = computed(
+    () => `message message--${this.type()} message--${this.presentation()}`,
+  );
+  protected readonly role = computed(() => (this.type() === 'error' ? 'alert' : null));
+  protected readonly ariaLive = computed(() => (this.type() === 'error' ? 'assertive' : 'polite'));
+}

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -24,4 +24,3 @@
 @import './styles/components/header-detail.css';
 @import './styles/components/section.css';
 @import './styles/components/table.css';
-@import './styles/components/message.css';

--- a/apps/frontend/src/styles/components/message.css
+++ b/apps/frontend/src/styles/components/message.css
@@ -1,7 +1,0 @@
-.app-message {
-    margin: 0;
-}
-
-.app-message--error {
-    color: var(--color-error-soft);
-}

--- a/apps/frontend/src/styles/components/section.css
+++ b/apps/frontend/src/styles/components/section.css
@@ -1,41 +1,28 @@
 .app-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--section-gap);
+  display: flex;
+  flex-direction: column;
+  gap: var(--section-gap);
 }
 
 .app-section__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .app-section__title {
-    font-size: var(--type-heading-md-font-size);
-    font-weight: var(--type-heading-md-font-weight);
-    line-height: var(--type-heading-md-line-height);
-    text-transform: var(--type-caps-text-transform);
-    letter-spacing: var(--type-caps-letter-spacing);
-    color: var(--accent-color);
-    margin: 0;
-}
-
-.app-section__message {
-    padding-block: var(--section-message-padding-block);
-    padding-inline: var(--section-message-padding-inline);
-    border-radius: var(--section-message-border-radius);
-    background-color: var(--section-message-background-color);
-    color: var(--section-message-text-color);
-}
-
-.app-section__message--error {
-    background: var(--color-error-soft-alpha-12);
-    color: var(--color-error-soft);
+  font-size: var(--type-heading-md-font-size);
+  font-weight: var(--type-heading-md-font-weight);
+  line-height: var(--type-heading-md-line-height);
+  text-transform: var(--type-caps-text-transform);
+  letter-spacing: var(--type-caps-letter-spacing);
+  color: var(--accent-color);
+  margin: 0;
 }
 
 @media (max-width: 640px) {
-    .app-section__header {
-        flex-direction: column;
-        align-items: flex-start;
-    }
+  .app-section__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide a single reusable message UI to consolidate how errors, loading and informational feedback are presented across the frontend. 
- Ensure messages are typed, accessible and allow consumers to project translated content without duplicating CSS per feature. 
- Replace ad-hoc, feature-scoped message rules with a central component that reuses existing CSS tokens for colors, padding and borders.

### Description
- Add a standalone `MessageComponent` at `apps/frontend/src/app/shared/ui/message/` with typed inputs `type: 'error'|'success'|'warning'|'info'` and `presentation: 'inline'|'panel'`, computed classes and derived ARIA semantics (`role`/`aria-live`).
- Implement template and styles that centralize margins, padding, background, border and color variants while reusing existing CSS variables like `--color-error-soft` and `--color-error-soft-alpha-12`.
- Migrate message occurrences in tables and pages (worksites, schedules, timelogs, worksite detail/create/edit, user preferences and application settings) to use `<app-message>` and add the component to the consuming components' `imports` arrays.
- Remove superseded message rules (feature-level and global `message.css`) and trim section styles no longer containing message rules, and add unit tests covering variants, presentations, content projection and accessible semantics.

### Testing
- `npm run build` completed successfully and produced the application bundle. 
- `npm run lint` completed successfully with no lint errors. 
- `git diff --check` produced no issues after changes. 
- `npm test -- --watch=false` and `npx ng test --include='src/app/shared/ui/message/message.component.spec.ts'` were blocked by a pre-existing unrelated test compilation error (`TS2322` in `chip.component.spec.ts`) that prevents running the full spec suite; the new `message` spec is present but could not be executed due to that unrelated failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67b0026b1883279a90eeb5a4fb0bad)