### PR TITLE
feat(frontend): standardize async state presentation

### DIFF
--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.html
@@ -17,13 +17,15 @@
     }
   </header>
 
-  @if (schedulesResource.error() !== undefined) {
-    <app-message type="error">{{ 'schedule.loadError' | translate }}</app-message>
-  }
-
-  @if (schedulesResource.isLoading()) {
-    <app-message type="info">{{ 'schedule.loading' | translate }}</app-message>
-  }
+  <app-async-state
+    [loading]="schedulesResource.isLoading()"
+    [error]="schedulesResource.error() !== undefined"
+    [empty]="isEmpty()"
+  >
+    <ng-template appAsyncLoading>{{ 'schedule.loading' | translate }}</ng-template>
+    <ng-template appAsyncError>{{ 'schedule.loadError' | translate }}</ng-template>
+    <ng-template appAsyncEmpty>{{ 'schedule.empty' | translate }}</ng-template>
+  </app-async-state>
 
   @if (!schedulesResource.isLoading() && schedules().length > 0) {
     <table class="app-table schedule-table__table">
@@ -42,9 +44,5 @@
         }
       </tbody>
     </table>
-  }
-
-  @if (isEmpty()) {
-    <app-message type="info">{{ 'schedule.empty' | translate }}</app-message>
   }
 </section>

--- a/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.ts
+++ b/apps/frontend/src/app/features/schedules/components/schedule-table/schedule-table.component.ts
@@ -17,12 +17,24 @@ import { ScheduleApiService, SchedulePage } from '../../services/schedule-api.se
 import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
 import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
-import { MessageComponent } from '../../../../shared/ui/message/message.component';
+import {
+  AsyncEmptyDirective,
+  AsyncErrorDirective,
+  AsyncLoadingDirective,
+  AsyncStateComponent,
+} from '../../../../shared/ui/async-state/async-state.component';
 
 @Component({
   selector: 'app-schedule-table',
   standalone: true,
-  imports: [MessageComponent, TranslatePipe, PaginatorComponent],
+  imports: [
+    AsyncStateComponent,
+    AsyncLoadingDirective,
+    AsyncErrorDirective,
+    AsyncEmptyDirective,
+    TranslatePipe,
+    PaginatorComponent,
+  ],
   templateUrl: './schedule-table.component.html',
   styleUrl: './schedule-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.html
@@ -17,13 +17,15 @@
     }
   </header>
 
-  @if (timelogsResource.error() !== undefined) {
-    <app-message type="error">{{ 'timelog.loadError' | translate }}</app-message>
-  }
-
-  @if (timelogsResource.isLoading()) {
-    <app-message type="info">{{ 'timelog.loading' | translate }}</app-message>
-  }
+  <app-async-state
+    [loading]="timelogsResource.isLoading()"
+    [error]="timelogsResource.error() !== undefined"
+    [empty]="isEmpty()"
+  >
+    <ng-template appAsyncLoading>{{ 'timelog.loading' | translate }}</ng-template>
+    <ng-template appAsyncError>{{ 'timelog.loadError' | translate }}</ng-template>
+    <ng-template appAsyncEmpty>{{ 'timelog.empty' | translate }}</ng-template>
+  </app-async-state>
 
   @if (!timelogsResource.isLoading() && timelogs().length > 0) {
     <table class="app-table timelog-table__table">
@@ -59,9 +61,5 @@
         }
       </tbody>
     </table>
-  }
-
-  @if (isEmpty()) {
-    <app-message type="info">{{ 'timelog.empty' | translate }}</app-message>
   }
 </section>

--- a/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
+++ b/apps/frontend/src/app/features/timelogs/components/timelog-table/timelog-table.component.ts
@@ -20,12 +20,26 @@ import { FALLBACK_LANGUAGE } from '../../../../core/i18n/language.util';
 import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.component';
 import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
-import { MessageComponent } from '../../../../shared/ui/message/message.component';
+import {
+  AsyncEmptyDirective,
+  AsyncErrorDirective,
+  AsyncLoadingDirective,
+  AsyncStateComponent,
+} from '../../../../shared/ui/async-state/async-state.component';
 
 @Component({
   selector: 'app-timelog-table',
   standalone: true,
-  imports: [MessageComponent, TranslatePipe, DatePipe, DurationPipe, PaginatorComponent],
+  imports: [
+    AsyncStateComponent,
+    AsyncLoadingDirective,
+    AsyncErrorDirective,
+    AsyncEmptyDirective,
+    TranslatePipe,
+    DatePipe,
+    DurationPipe,
+    PaginatorComponent,
+  ],
   templateUrl: './timelog-table.component.html',
   styleUrl: './timelog-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.html
@@ -17,13 +17,15 @@
     }
   </header>
 
-  @if (worksitesResource.error() !== undefined) {
-    <app-message type="error">{{ 'worksite.loadError' | translate }}</app-message>
-  }
-
-  @if (worksitesResource.isLoading()) {
-    <app-message type="info">{{ 'worksite.loading' | translate }}</app-message>
-  }
+  <app-async-state
+    [loading]="worksitesResource.isLoading()"
+    [error]="worksitesResource.error() !== undefined"
+    [empty]="isEmpty()"
+  >
+    <ng-template appAsyncLoading>{{ 'worksite.loading' | translate }}</ng-template>
+    <ng-template appAsyncError>{{ 'worksite.loadError' | translate }}</ng-template>
+    <ng-template appAsyncEmpty>{{ 'worksite.empty' | translate }}</ng-template>
+  </app-async-state>
 
   @if (!worksitesResource.isLoading() && worksites().length > 0) {
     <table class="app-table worksite-table__table">
@@ -57,9 +59,5 @@
         }
       </tbody>
     </table>
-  }
-
-  @if (isEmpty()) {
-    <app-message type="info">{{ 'worksite.empty' | translate }}</app-message>
   }
 </section>

--- a/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
+++ b/apps/frontend/src/app/features/worksites/components/worksite-table/worksite-table.component.ts
@@ -20,12 +20,25 @@ import { PaginatorComponent } from '../../../../shared/ui/paginator/paginator.co
 import { ChipComponent } from '../../../../shared/ui/chip/chip.component';
 import { retryTransientHttpErrors } from '../../../../shared/utils/http-retry.util';
 
-import { MessageComponent } from '../../../../shared/ui/message/message.component';
+import {
+  AsyncEmptyDirective,
+  AsyncErrorDirective,
+  AsyncLoadingDirective,
+  AsyncStateComponent,
+} from '../../../../shared/ui/async-state/async-state.component';
 
 @Component({
   selector: 'app-worksite-table',
   standalone: true,
-  imports: [MessageComponent, TranslatePipe, PaginatorComponent, ChipComponent],
+  imports: [
+    AsyncStateComponent,
+    AsyncLoadingDirective,
+    AsyncErrorDirective,
+    AsyncEmptyDirective,
+    TranslatePipe,
+    PaginatorComponent,
+    ChipComponent,
+  ],
   templateUrl: './worksite-table.component.html',
   styleUrl: './worksite-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/frontend/src/app/shared/ui/async-state/async-state.component.html
+++ b/apps/frontend/src/app/shared/ui/async-state/async-state.component.html
@@ -1,0 +1,13 @@
+@if (error()) {
+  <app-message type="error">
+    <ng-container [ngTemplateOutlet]="errorContent()?.template ?? null" />
+  </app-message>
+} @else if (loading()) {
+  <app-message type="info">
+    <ng-container [ngTemplateOutlet]="loadingContent()?.template ?? null" />
+  </app-message>
+} @else if (empty()) {
+  <app-message type="info">
+    <ng-container [ngTemplateOutlet]="emptyContent()?.template ?? null" />
+  </app-message>
+}

--- a/apps/frontend/src/app/shared/ui/async-state/async-state.component.spec.ts
+++ b/apps/frontend/src/app/shared/ui/async-state/async-state.component.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  AsyncEmptyDirective,
+  AsyncErrorDirective,
+  AsyncLoadingDirective,
+  AsyncStateComponent,
+} from './async-state.component';
+
+@Component({
+  standalone: true,
+  imports: [AsyncStateComponent, AsyncLoadingDirective, AsyncErrorDirective, AsyncEmptyDirective],
+  template: `
+    <app-async-state [loading]="loading" [error]="error" [empty]="empty">
+      <ng-template appAsyncLoading><span data-state="loading">Loading</span></ng-template>
+      <ng-template appAsyncError><span data-state="error">Error</span></ng-template>
+      <ng-template appAsyncEmpty><span data-state="empty">Empty</span></ng-template>
+    </app-async-state>
+  `,
+})
+class TestHostComponent {
+  loading = false;
+  error = false;
+  empty = false;
+}
+
+describe('AsyncStateComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [TestHostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it.each([
+    ['loading', { loading: true, error: false, empty: false }, 'polite'],
+    ['error', { loading: false, error: true, empty: false }, 'assertive'],
+    ['empty', { loading: false, error: false, empty: true }, 'polite'],
+  ] as const)('shows only the %s state', (state, values, ariaLive) => {
+    Object.assign(host, values);
+    fixture.detectChanges();
+
+    expect(visibleStates()).toEqual([state]);
+    expect(message()?.getAttribute('aria-live')).toBe(ariaLive);
+    expect(message()?.getAttribute('role')).toBe(state === 'error' ? 'alert' : null);
+  });
+
+  it('prioritizes error when incompatible states are simultaneously true', () => {
+    host.loading = true;
+    host.error = true;
+    host.empty = true;
+    fixture.detectChanges();
+
+    expect(visibleStates()).toEqual(['error']);
+    expect(message()?.getAttribute('role')).toBe('alert');
+  });
+
+  it('prioritizes loading over empty and renders nothing without an active state', () => {
+    host.loading = true;
+    host.empty = true;
+    fixture.detectChanges();
+    expect(visibleStates()).toEqual(['loading']);
+
+    host.loading = false;
+    host.empty = false;
+    fixture.detectChanges();
+    expect(visibleStates()).toEqual([]);
+    expect(message()).toBeNull();
+  });
+
+  function visibleStates(): string[] {
+    return Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll('[data-state]')).map(
+      (element) => element.dataset['state']!,
+    );
+  }
+
+  function message(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('.message');
+  }
+});

--- a/apps/frontend/src/app/shared/ui/async-state/async-state.component.ts
+++ b/apps/frontend/src/app/shared/ui/async-state/async-state.component.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  TemplateRef,
+  contentChild,
+  inject,
+  input,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+
+import { MessageComponent } from '../message/message.component';
+
+@Directive({ selector: 'ng-template[appAsyncLoading]', standalone: true })
+export class AsyncLoadingDirective {
+  readonly template = inject(TemplateRef<unknown>);
+}
+
+@Directive({ selector: 'ng-template[appAsyncError]', standalone: true })
+export class AsyncErrorDirective {
+  readonly template = inject(TemplateRef<unknown>);
+}
+
+@Directive({ selector: 'ng-template[appAsyncEmpty]', standalone: true })
+export class AsyncEmptyDirective {
+  readonly template = inject(TemplateRef<unknown>);
+}
+
+@Component({
+  selector: 'app-async-state',
+  standalone: true,
+  imports: [MessageComponent, NgTemplateOutlet],
+  templateUrl: './async-state.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AsyncStateComponent {
+  readonly loading = input(false);
+  readonly error = input(false);
+  readonly empty = input(false);
+
+  protected readonly loadingContent = contentChild(AsyncLoadingDirective);
+  protected readonly errorContent = contentChild(AsyncErrorDirective);
+  protected readonly emptyContent = contentChild(AsyncEmptyDirective);
+}


### PR DESCRIPTION
### Motivation

- Reduce duplicated loading/error/empty markup across feature tables by introducing a lightweight shared wrapper that projects feature-specific templates. 
- Ensure a consistent accessible behavior where `error` takes precedence and ARIA announcements are correct without coupling the wrapper to `rxResource` or HTTP logic. 

### Description

- Add `AsyncStateComponent` and three small template directives `AsyncLoadingDirective`, `AsyncErrorDirective`, and `AsyncEmptyDirective` in `apps/frontend/src/app/shared/ui/async-state/` to accept boolean inputs for `loading`, `error`, and `empty` and render projected templates. 
- Implement exclusive rendering priority `error` → `loading` → `empty` and reuse `MessageComponent` for consistent `role`/`aria-live` semantics. 
- Migrate the worksite, schedule and timelog table templates to use `app-async-state` while keeping `rxResource` usage and translated strings inside each feature. 
- Add unit tests `async-state.component.spec.ts` that verify single-state visibility, precedence rules, and correct ARIA attributes for each state. 

### Testing

- Ran `npm run build` for the frontend and the build completed successfully. 
- Linted the modified files with `npx eslint` for the targeted sources and no new lint errors were reported. 
- Verified repository checks with `git diff --check` and local formatting via `prettier`. 
- Attempted to run the focused unit tests via `npm test -- --include='src/app/shared/ui/async-state/async-state.component.spec.ts'`, but test execution was blocked by a pre-existing unrelated type error in `chip.component.spec.ts` (type mismatch), preventing the test run from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67b346e140832796d8f2a3fe1ef902)